### PR TITLE
Add abilities test harness and training signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ WP-Bench measures AI model capabilities across two dimensions:
 - **Knowledge** — Multiple-choice questions testing WordPress concepts, APIs, and best practices
 - **Execution** — Code generation tasks graded by a real WordPress runtime for correctness and quality
 
+Optional (experimental):
+
+- **Abilities (Tool Use)** — Multi-step tasks that call WordPress abilities via typed, permissioned tool schemas
+  - Requires the Abilities API (WordPress 6.9+ or the Abilities API plugin)
+
 The benchmark uses WordPress itself as the grader, running generated code in a sandboxed environment with static analysis and runtime assertions.
 
 ## Quick Start
@@ -116,7 +121,10 @@ Test suites live in `datasets/suites/<suite-name>/` with two directories per sui
 - `execution/` — Code generation tasks with assertions (one JSON file per category)
 - `knowledge/` — Multiple-choice knowledge questions (one JSON file per category)
 
+An optional `abilities/` directory can be added for tool-use tasks. The harness will load and run these tests when present.
+
 The default suite `wp-core-v1` covers WordPress core APIs, hooks, database operations, and security patterns.
+An experimental `wp-abilities-v1` suite adds Abilities API knowledge + tool-use tasks (requires Abilities API support in the runtime).
 
 ### Loading from Hugging Face
 
@@ -152,6 +160,9 @@ The notebook generates:
 ```bash
 # Manual grading example (run from runtime/ directory)
 npm run wp-bench -- verify --payload=$(echo '{"code":"<?php echo 1;"}' | base64)
+
+# Manual ability execution example (run from runtime/ directory)
+npm run wp-bench -- ability --payload=$(echo '{"ability":"wpbench/get_site_info","input":{}}' | base64)
 ```
 
 ## Development

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -53,7 +53,7 @@ dataset:
 
 ## Adding New Suites
 
-1. Create `suites/<suite-name>/execution/` and `knowledge/` directories
+1. Create `suites/<suite-name>/execution/`, `knowledge/`, and optionally `abilities/` directories
 2. Add category JSON files (e.g., `hooks.json`, `rest-api.json`) to each directory
 3. Follow the schema in existing suites
 4. Run `python datasets/export_dataset.py` to include in Parquet export
@@ -77,3 +77,72 @@ dataset:
 | `prompt` | string | Question text |
 | `choices` | array | Multiple choice options `[{key, text}]` |
 | `correct_answer` | string | Correct choice key (e.g., "B") |
+
+### Abilities Tests (Tool Use)
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique test ID |
+| `prompt` | string | Task description for the model |
+| `allowed_abilities` | array | List of ability names allowed |
+| `max_steps` | integer | Max tool calls |
+| `fixtures` | object | Setup/teardown or initial state |
+| `verifiers` | array | Verifier names to score this task |
+| `expected_outputs` | array | Optional expected tool outputs |
+| `expected_state` | object | Optional expected state |
+
+Notes:
+- Abilities tests require the Abilities API to be available in the runtime (WordPress 6.9+ or the Abilities API plugin).
+
+#### Verifier Names (Abilities)
+Common verifier keys you can use in `verifiers`:
+- `tool_calls_present` — at least one tool call was produced
+- `schema_validity` — tool call includes required fields with basic types
+- `allowed_abilities_only` — only abilities in `allowed_abilities` are used
+- `max_steps_respected` — tool call count does not exceed `max_steps`
+- `ability_success` — all tool calls executed successfully
+- `ability_found` — all tool calls targeted a registered ability
+- `method_valid` — ability method respected read-only vs write expectations
+- `permission_ok` — no permission errors were raised by the ability
+- `confirmation_ok` — destructive abilities included confirmation fields
+- `expected_outputs_match` — tool call outputs match `expected_outputs`
+- `expected_state_match` — post-run state checks in `expected_state` pass
+
+#### expected_outputs
+List aligned to tool call order. Each entry can be:
+- a subset object matched against the tool observation `result`
+- or an object with one of:
+  - `match`: subset matched against `result`
+  - `result`: exact/partial match against `result`
+  - `equals`: exact/partial match against the full observation
+  - `ability`: optional guard to ensure the expected entry aligns with a specific ability name
+
+Example:
+```json
+{
+  "expected_outputs": [
+    {
+      "ability": "wpbench/get_site_info",
+      "match": { "name": "My Site" }
+    }
+  ]
+}
+```
+
+#### expected_state
+Optional list of post-run checks, each with:
+- `ability` (required)
+- `input` (optional)
+- `method` (optional)
+- `match` / `result` / `equals` (optional match against the ability result)
+
+Example:
+```json
+{
+  "expected_state": [
+    {
+      "ability": "wpbench/get_site_info",
+      "match": { "url": "https://example.test" }
+    }
+  ]
+}
+```

--- a/datasets/export_dataset.py
+++ b/datasets/export_dataset.py
@@ -44,6 +44,12 @@ def load_suite(suite_name: str) -> list[dict]:
                     "runtime_checks": orjson.dumps(t.get("runtime_checks", {})).decode(),
                     "judge_config": orjson.dumps(t.get("judge_config", {})).decode(),
                     "reference_solution": t.get("reference_solution", ""),
+                    "allowed_abilities": "[]",
+                    "max_steps": 0,
+                    "fixtures": "{}",
+                    "verifiers": "[]",
+                    "expected_outputs": "[]",
+                    "expected_state": "{}",
                 })
 
     # Load all knowledge tests from knowledge/ directory
@@ -66,6 +72,40 @@ def load_suite(suite_name: str) -> list[dict]:
                     "runtime_checks": "{}",
                     "judge_config": "{}",
                     "reference_solution": "",
