### PR TITLE
Adds support for running tests concurrently

### DIFF
--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -53,7 +53,7 @@ class RunConfig(BaseModel):
     suite: str = "wp-core-v1"
     limit: Optional[int] = None
     seed: int = 1337
-    concurrency: int = 4
+    concurrency: int = 5
     dry_run: bool = False
     skip_judge: bool = False
     skip_runtime: bool = False

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -1,13 +1,15 @@
 """Main orchestration loop for WP-Bench."""
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
 import orjson
 from rich.console import Console
-from rich.progress import track
+from rich.progress import Progress
 from rich.table import Table
 
 from .config import HarnessConfig, ModelConfig
@@ -27,14 +29,34 @@ def _timestamped_path(path: Path) -> Path:
 
 
 class BenchmarkRunner:
+    """Primary benchmark orchestrator for single-model evaluation.
+
+    Loads tests from the configured dataset, runs them against a single LLM,
+    executes generated code in a WordPress environment, and aggregates scores.
+    """
+
     def __init__(self, config: HarnessConfig):
+        """Initialize the runner with harness configuration.
+
+        Args:
+            config: Full harness configuration including model, grader, and output settings.
+        """
         self.config = config
         self.model = ModelInterface(config.model)
         self.environment = WordPressEnvironment(config.grader)
         self.aggregator = ScoreAggregator()
         self.records: List[Dict[str, Any]] = []
+        self._lock = threading.Lock()
 
     def run(self) -> Dict[str, Any]:
+        """Execute the full benchmark pipeline.
+
+        Loads tests, sets up the WordPress environment, runs knowledge and execution
+        tests in parallel, computes aggregate scores, and writes results to disk.
+
+        Returns:
+            Dict containing metadata (scores, config) and individual test results.
+        """
         tests = load_tests(self.config.dataset)
         self.environment.setup()
         self._run_knowledge_tests(tests["knowledge"])
@@ -58,35 +80,60 @@ class BenchmarkRunner:
         self._write_outputs(payload)
         return payload
 
-    # Internal helpers --------------------------------------------------
     def _run_knowledge_tests(self, tests: List[KnowledgeTest]) -> None:
+        """Run multiple-choice knowledge tests in parallel.
+
+        Prompts the model with WordPress knowledge questions and scores responses
+        based on whether they match the expected answer letter.
+
+        Args:
+            tests: List of knowledge test definitions.
+        """
         limit = self.config.run.limit or len(tests)
-        for test in track(tests[:limit], description="Knowledge"):
-            messages = ModelInterface.to_messages(
-                "You are an expert WordPress developer.",
-                self._render_knowledge_prompt(test),
-            )
-            answer = strip_code_fences(self.model.generate(messages)).strip()
+        tests_to_run = tests[:limit]
+        concurrency = self.config.run.concurrency
+
+        def process_test(test: KnowledgeTest) -> Dict[str, Any]:
+            prompt = self._render_knowledge_prompt(test)
+            answer = strip_code_fences(self.model.generate(prompt)).strip()
             correct = 1.0 if (test.correct_answer and answer.upper().startswith(test.correct_answer)) else 0.0
-            self.aggregator.add_knowledge(correct)
-            self.records.append(
-                {
-                    "test_id": test.id,
-                    "type": "knowledge",
-                    "prompt_hash": sha256(messages[-1]["content"]),
-                    "answer": answer,
-                    "correct": bool(correct),
-                }
-            )
+            return {
+                "test_id": test.id,
+                "type": "knowledge",
+                "prompt_hash": sha256(prompt),
+                "answer": answer,
+                "correct": bool(correct),
+                "score": correct,
+            }
+
+        with Progress() as progress:
+            task = progress.add_task("Knowledge", total=len(tests_to_run))
+            with ThreadPoolExecutor(max_workers=concurrency) as executor:
+                futures = {executor.submit(process_test, test): test for test in tests_to_run}
+                for future in as_completed(futures):
+                    result = future.result()
+                    with self._lock:
+                        self.aggregator.add_knowledge(result["score"])
+                        self.records.append(result)
+                    progress.update(task, advance=1)
 
     def _run_execution_tests(self, tests: List[ExecutionTest]) -> None:
+        """Run code generation execution tests in parallel.
+
+        Prompts the model to generate PHP code, executes it in the WordPress
+        environment, and scores based on static/runtime assertions.
+
+        Args:
+            tests: List of execution test definitions.
+        """
         limit = self.config.run.limit or len(tests)
