### PR TITLE
fix: isolate WordPress runtime state per execution test

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ run:
   limit: 10                  # limit tests (null = all)
   test_ids: []               # optional explicit test IDs to run
   dry_run: false             # load/filter tests without calling models
-  concurrency: 4
+  concurrency: 4             # model-call concurrency (knowledge tests)
+  execution_isolation: reset_per_test  # reset WordPress before each execution test
+  execution_concurrency: 1   # must stay 1 under reset_per_test isolation
 
 output:
   path: output/results.json

--- a/python/tests/test_execution_isolation.py
+++ b/python/tests/test_execution_isolation.py
@@ -1,0 +1,212 @@
+"""Tests for execution-test state isolation (reset_per_test strategy)."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wp_bench.config import (
+    DatasetConfig,
+    GraderConfig,
+    HarnessConfig,
+    ModelConfig,
+    OutputConfig,
+    RunConfig,
+)
+from wp_bench.core import BenchmarkRunner, MultiModelRunner
+from wp_bench.datasets import ExecutionTest
+from wp_bench.environment import ExecutionResult
+
+
+def _execution_test(test_id: str) -> ExecutionTest:
+    return ExecutionTest(
+        id=test_id,
+        suite="wp-core-v1",
+        prompt="Prompt",
+        expected_behavior="expected",
+        test_type="execution",
+        category="general",
+        difficulty="basic",
+        requirements=["Requirement"],
+        test_function=None,
+        static_checks={},
+        runtime_checks={"assertions": [{"type": "custom_assertion", "code": "return true;", "weight": 1}]},
+        reference_solution="function ref() { return true; }",
+        metadata={},
+    )
+
+
+def _passing_result() -> ExecutionResult:
+    raw = {
+        "success": True,
+        "static": {"score": 1.0, "details": {"total_weight": 1}},
+        "runtime": {"score": 1.0, "details": {"total_weight": 1}},
+    }
+    return ExecutionResult(success=True, raw=raw, stdout="", stderr="")
+
+
+def _config(tmp_path: Path, **run_overrides: Any) -> HarnessConfig:
+    return HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        model=ModelConfig(name="test-model"),
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(test_type="execution", **run_overrides),
+        output=OutputConfig(path=tmp_path / "results.json", jsonl_path=None),
+    )
+
+
+class SpyEnvironment:
+    """Records the interleaving of reset and execute calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def setup(self) -> None:
+        self.calls.append("setup")
+
+    def reset(self) -> None:
+        self.calls.append("reset")
+
+    def execute_code(self, code: str, verification_spec: dict) -> ExecutionResult:
+        self.calls.append("execute")
+        return _passing_result()
+
+
+def test_execution_runner_resets_between_tests(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Every execution test is preceded by an environment reset."""
+    tests = [_execution_test("e-one"), _execution_test("e-two"), _execution_test("e-three")]
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": tests, "knowledge": []},
+    )
+    config = _config(tmp_path)
+    runner = BenchmarkRunner(config)
+    spy = SpyEnvironment()
+    runner.environment = spy  # type: ignore[assignment]
+    monkeypatch.setattr(runner.model, "generate", lambda prompt: "```php\ncode\n```")
+
+    runner.run()
+
+    assert spy.calls == [
+        "setup",
+        "reset", "execute",
+        "reset", "execute",
+        "reset", "execute",
+    ]
+
+
+def test_reference_solution_mode_resets_between_tests(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Reference-solution mode uses the same isolation path."""
+    tests = [_execution_test("e-one"), _execution_test("e-two")]
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": tests, "knowledge": []},
+    )
+    config = _config(tmp_path, check_reference_solution=True)
+    runner = BenchmarkRunner(config)
+    spy = SpyEnvironment()
+    runner.environment = spy  # type: ignore[assignment]
+
+    runner.run()
+
+    assert spy.calls == ["setup", "reset", "execute", "reset", "execute"]
+
+
+def test_multi_model_runner_resets_between_models(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """State from one model run cannot leak into the next model's tests."""
+    tests = [_execution_test("e-one")]
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": tests, "knowledge": []},
+    )
+    config = HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        models=[ModelConfig(name="model-a"), ModelConfig(name="model-b")],
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(test_type="execution"),
+        output=OutputConfig(path=tmp_path / "results.json", jsonl_path=None),
+    )
+    runner = MultiModelRunner(config)
+    spy = SpyEnvironment()
+    runner.environment = spy  # type: ignore[assignment]
+    monkeypatch.setattr(
+        "wp_bench.core.ModelInterface",
+        lambda model_config: type(
+            "FakeModel", (), {"generate": staticmethod(lambda prompt: "```php\ncode\n```")}
+        )(),
+    )
+
+    runner.run()
+
+    # Each model's only test is preceded by its own reset: no state carries over.
+    assert spy.calls == ["setup", "reset", "execute", "reset", "execute"]
+
+
+def test_concurrency_above_one_rejected_for_reset_per_test() -> None:
+    """reset_per_test isolation cannot support concurrent execution tests."""
+    with pytest.raises(ValueError, match="execution_concurrency must be 1"):
+        RunConfig(execution_isolation="reset_per_test", execution_concurrency=4)
+
+
+def test_isolation_none_allows_concurrency() -> None:
+    """Legacy concurrent mode is available only by explicit opt-out."""
+    config = RunConfig(execution_isolation="none", execution_concurrency=4)
+    assert config.execution_concurrency == 4
+
+
+def test_execution_concurrency_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="must be >= 1"):
+        RunConfig(execution_isolation="none", execution_concurrency=0)
+
+
+def test_result_metadata_records_isolation_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Isolation strategy is auditable from result metadata."""
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": [_execution_test("e-one")], "knowledge": []},
+    )
+    config = _config(tmp_path)
+    runner = BenchmarkRunner(config)
+    spy = SpyEnvironment()
+    runner.environment = spy  # type: ignore[assignment]
+    monkeypatch.setattr(runner.model, "generate", lambda prompt: "```php\ncode\n```")
+
+    payload = runner.run()
+
+    assert payload["metadata"]["runtime_isolation"] == "reset_per_test"
+
+
+def test_isolation_none_still_runs_all_tests(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Opting out of isolation preserves the legacy concurrent path."""
+    tests = [_execution_test("e-one"), _execution_test("e-two")]
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": tests, "knowledge": []},
+    )
+    config = _config(tmp_path, execution_isolation="none", execution_concurrency=2)
+    runner = BenchmarkRunner(config)
+    spy = SpyEnvironment()
+    runner.environment = spy  # type: ignore[assignment]
+    monkeypatch.setattr(runner.model, "generate", lambda prompt: "```php\ncode\n```")
+
+    payload = runner.run()
+
+    assert spy.calls.count("execute") == 2
+    assert spy.calls.count("reset") == 0
+    assert payload["metadata"]["runtime_isolation"] == "none"

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, Field, HttpUrl, validator
+from pydantic import BaseModel, Field, HttpUrl, model_validator, validator
 
 ArtifactKind = Literal[
     "php_snippet",
@@ -44,9 +44,13 @@ class GraderConfig(BaseModel):
     image: str = "ghcr.io/wordpress/wp-bench-grader:latest"
     container_name: str = "wp-bench-grader"
     url: Optional[HttpUrl] = None
+    base_url: str = "http://localhost:8888"
     concurrency: int = 4
     timeout_seconds: int = 90
     wp_env_dir: Optional[Path] = None
+
+
+ExecutionIsolation = Literal["reset_per_test", "none"]
 
 
 class RunConfig(BaseModel):
@@ -56,10 +60,33 @@ class RunConfig(BaseModel):
     test_ids: List[str] = Field(default_factory=list)
     seed: int = 1337
     concurrency: int = 5
+    execution_isolation: ExecutionIsolation = "reset_per_test"
+    execution_concurrency: int = 1
     dry_run: bool = False
     check_reference_solution: bool = False
     skip_runtime: bool = False
     skip_static: bool = False
+
+    @model_validator(mode="after")
+    def _validate_execution_concurrency(self) -> "RunConfig":
+        """Reject concurrency the isolation strategy cannot support.
+
+        ``reset_per_test`` isolation resets one shared WordPress runtime
+        before every execution test, which is only sound when execution
+        tests run serially. Fail loudly instead of silently sharing mutable
+        WordPress state across concurrent tests.
+        """
+        if self.execution_concurrency < 1:
+            raise ValueError("run.execution_concurrency must be >= 1")
+        if self.execution_isolation == "reset_per_test" and self.execution_concurrency > 1:
+            raise ValueError(
+                "run.execution_concurrency must be 1 when "
+                "run.execution_isolation is 'reset_per_test': concurrent tests "
+                "would share one mutable WordPress runtime. Set "
+                "run.execution_isolation to 'none' to opt out of isolation "
+                "(not valid for official benchmark runs)."
+            )
+        return self
 
 
 class OutputConfig(BaseModel):

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -61,6 +61,56 @@ def _limit_tests(tests: List[Any], config: HarnessConfig) -> List[Any]:
     return tests[:limit]
 
 
+def _run_isolated_execution_loop(
+    *,
+    tests_to_run: List[Any],
+    config: HarnessConfig,
+    environment: WordPressEnvironment,
+    process_test: Any,
+    on_result: Any,
+    progress_label: str,
+) -> None:
+    """Run execution-style tests honoring the configured isolation strategy.
+
+    ``reset_per_test`` (default): tests run serially and the WordPress
+    environment is reset to a known baseline before every test, so no test
+    can observe state (options, posts, roles, hooks persisted to DB, etc.)
+    left behind by a previous test or a previous model run.
+
+    ``none``: legacy concurrent behavior against a shared environment,
+    bounded by ``run.execution_concurrency``. Not valid for official runs.
+
+    Args:
+        tests_to_run: Tests to execute, already limited/filtered.
+        config: Harness configuration (isolation strategy, concurrency).
+        environment: WordPress environment shared by this run.
+        process_test: Callable taking a test and returning a record dict.
+        on_result: Callable invoked with each record (aggregation/appending).
+        progress_label: Label for the progress bar.
+    """
+    isolation = config.run.execution_isolation
+    with create_progress() as progress:
+        task = progress.add_task(progress_label, total=len(tests_to_run))
+        if isolation == "reset_per_test":
+            for test in tests_to_run:
+                environment.reset()
+                result = process_test(test)
+                on_result(result)
+                progress.update(task, advance=1)
+            return
+        with ThreadPoolExecutor(max_workers=config.run.execution_concurrency) as executor:
+            futures = {executor.submit(process_test, test): test for test in tests_to_run}
+            for future in as_completed(futures):
+                try:
+                    result = future.result()
+                    on_result(result)
+                    progress.update(task, advance=1)
+                except TestError:
+                    for f in futures:
+                        f.cancel()
+                    raise
+
+
 class BenchmarkRunner:
     """Primary benchmark orchestrator for single-model evaluation.
 
@@ -130,6 +180,7 @@ class BenchmarkRunner:
                 "model": model_config,
                 "grader": self.config.grader.model_dump(mode="json"),
                 "dataset": self.config.dataset.model_dump(mode="json"),
+                "runtime_isolation": self.config.run.execution_isolation,
                 "scores": {
                     "knowledge": summary.knowledge,
                     "correctness": summary.correctness,
@@ -223,10 +274,9 @@ class BenchmarkRunner:
             TestError: If any test fails, stops execution and raises with details.
         """
         tests_to_run = _limit_tests(tests, self.config)
-        concurrency = self.config.run.concurrency
 
         def process_test(test: ExecutionTest) -> Dict[str, Any]:
-            """Process a single execution test (runs in thread pool)."""
+            """Process a single execution test."""
             try:
                 prompt = self._render_execution_prompt(test)
                 completion = self.model.generate(prompt)
@@ -247,26 +297,23 @@ class BenchmarkRunner:
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
 
-        with create_progress() as progress:
-            task = progress.add_task("Execution", total=len(tests_to_run))
-            with ThreadPoolExecutor(max_workers=concurrency) as executor:
-                futures = {executor.submit(process_test, test): test for test in tests_to_run}
-                for future in as_completed(futures):
-                    try:
-                        result = future.result()
-                        with self._lock:
-                            self.aggregator.add_execution(result["correctness"])
-                            self.records.append(result)
-                        progress.update(task, advance=1)
-                    except TestError:
-                        for f in futures:
-                            f.cancel()
-                        raise
+        def on_result(result: Dict[str, Any]) -> None:
+            with self._lock:
+                self.aggregator.add_execution(result["correctness"])
+                self.records.append(result)
+
+        _run_isolated_execution_loop(
+            tests_to_run=tests_to_run,
+            config=self.config,
+            environment=self.environment,
+            process_test=process_test,
+            on_result=on_result,
+            progress_label="Execution",
+        )
 
     def _run_reference_solution_tests(self, tests: List[ExecutionTest]) -> None:
         """Run execution tests using their reference_solution as candidate code."""
         tests_to_run = _limit_tests(tests, self.config)
-        concurrency = self.config.run.concurrency
 
         def process_test(test: ExecutionTest) -> Dict[str, Any]:
             try:
@@ -289,21 +336,19 @@ class BenchmarkRunner:
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
 
-        with create_progress() as progress:
-            task = progress.add_task("Reference solutions", total=len(tests_to_run))
-            with ThreadPoolExecutor(max_workers=concurrency) as executor:
-                futures = {executor.submit(process_test, test): test for test in tests_to_run}
-                for future in as_completed(futures):
-                    try:
-                        result = future.result()
-                        with self._lock:
-                            self.aggregator.add_execution(result["correctness"])
-                            self.records.append(result)
-                        progress.update(task, advance=1)
-                    except TestError:
-                        for f in futures:
-                            f.cancel()
-                        raise
+        def on_result(result: Dict[str, Any]) -> None:
+            with self._lock:
+                self.aggregator.add_execution(result["correctness"])
+                self.records.append(result)
+
+        _run_isolated_execution_loop(
+            tests_to_run=tests_to_run,
+            config=self.config,
+            environment=self.environment,
+            process_test=process_test,
+            on_result=on_result,
+            progress_label="Reference solutions",
+        )
 
     @staticmethod
     def _render_knowledge_prompt(test: KnowledgeTest) -> str:
@@ -543,6 +588,7 @@ class MultiModelRunner:
                 "suite": self.config.run.suite,
                 "grader": self.config.grader.model_dump(mode="json"),
                 "dataset": self.config.dataset.model_dump(mode="json"),
+                "runtime_isolation": self.config.run.execution_isolation,
             },
             "models": {
                 name: {
@@ -649,9 +695,8 @@ class SingleModelRunner:
                         raise
 
     def _run_execution_tests(self, tests: List[ExecutionTest]) -> None:
-        """Run execution tests in parallel. See BenchmarkRunner._run_execution_tests."""
+        """Run execution tests with isolation. See BenchmarkRunner._run_execution_tests."""
         tests_to_run = _limit_tests(tests, self.config)
-        concurrency = self.config.run.concurrency
 
         def process_test(test: ExecutionTest) -> Dict[str, Any]:
             try:
@@ -670,18 +715,16 @@ class SingleModelRunner:
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
 
-        with create_progress() as progress:
-            task = progress.add_task("Execution", total=len(tests_to_run))
-            with ThreadPoolExecutor(max_workers=concurrency) as executor:
-                futures = {executor.submit(process_test, test): test for test in tests_to_run}
-                for future in as_completed(futures):
-                    try:
-                        result = future.result()
-                        with self._lock:
-                            self.aggregator.add_execution(result["correctness"])
-                            self.records.append(result)
-                        progress.update(task, advance=1)
-                    except TestError:
-                        for f in futures:
-                            f.cancel()
-                        raise
+        def on_result(result: Dict[str, Any]) -> None:
+            with self._lock:
+                self.aggregator.add_execution(result["correctness"])
+                self.records.append(result)
+
+        _run_isolated_execution_loop(
+            tests_to_run=tests_to_run,
+            config=self.config,
+            environment=self.environment,
+            process_test=process_test,
+            on_result=on_result,
+            progress_label="Execution",
+        )

--- a/python/wp_bench/environment.py
+++ b/python/wp_bench/environment.py
@@ -34,10 +34,32 @@ class WordPressEnvironment:
             self._start_container()
 
     def reset(self) -> None:
+        """Restore the WordPress runtime to a known clean baseline.
+
+        ``wp db reset`` drops every table, which leaves WordPress uninstalled,
+        so a fresh ``wp core install`` follows to return to a deterministic
+        just-installed state. Called before every execution test when
+        ``run.execution_isolation`` is ``reset_per_test`` so no test can
+        observe database state (options, posts, roles, transients, cron
+        events, etc.) left behind by an earlier test or model run.
+        """
+        install_cmd = [
+            "wp",
+            "core",
+            "install",
+            f"--url={self.config.base_url}",
+            "--title=WP-Bench",
+            "--admin_user=admin",
+            "--admin_password=password",
+            "--admin_email=admin@wp-bench.test",
+            "--skip-email",
+        ]
         if self.config.wp_env_dir:
             self._run_wp_env(["npx", "wp-env", "run", "cli", "wp", "db", "reset", "--yes"])
+            self._run_wp_env(["npx", "wp-env", "run", "cli", *install_cmd])
         elif self.config.kind == "docker":
             self._exec(["wp", "db", "reset", "--yes"])
+            self._exec(install_cmd)
 
     def execute_code(self, code: str, verification_spec: Dict[str, Any]) -> ExecutionResult:
         payload = {

--- a/wp-bench.example.yaml
+++ b/wp-bench.example.yaml
@@ -32,7 +32,13 @@ run:
   # limit: 10            # limit tests per model (null = all)
   # test_ids: []         # optional explicit test IDs to run
   # dry_run: false       # load/filter tests without calling models
-  concurrency: 5
+  concurrency: 5         # model-call concurrency (knowledge tests)
+  # Execution-test isolation. 'reset_per_test' (default) resets WordPress
+  # to a clean baseline before every execution test and runs them serially.
+  # 'none' opts out and allows execution_concurrency > 1, but tests then
+  # share mutable WordPress state (not valid for official benchmark runs).
+  # execution_isolation: reset_per_test
+  # execution_concurrency: 1
 
 # Output paths
 output:


### PR DESCRIPTION
## Why this matters

WP-Bench scores are only meaningful if they're reproducible. Today, execution tests run concurrently against one shared WordPress instance with no reset between tests. WordPress is deeply stateful — options, posts, roles, hooks, transients, cron events all persist in the database — so code generated for one test can silently change the outcome of the next. In multi-model mode the problem compounds: one model's leftover state can help or hurt the *next model's* scores. That means rankings can shift based on test ordering and scheduling luck, and a provider who re-runs the suite may get different numbers. No leaderboard can be trusted on that foundation. This change makes every execution test start from a known-clean WordPress baseline, which is the prerequisite for every scoring and auditability improvement that follows.

## Changes

- **`RunConfig`**: new `execution_isolation` (`reset_per_test` default | `none`) and `execution_concurrency` (default 1). A model validator rejects `execution_concurrency > 1` under `reset_per_test` with a clear error instead of silently sharing state.
- **`core.py`**: single-model, multi-model, and reference-solution execution paths now route through one shared `_run_isolated_execution_loop()` that calls `environment.reset()` before every test. Knowledge tests keep their existing concurrency (they never touch the WordPress runtime).
- **`WordPressEnvironment.reset()`**: `wp db reset` drops all tables and leaves WordPress uninstalled, so reset now follows with `wp core install` to return to a deterministic just-installed baseline (`grader.base_url` added for the install URL).
- **Result metadata**: `metadata.runtime_isolation` records the mode used, in both single- and multi-model payloads, so any results file shows how it was produced.
- **Docs**: README + `wp-bench.example.yaml` document the isolation semantics and the official-run requirement.

## Verification

- `pytest python`: **41 passed** (8 new isolation tests: reset-before-every-test in all three modes, reset between models, concurrency rejection, metadata recording, legacy opt-out)
- `ruff check python`: clean
- `mypy python`: 3 pre-existing trunk errors only (none introduced)
- Runtime smoke test vs Docker/wp-env: not run in this PR (no local runtime up); the reset→reinstall sequence follows the wp-env docs and a state-leak interleaving assertion is covered in the mocked tests.

## Notes for reviewers

- First PR in a series moving the harness toward provider-grade reproducibility; subsequent PRs stack on this branch.
- A per-worker isolated-runtime pool (parallel execution with full isolation) is intentionally deferred to keep this diff reviewable — the `execution_isolation` config surface leaves room for a future `container_per_worker` mode.