+                    "allowed_abilities": "[]",
+                    "max_steps": 0,
+                    "fixtures": "{}",
+                    "verifiers": "[]",
+                    "expected_outputs": "[]",
+                    "expected_state": "{}",
+                })
+
+    # Load all abilities tests from abilities/ directory
+    abilities_dir = suite_dir / "abilities"
+    if abilities_dir.is_dir():
+        for path in sorted(abilities_dir.glob("*.json")):
+            data = orjson.loads(path.read_bytes())
+            for t in data.get("tests", []):
+                rows.append({
+                    "id": t["id"],
+                    "suite": suite_name,
+                    "test_kind": "abilities",
+                    "prompt": t["prompt"],
+                    "category": t.get("category", "general"),
+                    "difficulty": t.get("difficulty", "unknown"),
+                    "choices": "[]",
+                    "correct_answer": "",
+                    "requirements": orjson.dumps(t.get("requirements", [])).decode(),
+                    "static_checks": "{}",
+                    "runtime_checks": "{}",
+                    "judge_config": "{}",
+                    "reference_solution": "",
+                    "allowed_abilities": orjson.dumps(t.get("allowed_abilities", [])).decode(),
+                    "max_steps": t.get("max_steps", 1),
+                    "fixtures": orjson.dumps(t.get("fixtures", {})).decode(),
+                    "verifiers": orjson.dumps(t.get("verifiers", [])).decode(),
+                    "expected_outputs": orjson.dumps(t.get("expected_outputs", [])).decode(),
+                    "expected_state": orjson.dumps(t.get("expected_state", {})).decode(),
                 })
 
     return rows

--- a/datasets/suites/wp-abilities-v1/abilities/core.json
+++ b/datasets/suites/wp-abilities-v1/abilities/core.json
@@ -1,0 +1,30 @@
+{
+  "id": "wp-abilities-v1-abilities-core",
+  "version": "1.0.0",
+  "metadata": {
+    "name": "WP Abilities v1 - Core Tool Tasks",
+    "description": "Minimal tool-use tasks for Abilities API",
+    "wp_version": "6.9",
+    "created_at": "2026-01-26"
+  },
+  "tests": [
+    {
+      "id": "a-abilities-001",
+      "category": "read-only",
+      "difficulty": "basic",
+      "prompt": "Fetch the site name and URL using the appropriate ability.",
+      "allowed_abilities": [
+        "wpbench/get_site_info"
+      ],
+      "max_steps": 2,
+      "fixtures": {},
+      "verifiers": [
+        "tool_calls_present",
+        "schema_validity",
+        "ability_success",
+        "allowed_abilities_only",
+        "max_steps_respected"
+      ]
+    }
+  ]
+}

--- a/datasets/suites/wp-abilities-v1/knowledge/abilities-api.json
+++ b/datasets/suites/wp-abilities-v1/knowledge/abilities-api.json
@@ -1,0 +1,26 @@
+{
+  "id": "wp-abilities-v1-knowledge-abilities",
+  "version": "1.0.0",
+  "metadata": {
+    "name": "WP Abilities v1 - Knowledge",
+    "description": "Abilities API knowledge checks",
+    "wp_version": "6.9",
+    "created_at": "2026-01-26"
+  },
+  "tests": [
+    {
+      "id": "k-abilities-001",
+      "category": "abilities-api",
+      "difficulty": "basic",
+      "prompt": "Which hook should plugins use to register abilities with the WordPress Abilities API?",
+      "type": "multiple_choice",
+      "choices": [
+        { "key": "A", "text": "init" },
+        { "key": "B", "text": "wp_loaded" },
+        { "key": "C", "text": "wp_abilities_api_init" },
+        { "key": "D", "text": "rest_api_init" }
+      ],
+      "correct_answer": "C"
+    }
+  ]
+}

--- a/python/wp_bench/cli.py
+++ b/python/wp_bench/cli.py
@@ -62,8 +62,14 @@ def dry_run(config: Optional[Path] = typer.Option(None, help="Config file")) -> 
     """Load dataset and render prompt statistics without hitting models."""
     harness_config = HarnessConfig.from_file(config) if config else HarnessConfig()
     tests = load_tests(harness_config.dataset)
+    abilities_count = len(tests.get("abilities", []))
     console.print(
-        f"Execution tests: {len(tests['execution'])}, Knowledge tests: {len(tests['knowledge'])}"
+        "Execution tests: "
+        f"{len(tests['execution'])}, "
+        "Knowledge tests: "
+        f"{len(tests['knowledge'])}, "
+        "Abilities tests: "
+        f"{abilities_count}"
     )
 
 

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List
 import orjson
 
 from .config import HarnessConfig, ModelConfig