-        for test in track(tests[:limit], description="Execution"):
-            messages = ModelInterface.to_messages(
-                "You are an expert WordPress core contributor.",
-                self._render_execution_prompt(test),
-            )
-            completion = self.model.generate(messages)
+        tests_to_run = tests[:limit]
+        concurrency = self.config.run.concurrency
+
+        def process_test(test: ExecutionTest) -> Dict[str, Any]:
+            """Process a single execution test (runs in thread pool)."""
+            prompt = self._render_execution_prompt(test)
+            completion = self.model.generate(prompt)
             code = strip_code_fences(completion)
             verification_spec = {
                 "static_checks": test.static_checks,
@@ -96,23 +143,39 @@ class BenchmarkRunner:
             env_result = self.environment.execute_code(code, verification_spec)
             correctness = self._score_assertions(env_result.raw)
             quality = env_result.raw.get("quality", {}).get("score") if env_result.raw else None
-            self.aggregator.add_execution(correctness, quality)
-            self.records.append(
-                {
-                    "test_id": test.id,
-                    "type": "execution",
-                    "prompt_hash": sha256(messages[-1]["content"]),
-                    "code": code,
-                    "result": env_result.raw,
-                    "stdout": env_result.stdout,
-                    "stderr": env_result.stderr,
-                    "correctness": correctness,
-                    "quality": quality,
-                }
-            )
+            return {
+                "test_id": test.id,
+                "type": "execution",
+                "prompt_hash": sha256(prompt),
+                "code": code,
+                "result": env_result.raw,
+                "stdout": env_result.stdout,
+                "stderr": env_result.stderr,
+                "correctness": correctness,
+                "quality": quality,
+            }
+
+        with Progress() as progress:
+            task = progress.add_task("Execution", total=len(tests_to_run))
+            with ThreadPoolExecutor(max_workers=concurrency) as executor:
+                futures = {executor.submit(process_test, test): test for test in tests_to_run}
+                for future in as_completed(futures):
+                    result = future.result()
+                    with self._lock:
+                        self.aggregator.add_execution(result["correctness"], result["quality"])
+                        self.records.append(result)
+                    progress.update(task, advance=1)
 
     @staticmethod
     def _render_knowledge_prompt(test: KnowledgeTest) -> str:
+        """Format a knowledge test into a multiple-choice prompt string.
+
+        Args:
+            test: Knowledge test with question and choices.
+
+        Returns:
+            Formatted prompt asking for a single letter answer.
+        """
         prompt = [test.prompt]
         if test.choices:
             prompt.append("Choices:")
@@ -123,6 +186,14 @@ class BenchmarkRunner:
 
     @staticmethod
     def _render_execution_prompt(test: ExecutionTest) -> str:
+        """Format an execution test into a code generation prompt.
+
+        Args:
+            test: Execution test with task description and requirements.
+
+        Returns:
+            Formatted prompt requesting PHP code in fenced blocks.
+        """
         lines = [test.prompt, "", "Requirements:"]
         for req in test.requirements:
             lines.append(f"- {req}")
@@ -133,6 +204,14 @@ class BenchmarkRunner:
 
     @staticmethod
     def _score_assertions(raw: Dict[str, Any]) -> float:
+        """Calculate correctness score from assertion results.
+
+        Args:
+            raw: Raw result dict from WordPress environment containing assertions.
+
+        Returns:
+            Float between 0.0 and 1.0 representing fraction of passed assertions.
+        """
         assertions = raw.get("assertions") or []
         if not assertions:
             return 0.0
@@ -140,6 +219,11 @@ class BenchmarkRunner:
         return round(passed / len(assertions), 4)
 
     def _write_outputs(self, payload: Dict[str, Any]) -> None:
+        """Write benchmark results to JSON and JSONL files.
+
+        Args:
+            payload: Complete results dict with metadata and test records.
+        """
         output_path = _timestamped_path(self.config.output.path)
         ensure_dir(output_path.parent)
         output_path.write_bytes(orjson.dumps(payload, option=orjson.OPT_INDENT_2))
@@ -154,15 +238,31 @@ class BenchmarkRunner:
 
 
 class MultiModelRunner:
-    """Run benchmarks across multiple models and produce comparison."""
+    """Run benchmarks across multiple models and produce a comparison table.
+
+    Iterates over all configured models, runs the full test suite for each using
+    SingleModelRunner, and outputs a side-by-side comparison of scores.
+    """
 
     def __init__(self, config: HarnessConfig):
+        """Initialize the multi-model runner.
+
+        Args:
+            config: Harness configuration with multiple models defined.
+        """
         self.config = config
         self.environment = WordPressEnvironment(config.grader)
         self.results: Dict[str, Dict[str, Any]] = {}
 
     def run(self) -> Dict[str, Any]:
-        """Run all models and return comparison matrix."""
+        """Execute benchmarks for all configured models.
+
+        Sets up the WordPress environment once, then runs each model sequentially.
+        Prints a comparison table and writes combined results.
+
+        Returns:
+            Dict mapping model names to their individual results.
+        """
         models = self.config.get_models()
         tests = load_tests(self.config.dataset)
         self.environment.setup()
@@ -185,7 +285,7 @@ class MultiModelRunner:
         return self.results
 
     def _print_comparison_table(self) -> None:
-        """Print a rich comparison table."""
+        """Print a formatted table comparing scores across all models."""
         table = Table(title="WP-Bench Results")
         table.add_column("Model", style="cyan")
         table.add_column("Knowledge", justify="right")
@@ -229,7 +329,11 @@ class MultiModelRunner:
 
 
 class SingleModelRunner:
-    """Run benchmark for a single model (used by MultiModelRunner)."""
+    """Run benchmark for a single model with pre-loaded tests.
+
+    Used by MultiModelRunner to evaluate one model at a time while sharing
+    the WordPress environment and test definitions across models.
+    """
 
     def __init__(
         self,
@@ -238,6 +342,14 @@ class SingleModelRunner:
         environment: WordPressEnvironment,
         tests: Dict[str, List[Any]],
     ):
+        """Initialize runner for a specific model.
+
+        Args:
+            config: Harness configuration for run settings.
+            model_config: Configuration for the specific model to evaluate.
+            environment: Shared WordPress environment instance.
+            tests: Pre-loaded dict of knowledge and execution tests.
+        """
         self.config = config
         self.model_config = model_config
         self.model = ModelInterface(model_config)
@@ -245,9 +357,14 @@ class SingleModelRunner:
         self.tests = tests
         self.aggregator = ScoreAggregator()
         self.records: List[Dict[str, Any]] = []
+        self._lock = threading.Lock()
 
     def run(self) -> Dict[str, Any]:
-        """Run all tests for this model."""
+        """Run all tests and return scores for this model.
+
+        Returns:
+            Dict with model config, aggregate scores, and individual results.
+        """
         self._run_knowledge_tests(self.tests["knowledge"])
         self._run_execution_tests(self.tests["execution"])
         summary = self.aggregator.finalize()
@@ -263,30 +380,43 @@ class SingleModelRunner:
         }
 
     def _run_knowledge_tests(self, tests: List[KnowledgeTest]) -> None:
+        """Run knowledge tests in parallel. See BenchmarkRunner._run_knowledge_tests."""
         limit = self.config.run.limit or len(tests)
-        for test in track(tests[:limit], description="Knowledge"):
-            messages = ModelInterface.to_messages(
-                "You are an expert WordPress developer.",
-                BenchmarkRunner._render_knowledge_prompt(test),
-            )
-            answer = strip_code_fences(self.model.generate(messages)).strip()
+        tests_to_run = tests[:limit]
+        concurrency = self.config.run.concurrency
+
+        def process_test(test: KnowledgeTest) -> Dict[str, Any]:
+            prompt = BenchmarkRunner._render_knowledge_prompt(test)
+            answer = strip_code_fences(self.model.generate(prompt)).strip()
             correct = 1.0 if (test.correct_answer and answer.upper().startswith(test.correct_answer)) else 0.0
-            self.aggregator.add_knowledge(correct)
-            self.records.append({
+            return {
                 "test_id": test.id,
                 "type": "knowledge",
                 "answer": answer,
                 "correct": bool(correct),
-            })
+                "score": correct,
+            }
+
+        with Progress() as progress:
+            task = progress.add_task("Knowledge", total=len(tests_to_run))
+            with ThreadPoolExecutor(max_workers=concurrency) as executor:
+                futures = {executor.submit(process_test, test): test for test in tests_to_run}
+                for future in as_completed(futures):
+                    result = future.result()
+                    with self._lock:
+                        self.aggregator.add_knowledge(result["score"])
+                        self.records.append(result)
+                    progress.update(task, advance=1)
 
     def _run_execution_tests(self, tests: List[ExecutionTest]) -> None:
+        """Run execution tests in parallel. See BenchmarkRunner._run_execution_tests."""
         limit = self.config.run.limit or len(tests)