-from .datasets import ExecutionTest, KnowledgeTest, load_tests
+from .datasets import AbilityTest, ExecutionTest, KnowledgeTest, load_tests
 from .environment import WordPressEnvironment
 from .models import ModelInterface
 from .output import (
@@ -35,6 +35,287 @@ class TestError(Exception):
         self.original_error = original_error
         self.traceback_str = traceback.format_exc()
         super().__init__(str(original_error))
+
+
+def render_abilities_prompt(test: AbilityTest, history: List[str] | None = None) -> str:
+    prompt = [test.prompt]
+    prompt.append(
+        'Return a tool call as JSON: {"ability": "name", "input": {...}}'
+    )
+    prompt.append(f"Allowed abilities: {', '.join(test.allowed_abilities)}")
+    if history:
+        prompt.append("History:")
+        prompt.extend(history)
+    prompt.append("If no tool is needed, answer normally.")
+    return "\n".join(prompt)
+
+
+def parse_tool_call(completion: str) -> Dict[str, Any] | None:
+    text = strip_code_fences(completion).strip()
+    if not text:
+        return None
+    if not text.startswith("{"):
+        start = text.find("{")
+        if start == -1:
+            return None
+        text = text[start:]
+    try:
+        data = orjson.loads(text)
+        if not isinstance(data, dict):
+            return None
+        if "ability" not in data:
+            return None
+        return data
+    except orjson.JSONDecodeError:
+        end = text.rfind("}")
+        if end == -1:
+            return None
+        try:
+            data = orjson.loads(text[: end + 1])
+            if not isinstance(data, dict):
+                return None
+            if "ability" not in data:
+                return None
+            return data
+        except orjson.JSONDecodeError:
+            return None
+
+
+def _tool_call_schema_valid(call: Dict[str, Any]) -> bool:
+    if not isinstance(call, dict):
+        return False
+    ability = call.get("ability")
+    if not isinstance(ability, str) or not ability:
+        return False
+    if "input" in call and call["input"] is not None and not isinstance(call["input"], dict):
+        return False
+    if "method" in call and call["method"] is not None and not isinstance(call["method"], str):
+        return False
+    return True
+
+
+def _looks_like_permission_error(value: Any) -> bool:
+    if value is None:
+        return False
+    text = str(value).lower()
+    return any(token in text for token in ("permission", "forbidden", "rest_forbidden", "rest_cannot"))
+
+
+def _observation_bool(observation: Dict[str, Any], key: str) -> bool | None:
+    if key not in observation:
+        return None
+    return bool(observation.get(key))
+
+
+def _observation_ability_found(observation: Dict[str, Any]) -> bool:
+    value = _observation_bool(observation, "ability_found")
+    if value is not None:
+        return value
+    if observation.get("error") == "ability_not_found":
+        return False
+    return bool(observation.get("success"))
+
+
+def _observation_method_valid(observation: Dict[str, Any]) -> bool:
+    value = _observation_bool(observation, "method_valid")
+    if value is not None:
+        return value
+    if observation.get("error") == "invalid_method":
+        return False
+    return True
+
+
+def _observation_permission_ok(observation: Dict[str, Any]) -> bool:
+    value = _observation_bool(observation, "permission_ok")
+    if value is not None:
+        return value
+    if _looks_like_permission_error(observation.get("error")):
+        return False
+    if observation.get("success") is True:
+        return True
+    return True
+
+
+def _observation_confirmation_ok(observation: Dict[str, Any]) -> bool:
+    value = _observation_bool(observation, "confirmation_ok")
+    if value is not None:
+        return value
+    if observation.get("confirmation_required"):
+        return False
+    return True
+
+
+def _all_observations(
+    observations: List[Dict[str, Any]],
+    predicate,
+    require: bool = True,
+) -> bool:
+    if not observations:
+        return False if require else True
+    return all(predicate(obs) for obs in observations)
+
+
+def _match_subset(expected: Any, actual: Any) -> bool:
+    if isinstance(expected, dict):
+        if not isinstance(actual, dict):
+            return False
+        for key, value in expected.items():
+            if key not in actual:
+                return False
+            if not _match_subset(value, actual[key]):
+                return False
+        return True
+    if isinstance(expected, list):
+        if not isinstance(actual, list):
+            return False
+        if len(expected) > len(actual):
+            return False
+        for idx, value in enumerate(expected):
+            if not _match_subset(value, actual[idx]):
+                return False
+        return True
+    return expected == actual
+
+
+def _extract_expected_match(expected_entry: Any, observation: Dict[str, Any]) -> bool:
+    if isinstance(expected_entry, dict):
+        if "match" in expected_entry:
+            expected_value = expected_entry["match"]
+            target = observation.get("result", observation)
+            return _match_subset(expected_value, target)
+        if "result" in expected_entry:
+            expected_value = expected_entry["result"]
+            target = observation.get("result")
+            return _match_subset(expected_value, target)
+        if "equals" in expected_entry:
+            return _match_subset(expected_entry["equals"], observation)
+    return _match_subset(expected_entry, observation.get("result", observation))
+
+
+def _check_expected_outputs(
+    expected_outputs: Any,
+    tool_calls: List[Dict[str, Any]],
+    observations: List[Dict[str, Any]],
+) -> bool:
+    if expected_outputs is None:
+        return True
+    if not isinstance(expected_outputs, list):
+        return False
+    if not expected_outputs:
+        return True
+    if not observations:
+        return False
+    for idx, expected_entry in enumerate(expected_outputs):
+        if idx >= len(observations):
+            return False
+        observation = observations[idx]
+        if isinstance(expected_entry, dict) and "ability" in expected_entry:
+            if idx >= len(tool_calls):
+                return False
+            if tool_calls[idx].get("ability") != expected_entry.get("ability"):
+                return False
+        if not _extract_expected_match(expected_entry, observation):
+            return False
+    return True
+
+
+def _normalize_state_checks(expected_state: Any) -> List[Dict[str, Any]]:
+    if expected_state is None:
+        return []
+    if isinstance(expected_state, list):
+        return [item for item in expected_state if isinstance(item, dict)]
+    if isinstance(expected_state, dict):
+        checks = expected_state.get("checks")
+        if isinstance(checks, list):
+            return [item for item in checks if isinstance(item, dict)]
+        if "ability" in expected_state:
+            return [expected_state]
+    return []
+
+
+def _run_state_checks(
+    expected_state: Any, environment: WordPressEnvironment
+) -> List[Dict[str, Any]]:
+    checks = _normalize_state_checks(expected_state)
+    results: List[Dict[str, Any]] = []
+    for check in checks:
+        ability = check.get("ability")
+        if not isinstance(ability, str) or not ability:
+            results.append(
+                {
+                    "ability": None,
+                    "success": False,
+                    "match": False,
+                    "error": "missing_ability",
+                }
+            )
+            continue
+        input_data = check.get("input")
+        method = check.get("method")
+        env_result = environment.execute_ability(
+            ability=ability,
+            input_data=input_data,
+            method=method if isinstance(method, str) else None,
+        )
+        observation = env_result.raw if env_result.raw else {"success": False, "error": "no_result"}
+        if "match" in check:
+            match_ok = _match_subset(check["match"], observation.get("result", observation))
+        elif "result" in check:
+            match_ok = _match_subset(check["result"], observation.get("result"))
+        elif "equals" in check:
+            match_ok = _match_subset(check["equals"], observation)
+        else:
+            match_ok = bool(observation.get("success"))
+        results.append(
+            {
+                "ability": ability,
+                "input": input_data,
+                "method": method,
+                "observation": observation,
+                "match": match_ok,
+            }
+        )
+    return results
+
+
+def score_abilities(
+    test: AbilityTest,
+    tool_calls: List[Dict[str, Any]],
+    observations: List[Dict[str, Any]],
+    final_answer: str,
+    state_checks: List[Dict[str, Any]] | None = None,
+) -> tuple[float, Dict[str, Any]]:
+    results: Dict[str, Any] = {}
+    has_tool_calls = len(tool_calls) > 0
+    results["tool_calls_present"] = has_tool_calls
+    results["schema_validity"] = has_tool_calls and all(_tool_call_schema_valid(t) for t in tool_calls)
+    results["allowed_abilities_only"] = all(t.get("ability") in test.allowed_abilities for t in tool_calls)
+    results["max_steps_respected"] = len(tool_calls) <= test.max_steps
+    results["ability_success"] = _all_observations(observations, lambda obs: bool(obs.get("success")))
+    results["ability_found"] = _all_observations(observations, _observation_ability_found)
+    results["method_valid"] = _all_observations(observations, _observation_method_valid)
+    results["permission_ok"] = _all_observations(observations, _observation_permission_ok)
+    results["confirmation_ok"] = _all_observations(observations, _observation_confirmation_ok)
+
+    results["expected_outputs_match"] = _check_expected_outputs(
+        test.expected_outputs, tool_calls, observations
+    )
+    if "expected_output_match" in test.verifiers:
+        results["expected_output_match"] = results["expected_outputs_match"]
+
+    if test.expected_state is not None:
+        if state_checks:
+            results["expected_state_match"] = all(check.get("match") for check in state_checks)
+        else:
+            results["expected_state_match"] = False
+    else:
+        results["expected_state_match"] = True
+
+    enabled = [k for k in results.keys() if k in test.verifiers]
+    if not enabled:
+        return (1.0, results)
+    score = sum(1.0 if results[k] else 0.0 for k in enabled) / len(enabled)
+    return (round(score, 4), results)
 
 
 def _timestamped_path(path: Path) -> Path:
@@ -80,6 +361,8 @@ class BenchmarkRunner:
         try:
             self._run_knowledge_tests(tests["knowledge"])
             self._run_execution_tests(tests["execution"])
+            if "abilities" in tests:
+                self._run_abilities_tests(tests["abilities"])
         except TestError as e:
             print_test_error(e)
             raise SystemExit(1) from e
@@ -97,6 +380,7 @@ class BenchmarkRunner:
                     "knowledge": summary.knowledge,
                     "correctness": summary.correctness,
                     "quality": summary.quality,
+                    "abilities": summary.abilities,
                     "overall": summary.overall(),
                 },
             },