-        for test in track(tests[:limit], description="Execution"):
-            messages = ModelInterface.to_messages(
-                "You are an expert WordPress core contributor.",
-                BenchmarkRunner._render_execution_prompt(test),
-            )
-            completion = self.model.generate(messages)
+        tests_to_run = tests[:limit]
+        concurrency = self.config.run.concurrency
+
+        def process_test(test: ExecutionTest) -> Dict[str, Any]:
+            prompt = BenchmarkRunner._render_execution_prompt(test)
+            completion = self.model.generate(prompt)
             code = strip_code_fences(completion)
             verification_spec = {
                 "static_checks": test.static_checks,
@@ -296,11 +426,21 @@ class SingleModelRunner:
             env_result = self.environment.execute_code(code, verification_spec)
             correctness = BenchmarkRunner._score_assertions(env_result.raw)
             quality = env_result.raw.get("quality", {}).get("score") if env_result.raw else None
-            self.aggregator.add_execution(correctness, quality)
-            self.records.append({
+            return {
                 "test_id": test.id,
                 "type": "execution",
                 "code": code,
                 "correctness": correctness,
                 "quality": quality,
-            })
+            }
+
+        with Progress() as progress:
+            task = progress.add_task("Execution", total=len(tests_to_run))
+            with ThreadPoolExecutor(max_workers=concurrency) as executor:
+                futures = {executor.submit(process_test, test): test for test in tests_to_run}
+                for future in as_completed(futures):
+                    result = future.result()
+                    with self._lock:
+                        self.aggregator.add_execution(result["correctness"], result["quality"])
+                        self.records.append(result)
+                    progress.update(task, advance=1)

--- a/python/wp_bench/models.py
+++ b/python/wp_bench/models.py
@@ -1,8 +1,6 @@
 """Model interface leveraging LiteLLM providers."""
 from __future__ import annotations
 
-from typing import List, Sequence
-
 from litellm import completion, completion_cost
 from litellm.utils import ModelResponse
 
@@ -15,10 +13,18 @@ class ModelInterface:
     def __init__(self, config: ModelConfig):
         self.config = config
 
-    def generate(self, messages: Sequence[dict]) -> str:
+    def generate(self, prompt: str) -> str:
+        """Generate a completion for the given prompt.
+
+        Args:
+            prompt: The user prompt to send to the model.
+
+        Returns:
+            The model's response text.
+        """
         response: ModelResponse = completion(
             model=self.config.name,
-            messages=list(messages),
+            messages=[{"role": "user", "content": prompt}],
             temperature=self.config.temperature,
             max_tokens=self.config.max_tokens,
             top_p=self.config.top_p,
@@ -26,13 +32,6 @@ class ModelInterface:
         )
         choice = response.choices[0]
         return choice.message["content"]  # type: ignore[index]
-
-    @staticmethod
-    def to_messages(system_prompt: str, user_prompt: str) -> List[dict]:
-        return [
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt},
-        ]
 
     @staticmethod
     def estimate_cost(response: ModelResponse) -> float:

--- a/wp-bench.example.yaml
+++ b/wp-bench.example.yaml
@@ -30,7 +30,7 @@ grader:
 run:
   suite: wp-core-v1
   # limit: 10            # limit tests per model (null = all)
-  concurrency: 4
+  concurrency: 5
 
 # Output paths
 output:


### PR DESCRIPTION
Depends on #2 (merge that one first)

## Summary                                                                                                  
                                                                                                           
  - Add parallel test execution with configurable concurrency (default: 5)                                 
  - Remove system prompts from model calls to reduce benchmark variables                                   
  - Simplify ModelInterface API                                                                            
                                                                                                           
## Details                                                                                                  
                                                                                                           
### Parallel Execution                                                                                       
                                                                                                           
  Tests now run concurrently using ThreadPoolExecutor, significantly reducing total benchmark runtime.     
  Concurrency is configurable via run.concurrency in the YAML config:                                      
  
```yaml
  run:
    concurrency: 5  # default
```
                                                                                                           
### System Prompt Removal                                                                                    
                                                                                                           
  Removed the system prompts ("You are an expert WordPress developer", etc.) from model calls. For a       
  benchmark, minimal prompts are preferable because:                                                       
                                                                                                           
  - Measures the model's intrinsic WordPress knowledge rather than prompt engineering                      
  - Fewer confounding variables for reproducibility                                                        
  - Fairer comparison across models                                                                        
                                                                                                           
### API Simplification                                                                                       
                                                                                                           
  Simplified ModelInterface.generate() to accept a prompt string directly instead of a message list.       
  Removed the now-unnecessary to_messages() helper. We can add complexity back later if multi-turn         
  conversations are needed.                                                                                
                                                                                                           
##  Test plan                                                                                                
                                                                                                           
  - Run benchmark with default concurrency: wp-bench run --config wp-bench.yaml                            
  - Verify results output matches expected format                                                          
  - Test with concurrency: 1 to confirm sequential fallback works