@@ -206,6 +490,99 @@ class BenchmarkRunner:
                         result = future.result()
                         with self._lock:
                             self.aggregator.add_execution(result["correctness"], result["quality"])
+                            self.records.append(result)
+                        progress.update(task, advance=1)
+                    except TestError:
+                        for f in futures:
+                            f.cancel()
+                        raise
+
+    def _run_abilities_tests(self, tests: List[AbilityTest]) -> None:
+        """Run tool-use ability tests in parallel."""
+        if not tests:
+            return
+
+        limit = self.config.run.limit or len(tests)
+        tests_to_run = tests[:limit]
+        concurrency = self.config.run.concurrency
+
+        def process_test(test: AbilityTest) -> Dict[str, Any]:
+            try:
+                history: List[str] = []
+                tool_calls: List[Dict[str, Any]] = []
+                observations: List[Dict[str, Any]] = []
+                trace: List[Dict[str, Any]] = []
+                final_answer = ""
+
+                setup = test.fixtures.get("setup") if isinstance(test.fixtures, dict) else None
+                teardown = test.fixtures.get("teardown") if isinstance(test.fixtures, dict) else None
+
+                for step in range(test.max_steps):
+                    prompt = render_abilities_prompt(test, history=history)
+                    completion = self.model.generate(prompt)
+                    trace_step: Dict[str, Any] = {
+                        "step": step,
+                        "prompt": prompt,
+                        "completion": completion,
+                    }
+                    parsed = parse_tool_call(completion)
+                    if parsed is None:
+                        final_answer = completion
+                        trace_step["tool_call"] = None
+                        trace.append(trace_step)
+                        break
+
+                    tool_calls.append(parsed)
+                    result = self.environment.execute_ability(
+                        ability=parsed.get("ability", ""),
+                        input_data=parsed.get("input"),
+                        method=parsed.get("method"),
+                        setup=setup if step == 0 else None,
+                        teardown=teardown if step == test.max_steps - 1 else None,
+                    )
+                    observation = result.raw if result.raw else {"success": False, "error": "no_result"}
+                    observations.append(observation)
+                    trace_step["tool_call"] = parsed
+                    trace_step["observation"] = observation
+                    trace.append(trace_step)
+                    history.append(f"TOOL_CALL: {parsed}")
+                    history.append(f"OBSERVATION: {observation}")
+                else:
+                    final_answer = ""
+
+                state_checks = _run_state_checks(test.expected_state, self.environment) if test.expected_state else []
+                score, verifier_results = score_abilities(
+                    test,
+                    tool_calls,
+                    observations,
+                    final_answer,
+                    state_checks=state_checks,
+                )
+
+                return {
+                    "test_id": test.id,
+                    "type": "abilities",
+                    "prompt_hash": sha256(render_abilities_prompt(test)),
+                    "tool_calls": tool_calls,
+                    "observations": observations,
+                    "trace": trace,
+                    "state_checks": state_checks,
+                    "final_answer": final_answer,
+                    "verifiers": verifier_results,
+                    "score": score,
+                }
+            except Exception as e:
+                raise TestError(test.id, "abilities", e) from e
+
+        with create_progress() as progress:
+            task = progress.add_task("Abilities", total=len(tests_to_run))
+            with ThreadPoolExecutor(max_workers=concurrency) as executor:
+                futures = {executor.submit(process_test, test): test for test in tests_to_run}
+                for future in as_completed(futures):
+                    try:
+                        result = future.result()
+                        with self._lock:
+                            self.aggregator.add_abilities(result["score"])
                             self.records.append(result)
                         progress.update(task, advance=1)
                     except TestError:
@@ -403,6 +780,8 @@ class SingleModelRunner:
         """
         self._run_knowledge_tests(self.tests["knowledge"])
         self._run_execution_tests(self.tests["execution"])
+        if "abilities" in self.tests:
+            self._run_abilities_tests(self.tests["abilities"])
         summary = self.aggregator.finalize()
         return {
             "model_config": self.model_config.model_dump(mode="json"),
@@ -410,6 +789,7 @@ class SingleModelRunner:
                 "knowledge": summary.knowledge,
                 "correctness": summary.correctness,
                 "quality": summary.quality,
+                "abilities": summary.abilities,
                 "overall": summary.overall(),
             },
             "results": self.records,
@@ -490,6 +870,99 @@ class SingleModelRunner:
                         result = future.result()
                         with self._lock:
                             self.aggregator.add_execution(result["correctness"], result["quality"])
+                            self.records.append(result)
+                        progress.update(task, advance=1)
+                    except TestError:
+                        for f in futures:
+                            f.cancel()
+                        raise
+
+    def _run_abilities_tests(self, tests: List[AbilityTest]) -> None:
+        """Run tool-use ability tests in parallel."""
+        if not tests:
+            return
+
+        limit = self.config.run.limit or len(tests)
+        tests_to_run = tests[:limit]
+        concurrency = self.config.run.concurrency
+
+        def process_test(test: AbilityTest) -> Dict[str, Any]:
+            try:
+                history: List[str] = []
+                tool_calls: List[Dict[str, Any]] = []
+                observations: List[Dict[str, Any]] = []
+                trace: List[Dict[str, Any]] = []
+                final_answer = ""
+
+                setup = test.fixtures.get("setup") if isinstance(test.fixtures, dict) else None
+                teardown = test.fixtures.get("teardown") if isinstance(test.fixtures, dict) else None
+
+                for step in range(test.max_steps):
+                    prompt = render_abilities_prompt(test, history=history)
+                    completion = self.model.generate(prompt)
+                    trace_step: Dict[str, Any] = {
+                        "step": step,
+                        "prompt": prompt,
+                        "completion": completion,
+                    }
+                    parsed = parse_tool_call(completion)
+                    if parsed is None:
+                        final_answer = completion
+                        trace_step["tool_call"] = None
+                        trace.append(trace_step)
+                        break
+
+                    tool_calls.append(parsed)
+                    result = self.environment.execute_ability(
+                        ability=parsed.get("ability", ""),
+                        input_data=parsed.get("input"),
+                        method=parsed.get("method"),
+                        setup=setup if step == 0 else None,
+                        teardown=teardown if step == test.max_steps - 1 else None,
+                    )
+                    observation = result.raw if result.raw else {"success": False, "error": "no_result"}
+                    observations.append(observation)
+                    trace_step["tool_call"] = parsed
+                    trace_step["observation"] = observation
+                    trace.append(trace_step)
+                    history.append(f"TOOL_CALL: {parsed}")
+                    history.append(f"OBSERVATION: {observation}")
+                else:
+                    final_answer = ""
+
+                state_checks = _run_state_checks(test.expected_state, self.environment) if test.expected_state else []
+                score, verifier_results = score_abilities(
+                    test,
+                    tool_calls,
+                    observations,
+                    final_answer,
+                    state_checks=state_checks,
+                )
+
+                return {
+                    "test_id": test.id,
+                    "type": "abilities",
+                    "prompt_hash": sha256(render_abilities_prompt(test)),
+                    "tool_calls": tool_calls,
+                    "observations": observations,
+                    "trace": trace,
+                    "state_checks": state_checks,
+                    "final_answer": final_answer,
+                    "verifiers": verifier_results,
+                    "score": score,
+                }
+            except Exception as e:
+                raise TestError(test.id, "abilities", e) from e
+
+        with create_progress() as progress:
+            task = progress.add_task("Abilities", total=len(tests_to_run))
+            with ThreadPoolExecutor(max_workers=concurrency) as executor:
+                futures = {executor.submit(process_test, test): test for test in tests_to_run}
+                for future in as_completed(futures):
+                    try:
+                        result = future.result()
+                        with self._lock:
+                            self.aggregator.add_abilities(result["score"])
                             self.records.append(result)
                         progress.update(task, advance=1)
                     except TestError:

--- a/python/wp_bench/datasets.py
+++ b/python/wp_bench/datasets.py
@@ -44,8 +44,26 @@ class KnowledgeTest:
     metadata: Optional[Dict[str, Any]] = None
 
 
+@dataclass
+class AbilityTest:
+    id: str
+    suite: str
+    prompt: str
+    test_type: str
+    category: str
+    difficulty: str
+    allowed_abilities: List[str]
+    max_steps: int
+    fixtures: Dict[str, Any]
+    verifiers: List[str]
+    expected_outputs: Optional[List[Any]] = None
+    expected_state: Optional[Dict[str, Any]] = None
+    requirements: Optional[List[str]] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
 def load_tests(config: DatasetConfig) -> Dict[str, List[Any]]:
-    """Load both execution and knowledge tests for a suite."""
+    """Load execution, knowledge, and ability tests for a suite."""
     if config.source == "huggingface":
         return _load_from_huggingface(config)
     return _load_from_local_files(config)
@@ -61,6 +79,7 @@ def _load_from_huggingface(config: DatasetConfig) -> Dict[str, List[Any]]:
     )
     execution: List[ExecutionTest] = []
     knowledge: List[KnowledgeTest] = []
+    abilities: List[AbilityTest] = []
 
     for row in dataset:
         # Parse JSON-encoded fields from Parquet format
@@ -87,6 +106,45 @@ def _load_from_huggingface(config: DatasetConfig) -> Dict[str, List[Any]]:
                     metadata={},
                 )
             )
+        elif row.get("test_kind") == "knowledge":
+            knowledge.append(
+                KnowledgeTest(
+                    id=row["id"],
+                    suite=row.get("suite", config.name),
+                    prompt=row["prompt"],
+                    test_type="knowledge",
+                    category=row.get("category", "general"),
+                    difficulty=row.get("difficulty", "unknown"),
+                    choices=choices if isinstance(choices, list) else None,
+                    correct_answer=row.get("correct_answer"),
+                    metadata={},
+                )
+            )
+        elif row.get("test_kind") == "abilities":
+            allowed = _parse_json_field(row.get("allowed_abilities", "[]"))
+            fixtures = _parse_json_field(row.get("fixtures", "{}"))
+            verifiers = _parse_json_field(row.get("verifiers", "[]"))
+            expected_outputs = _parse_json_field(row.get("expected_outputs", "[]"))
+            expected_state = _parse_json_field(row.get("expected_state", "{}"))
+            requirements = _parse_json_field(row.get("requirements", "[]"))
+            abilities.append(
+                AbilityTest(
+                    id=row["id"],
+                    suite=row.get("suite", config.name),
+                    prompt=row["prompt"],
+                    test_type="abilities",
+                    category=row.get("category", "general"),
+                    difficulty=row.get("difficulty", "unknown"),
+                    allowed_abilities=allowed if isinstance(allowed, list) else [],
+                    max_steps=int(row.get("max_steps", 1)),
+                    fixtures=fixtures if isinstance(fixtures, dict) else {},
+                    verifiers=verifiers if isinstance(verifiers, list) else [],
+                    expected_outputs=expected_outputs if isinstance(expected_outputs, list) else None,
+                    expected_state=expected_state if isinstance(expected_state, dict) else None,
+                    requirements=requirements if isinstance(requirements, list) else None,
+                    metadata={},
+                )
+            )
         else:
             knowledge.append(
                 KnowledgeTest(
@@ -101,7 +159,7 @@ def _load_from_huggingface(config: DatasetConfig) -> Dict[str, List[Any]]:
                     metadata={},
                 )
             )
-    return {"execution": execution, "knowledge": knowledge}
+    return {"execution": execution, "knowledge": knowledge, "abilities": abilities}
 
 
 def _parse_json_field(value: Any) -> Any:
@@ -120,6 +178,7 @@ def _load_from_local_files(config: DatasetConfig) -> Dict[str, List[Any]]:
 
     execution: List[ExecutionTest] = []
     knowledge: List[KnowledgeTest] = []
+    abilities: List[AbilityTest] = []
 
     # Load all execution test files from execution/ directory
     execution_dir = suite_dir / "execution"
@@ -133,9 +192,14 @@ def _load_from_local_files(config: DatasetConfig) -> Dict[str, List[Any]]:
         for path in sorted(knowledge_dir.glob("*.json")):
             knowledge.extend(_parse_knowledge_suite(path))
 
+    abilities_dir = suite_dir / "abilities"
+    if abilities_dir.is_dir():
+        for path in sorted(abilities_dir.glob("*.json")):
+            abilities.extend(_parse_abilities_suite(path))
+
     if config.split != "test":
         raise ValueError("Local dataset loader only supports the 'test' split")
-    return {"execution": execution, "knowledge": knowledge}
+    return {"execution": execution, "knowledge": knowledge, "abilities": abilities}
 
 
 def _parse_execution_suite(path: Path) -> List[ExecutionTest]:
@@ -179,6 +243,33 @@ def _parse_knowledge_suite(path: Path) -> List[KnowledgeTest]:
                 difficulty=test.get("difficulty", "unknown"),
                 choices=test.get("choices"),
                 correct_answer=test.get("correct_answer"),
+                metadata={"suite_metadata": metadata},
+            )
+        )
+    return tests
+
+
+def _parse_abilities_suite(path: Path) -> List[AbilityTest]:
+    data = _read_json(path)
+    suite_id = data.get("id", path.stem)
+    metadata = data.get("metadata", {})
+    tests = []
+    for test in data.get("tests", []):
+        tests.append(
+            AbilityTest(
+                id=test["id"],
+                suite=suite_id,
+                prompt=test["prompt"],
+                test_type="abilities",
+                category=test.get("category", "general"),
+                difficulty=test.get("difficulty", "unknown"),
+                allowed_abilities=test.get("allowed_abilities", []),
+                max_steps=int(test.get("max_steps", 1)),
+                fixtures=test.get("fixtures", {}),
+                verifiers=test.get("verifiers", []),
+                expected_outputs=test.get("expected_outputs"),
+                expected_state=test.get("expected_state"),
+                requirements=test.get("requirements"),
                 metadata={"suite_metadata": metadata},
             )
         )

--- a/python/wp_bench/environment.py
+++ b/python/wp_bench/environment.py
@@ -18,6 +18,14 @@ class ExecutionResult:
     stderr: str
 
 
+@dataclass
+class AbilityResult:
+    success: bool
+    raw: Dict[str, Any]
+    stdout: str
+    stderr: str
+
+
 class WordPressEnvironment:
     """Shells out to wp-env/docker runtime to execute verification."""
 
@@ -61,6 +69,43 @@ class WordPressEnvironment:
                 data = {"success": False, "fatal_error": "Invalid JSON"}
         success = data.get("success", False) and rc == 0
         return ExecutionResult(success=success, raw=data, stdout=stdout, stderr=stderr)
+
+    def execute_ability(
+        self,
+        ability: str,
+        input_data: Any | None = None,
+        method: str | None = None,
+        setup: str | None = None,
+        teardown: str | None = None,
+    ) -> AbilityResult:
+        payload: Dict[str, Any] = {
+            "ability": ability,
+            "input": input_data,
+        }
+        if method:
+            payload["method"] = method
+        if setup:
+            payload["setup"] = setup
+        if teardown:
+            payload["teardown"] = teardown
+
+        encoded = base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
+        cmd = [
+            "wp",
+            "bench",
+            "ability",
+            f"--payload={encoded}",
+            "--format=json",
+        ]
+        stdout, stderr, rc = self._exec(cmd)
+        data: Dict[str, Any] = {}
+        if stdout.strip():
+            try:
+                data = json.loads(stdout)
+            except json.JSONDecodeError:
+                data = {"success": False, "fatal_error": "Invalid JSON"}
+        success = data.get("success", False) and rc == 0
+        return AbilityResult(success=success, raw=data, stdout=stdout, stderr=stderr)
 
     # Internal helpers --------------------------------------------------
     def _container_exists(self) -> bool:

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -83,17 +83,25 @@ def print_comparison_table(results: Dict[str, Dict[str, Any]]) -> None:
     table.add_column("Knowledge", justify="right")
     table.add_column("Correctness", justify="right")
     table.add_column("Quality", justify="right")
+
+    include_abilities = any("abilities" in result["scores"] and result["scores"]["abilities"] is not None for result in results.values())
+    if include_abilities:
+        table.add_column("Abilities", justify="right")
     table.add_column("Overall", justify="right", style="bold")
 
     for model_name, result in results.items():
         scores = result["scores"]
-        table.add_row(
+        row = [
             model_name,
             f"{scores['knowledge']*100:.1f}%",
             f"{scores['correctness']*100:.1f}%",
             f"{scores['quality']*100:.1f}%" if scores["quality"] else "N/A",
-            f"{scores['overall']*100:.1f}%",
-        )
+        ]
+        if include_abilities:
+            abil = scores.get("abilities")
+            row.append(f"{abil*100:.1f}%" if abil is not None else "N/A")
+        row.append(f"{scores['overall']*100:.1f}%")
+        table.add_row(*row)
 
     console.print(table)
 

--- a/python/wp_bench/scoring.py
+++ b/python/wp_bench/scoring.py
@@ -11,15 +11,28 @@ class ScoreBreakdown:
     knowledge: float = 0.0
     correctness: float = 0.0
     quality: float = 0.0
+    abilities: float | None = None
     weights: Dict[str, float] = field(
-        default_factory=lambda: {"knowledge": 0.3, "correctness": 0.4, "quality": 0.3}
+        default_factory=lambda: {
+            "knowledge": 0.3,
+            "correctness": 0.4,
+            "quality": 0.3,
+            "abilities": 0.2,
+        }
     )
 
     def overall(self) -> float:
         total = 0.0
+        total_weight = 0.0
         for key, weight in self.weights.items():
-            total += getattr(self, key, 0.0) * weight
-        return round(total, 4)
+            value = getattr(self, key, None)
+            if value is None:
+                continue
+            total += value * weight
+            total_weight += weight
+        if total_weight == 0.0:
+            return 0.0
+        return round(total / total_weight, 4)
 
 
 class ScoreAggregator:
@@ -27,6 +40,7 @@ class ScoreAggregator:
         self.knowledge_scores: List[float] = []
         self.correctness_scores: List[float] = []
         self.quality_scores: List[float] = []
+        self.abilities_scores: List[float] = []
 
     def add_execution(self, correctness: float, quality: float | None = None) -> None:
         self.correctness_scores.append(correctness)
@@ -35,6 +49,9 @@ class ScoreAggregator:
 
     def add_knowledge(self, score: float) -> None:
         self.knowledge_scores.append(score)
+
+    def add_abilities(self, score: float) -> None:
+        self.abilities_scores.append(score)
 
     def finalize(self) -> ScoreBreakdown:
         breakdown = ScoreBreakdown()
@@ -46,4 +63,6 @@ class ScoreAggregator:
             breakdown.quality = mean(self.quality_scores)
         else:
             breakdown.quality = 0.0
+        if self.abilities_scores:
+            breakdown.abilities = mean(self.abilities_scores)
         return breakdown

--- a/runtime/src/class-cli-ability.php
+++ b/runtime/src/class-cli-ability.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * WP-CLI bridge for executing Abilities API calls.
+ */
+
+declare(strict_types=1);
+
+namespace WPBench\Runtime;
+
+use WP_CLI;
+use WP_Error;
+
+class CLI_Ability {
+	private Sandbox $sandbox;
+
+	public function __construct() {
+		$this->sandbox = new Sandbox();
+	}
+
+	/**
+	 * Execute an ability from a Base64 payload.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--payload=<payload>]
+	 * : Base64 encoded JSON payload containing ability name, input, and optional setup/teardown.
+	 *
+	 * [--format=<format>]
+	 * : Output format (json or table).
+	 */
+	public function __invoke( array $args, array $assoc_args ): void {
+		$payload_b64 = $assoc_args['payload'] ?? null;
+		if ( ! $payload_b64 ) {
+			WP_CLI::error( 'Missing --payload argument.' );
+		}
+
+		$payload_json = base64_decode( (string) $payload_b64, true );
+		if ( false === $payload_json ) {
+			WP_CLI::error( 'Invalid payload encoding.' );
+		}
+
+		$payload = json_decode( $payload_json, true );
+		if ( ! is_array( $payload ) ) {
+			WP_CLI::error( 'Payload is not valid JSON.' );
+		}
+
+		$name   = $payload['ability'] ?? '';
+		$input  = $payload['input'] ?? null;
+		$setup  = $payload['setup'] ?? '';
+		$teardown = $payload['teardown'] ?? '';
+		$method = $payload['method'] ?? '';
+
+		if ( ! is_string( $name ) || '' === $name ) {
+			WP_CLI::error( 'Ability name is required.' );
+		}
+
+		if ( is_string( $setup ) && $setup !== '' ) {
+			$setup_result = $this->sandbox->execute_snippet( $setup );
+			if ( ! $setup_result['success'] ) {
+				$this->render_response(
+					array(
+						'success' => false,
+						'error'   => $setup_result['error'],
+						'trace'   => $setup_result['trace'],
+					),
+					$assoc_args
+				);
+				return;
+			}
+		}
+
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			$this->render_response(
+				array(
+					'success' => false,
+					'error'   => 'abilities_api_missing',
+				),
+				$assoc_args
+			);
+			return;
+		}
+
+		$ability = wp_get_ability( $name );
+		if ( ! $ability ) {
+			$this->render_response(
+				array(
+					'success' => false,
+					'ability' => $name,
+					'ability_found' => false,
+					'error'   => 'ability_not_found',
+				),
+				$assoc_args
+			);
+			return;
+		}
+
+		$annotations = $ability->get_meta_item( 'annotations' );
+		$is_readonly = ! empty( $annotations['readonly'] );
+		$method_valid = true;
+		$expected_method = null;
+
+		if ( is_string( $method ) && '' !== $method ) {
+			if ( $is_readonly && 'GET' !== $method ) {
+				$method_valid = false;
+				$expected_method = 'GET';
+			}
+			if ( ! $is_readonly && 'POST' !== $method ) {
+				$method_valid = false;
+				$expected_method = 'POST';
+			}
+			if ( ! $method_valid ) {
+				$this->render_response(
+					array(
+						'success' => false,
+						'ability' => $name,
+						'ability_found' => true,
+						'method_valid' => false,
+						'expected_method' => $expected_method,
+						'error'   => 'invalid_method',
+					),
+					$assoc_args
+				);
+				return;
+			}
+		}
+
+		$confirmation_required = $this->requires_confirmation( $annotations );
+		$confirmation_ok = true;
+		if ( $confirmation_required ) {
+			$confirmation_ok = $this->has_confirmation( $input );
+			if ( ! $confirmation_ok ) {
+				$this->render_response(
+					array(
+						'success' => false,
+						'ability' => $name,
+						'ability_found' => true,
+						'method_valid' => $method_valid,
+						'confirmation_required' => true,
+						'confirmation_ok' => false,
+						'error' => 'confirmation_required',
+					),
+					$assoc_args
+				);
+				return;
+			}
+		}
+
+		$result = $ability->execute( $input );
+		if ( is_wp_error( $result ) ) {
+			$error_code = $result->get_error_code();
+			$permission_ok = null;
+			if ( $this->looks_like_permission_error( $error_code ) ) {
+				$permission_ok = false;
+			}
+			$this->render_response(
+				array(
+					'success' => false,
+					'ability' => $name,
+					'ability_found' => true,
+					'method_valid' => $method_valid,
+					'confirmation_required' => $confirmation_required,
+					'confirmation_ok' => $confirmation_ok,
+					'permission_ok' => $permission_ok,
+					'error'   => $result->get_error_code(),
+					'message' => $result->get_error_message(),
+				),
+				$assoc_args
+			);
+			return;
+		}
+
+		if ( is_string( $teardown ) && $teardown !== '' ) {
+			$this->sandbox->execute_snippet( $teardown );
+		}
+
+		$this->render_response(
+			array(
+				'success' => true,
+				'ability' => $name,
+				'ability_found' => true,
+				'method_valid' => $method_valid,
+				'confirmation_required' => $confirmation_required,
+				'confirmation_ok' => $confirmation_ok,
+				'permission_ok' => true,
+				'result'  => $result,
+			),
+			$assoc_args
+		);
+	}
+
+	/**
+	 * Render output based on requested format.
+	 *
+	 * @param array<string, mixed> $response Response payload.
+	 * @param array<string, mixed> $assoc_args Command args.
+	 */
+	private function render_response( array $response, array $assoc_args ): void {
+		$format = $assoc_args['format'] ?? 'json';
+		if ( 'json' === $format ) {
+			WP_CLI::line( wp_json_encode( $response, JSON_PRETTY_PRINT ) );
+			return;
+		}
+		WP_CLI::print_value( $response );
+	}
+
+	/**
+	 * Check if an ability annotation indicates confirmation is required.
+	 *
+	 * @param mixed $annotations Ability annotations.
+	 * @return bool
+	 */
+	private function requires_confirmation( $annotations ): bool {
+		if ( ! is_array( $annotations ) ) {
+			return false;
+		}
+		if ( ! empty( $annotations['requires_confirmation'] ) ) {
+			return true;
+		}
+		if ( ! empty( $annotations['destructive'] ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Check if an input payload includes a confirmation signal.
+	 *
+	 * @param mixed $input Ability input payload.
+	 * @return bool
+	 */
+	private function has_confirmation( $input ): bool {
+		if ( ! is_array( $input ) ) {
+			return false;
+		}
+		foreach ( [ 'confirm', 'confirmation', 'nonce' ] as $key ) {
+			if ( ! empty( $input[ $key ] ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Heuristic for permission-related errors.
+	 *
+	 * @param string $error_code Error code.
+	 * @return bool
+	 */
+	private function looks_like_permission_error( string $error_code ): bool {
+		$code = strtolower( $error_code );
+		return str_contains( $code, 'permission' ) || str_contains( $code, 'forbidden' );
+	}
+}

--- a/runtime/src/class-sandbox.php
+++ b/runtime/src/class-sandbox.php
@@ -124,6 +124,29 @@ class Sandbox {
 	}
 
 	/**
+	 * Execute a PHP snippet safely (used for ability fixtures).
+	 *
+	 * @param string $code PHP code to execute.
+	 * @return array{success: bool, error: string|null, trace: array<int,string>}
+	 */
+	public function execute_snippet( string $code ): array {
+		try {
+			$this->safe_eval( $code );
+			return [
+				'success' => true,
+				'error'   => null,
+				'trace'   => [],
+			];
+		} catch ( \Throwable $e ) {
+			return [
+				'success' => false,
+				'error'   => $e->getMessage(),
+				'trace'   => $this->get_safe_trace( $e ),
+			];
+		}
+	}
+
+	/**
 	 * Run a single assertion.
 	 *
 	 * @param array<string, mixed> $assertion Assertion configuration.

--- a/runtime/wp-bench-runtime.php
+++ b/runtime/wp-bench-runtime.php
@@ -21,8 +21,71 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/src/class-sandbox.php';
 	require_once __DIR__ . '/src/class-static-analysis.php';
 	require_once __DIR__ . '/src/class-cli-verifier.php';
+	require_once __DIR__ . '/src/class-cli-ability.php';
 }
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	\WP_CLI::add_command( 'bench verify', \WPBench\Runtime\CLI_Verifier::class );
+	\WP_CLI::add_command( 'bench ability', \WPBench\Runtime\CLI_Ability::class );
 }
+
+// Register a minimal ability for tooling tests when Abilities API is available.
+add_action(
+	'wp_abilities_api_categories_init',
+	static function (): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) ) {
+			return;
+		}
+		wp_register_ability_category(
+			'wpbench',
+			array(
+				'label'       => 'WP-Bench',
+				'description' => 'Abilities registered for WP-Bench runtime tests.',
+			)
+		);
+	}
+);
+
+add_action(
+	'wp_abilities_api_init',
+	static function (): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'wpbench/get_site_info',
+			array(
+				'label'               => 'Get site info',
+				'description'         => 'Returns basic site information.',
+				'category'            => 'wpbench',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'name' => array( 'type' => 'string' ),
+						'url'  => array( 'type' => 'string' ),
+					),
+					'required'   => array( 'name', 'url' ),
+				),
+				'execute_callback'    => static function (): array {
+					return array(
+						'name' => get_bloginfo( 'name' ),
+						'url'  => home_url(),
+					);
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array(
+					'show_in_rest' => true,
+					'annotations'  => array(
+						'readonly' => true,
+					),
+				),
+			)
+		);
+	}
+);


### PR DESCRIPTION
**Summary**
- Add an Abilities test kind to the harness, dataset export, and scoring pipeline.
- Introduce a WP-CLI ability runner in the runtime and a minimal built-in ability for sanity checks.
- Expand tool-use verifiers (schema validity, permissions, confirmation, method checks) and trace outputs.
- Document abilities suites and add an experimental wp-abilities-v1 suite.

**Why**
- Enables tool-use evaluation against real WordPress abilities.
- Provides dense, structured verifier signals and traces that can be used for training, regression testing, and comparisons.

**Testing**
- Not run (local runtime not started in this environment).