### PR TITLE
fix: enforce runtime and subprocess timeouts end-to-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ models:
 grader:
   kind: docker
   wp_env_dir: ./runtime      # path to wp-env project
+  timeout_seconds: 90        # hard cap per runtime execution (timeout = 0.0 score)
+  setup_timeout_seconds: 600 # hard cap for environment setup
 
 run:
   suite: wp-core-v1

--- a/python/tests/test_environment.py
+++ b/python/tests/test_environment.py
@@ -12,13 +12,13 @@ def test_execute_code_uses_internal_runtime_verifier_for_wp_env() -> None:
     calls: list[list[str]] = []
     environment = WordPressEnvironment(GraderConfig(kind="docker", wp_env_dir=Path("runtime")))
 
-    def fake_exec(command: list[str]) -> tuple[str, str, int]:
+    def fake_exec(command: list[str]) -> tuple[str, str, int, bool]:
         calls.append(command)
         payload = json.loads(base64.b64decode(command[3]).decode("utf-8"))
         assert payload["code"] == "function demo() { return true; }"
         assert payload["static_checks"] == {"required_patterns": []}
         assert payload["runtime_checks"] == {"assertions": []}
-        return ('{"success": true}', "", 0)
+        return ('{"success": true}', "", 0, False)
 
     environment._exec = fake_exec  # type: ignore[method-assign]
 

--- a/python/tests/test_environment_timeouts.py
+++ b/python/tests/test_environment_timeouts.py
@@ -1,0 +1,131 @@
+"""Tests for hard timeout enforcement across environment subprocess paths."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wp_bench.config import GraderConfig
+from wp_bench.environment import (
+    EnvironmentSetupTimeout,
+    ExecutionResult,
+    WordPressEnvironment,
+)
+
+
+def _raise_timeout(*args: Any, **kwargs: Any) -> None:
+    raise subprocess.TimeoutExpired(
+        cmd=args[0] if args else kwargs.get("args", ["cmd"]),
+        timeout=kwargs.get("timeout", 1),
+        output=b"partial stdout",
+        stderr=b"partial stderr",
+    )
+
+
+def test_exec_passes_timeout_to_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every _exec path forwards grader.timeout_seconds to subprocess.run."""
+    seen: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+        seen["timeout"] = kwargs.get("timeout")
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    environment = WordPressEnvironment(GraderConfig(kind="cli", timeout_seconds=42))
+
+    environment._exec(["wp", "cli", "version"])
+
+    assert seen["timeout"] == 42
+
+
+def test_exec_times_out_returns_timed_out_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hung subprocess surfaces as timed_out=True with partial output."""
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    environment = WordPressEnvironment(GraderConfig(kind="cli", timeout_seconds=1))
+
+    stdout, stderr, returncode, timed_out = environment._exec(["wp", "eval-file", "x"])
+
+    assert timed_out is True
+    assert returncode == -1
+    assert stdout == "partial stdout"
+    assert stderr == "partial stderr"
+
+
+def test_execute_code_timeout_returns_structured_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime timeout becomes a scored per-test failure, not a crash."""
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    environment = WordPressEnvironment(GraderConfig(kind="cli", timeout_seconds=7))
+
+    result = environment.execute_code("while (true) {}", {"static_checks": {}, "runtime_checks": {}})
+
+    assert isinstance(result, ExecutionResult)
+    assert result.success is False
+    assert result.timed_out is True
+    assert result.raw["timeout"] is True
+    assert result.raw["success"] is False
+    assert result.raw["runtime"]["score"] == 0.0
+    assertions = result.raw["runtime"]["details"]["assertions"]
+    assert assertions[0]["type"] == "timeout"
+    assert assertions[0]["timeout_seconds"] == 7
+
+
+def test_execute_code_timeout_preserves_partial_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    environment = WordPressEnvironment(GraderConfig(kind="cli"))
+
+    result = environment.execute_code("code", {})
+
+    assert result.stdout == "partial stdout"
+    assert result.stderr == "partial stderr"
+
+
+def test_setup_timeout_raises_clear_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """wp-env setup timeout is a harness failure with actionable message."""
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    environment = WordPressEnvironment(
+        GraderConfig(kind="docker", wp_env_dir=Path("runtime"), setup_timeout_seconds=5)
+    )
+
+    with pytest.raises(EnvironmentSetupTimeout, match="Timed out running npx wp-env start"):
+        environment.setup()
+
+
+def test_start_container_timeout_raises_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    environment = WordPressEnvironment(GraderConfig(kind="docker", timeout_seconds=5))
+
+    with pytest.raises(EnvironmentSetupTimeout):
+        environment._start_container()
+
+
+def test_container_exists_timeout_raises_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(subprocess, "run", _raise_timeout)
+    environment = WordPressEnvironment(GraderConfig(kind="docker"))
+
+    with pytest.raises(EnvironmentSetupTimeout, match="Docker daemon"):
+        environment._container_exists()
+
+
+def test_run_wp_env_nonzero_exit_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Nonzero wp-env exits keep failing loudly (previous check=True behavior)."""
+
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+        return subprocess.CompletedProcess(args=args[0], returncode=3, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    environment = WordPressEnvironment(
+        GraderConfig(kind="docker", wp_env_dir=Path("runtime"))
+    )
+
+    with pytest.raises(RuntimeError, match="exit code 3"):
+        environment._run_wp_env(["npx", "wp-env", "start"])

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -47,6 +47,7 @@ class GraderConfig(BaseModel):
     base_url: str = "http://localhost:8888"
     concurrency: int = 4
     timeout_seconds: int = 90
+    setup_timeout_seconds: int = 600
     wp_env_dir: Optional[Path] = None
 
 

--- a/python/wp_bench/environment.py
+++ b/python/wp_bench/environment.py
@@ -5,9 +5,21 @@ import base64
 import json
 import subprocess
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from .config import GraderConfig
+
+#: Short timeout for cheap local Docker queries (e.g. ``docker ps``).
+CONTAINER_QUERY_TIMEOUT_SECONDS = 30
+
+
+class EnvironmentSetupTimeout(RuntimeError):
+    """Raised when environment setup (wp-env/Docker) exceeds its timeout.
+
+    Setup timeouts are harness/environment failures, not per-test results,
+    so they fail fast with a clear message instead of being recorded as a
+    test outcome.
+    """
 
 
 @dataclass
@@ -16,6 +28,17 @@ class ExecutionResult:
     raw: Dict[str, Any]
     stdout: str
     stderr: str
+    timed_out: bool = False
+
+
+@dataclass
+class ProcessResult:
+    """Outcome of a subprocess run, including timeout state."""
+
+    stdout: str
+    stderr: str
+    returncode: int
+    timed_out: bool
 
 
 class WordPressEnvironment:
@@ -62,6 +85,13 @@ class WordPressEnvironment:
             self._exec(install_cmd)
 
     def execute_code(self, code: str, verification_spec: Dict[str, Any]) -> ExecutionResult:
+        """Run candidate code through the runtime verifier.
+
+        A runtime timeout is a per-test failure, not a harness crash: it
+        returns a structured ``ExecutionResult`` with ``timed_out=True`` and
+        a synthetic zero-score runtime payload, so the benchmark records the
+        timeout and continues with the next test.
+        """
         payload = {
             "code": code,
             **verification_spec,
@@ -74,7 +104,15 @@ class WordPressEnvironment:
             verifier_path,
             encoded,
         ]
-        stdout, stderr, rc = self._exec(cmd)
+        stdout, stderr, rc, timed_out = self._exec(cmd)
+        if timed_out:
+            return ExecutionResult(
+                success=False,
+                raw=self._timeout_raw_result(),
+                stdout=stdout,
+                stderr=stderr,
+                timed_out=True,
+            )
         data: Dict[str, Any] = {}
         if stdout.strip():
             try:
@@ -85,13 +123,81 @@ class WordPressEnvironment:
         return ExecutionResult(success=success, raw=data, stdout=stdout, stderr=stderr)
 
     # Internal helpers --------------------------------------------------
+    def _timeout_raw_result(self) -> Dict[str, Any]:
+        """Build the stable raw payload recorded for a runtime timeout."""
+        return {
+            "success": False,
+            "timeout": True,
+            "runtime": {
+                "score": 0.0,
+                "details": {
+                    "assertions": [
+                        {
+                            "type": "timeout",
+                            "description": "Runtime execution timed out",
+                            "passed": False,
+                            "timeout_seconds": self.config.timeout_seconds,
+                        }
+                    ],
+                    "total_weight": 0,
+                    "passed_weight": 0,
+                },
+            },
+            "static": {"score": 0.0, "details": {}},
+        }
+
     def _runtime_verifier_path(self) -> str:
         if self.config.wp_env_dir:
             return "/var/www/html/wp-content/plugins/runtime/verify-runtime.php"
         return "/var/www/html/wp-content/plugins/wp-bench-runtime/verify-runtime.php"
 
+    def _run_process(
+        self,
+        command: list[str],
+        *,
+        cwd: Optional[str] = None,
+        timeout: Optional[float] = None,
+        capture_output: bool = True,
+    ) -> ProcessResult:
+        """Run a subprocess with a hard timeout.
+
+        Central chokepoint for every external command the environment runs:
+        no call path that shells out to Docker, wp-env, or WP-CLI may hang
+        indefinitely. On ``subprocess.TimeoutExpired`` any partial output
+        captured by the exception is preserved.
+        """
+        try:
+            proc = subprocess.run(
+                command,
+                capture_output=capture_output,
+                text=True,
+                check=False,
+                cwd=cwd,
+                timeout=timeout,
+            )
+            return ProcessResult(
+                stdout=proc.stdout if capture_output else "",
+                stderr=proc.stderr if capture_output else "",
+                returncode=proc.returncode,
+                timed_out=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            def _decode(stream: Any) -> str:
+                if stream is None:
+                    return ""
+                if isinstance(stream, bytes):
+                    return stream.decode("utf-8", errors="replace")
+                return str(stream)
+
+            return ProcessResult(
+                stdout=_decode(exc.stdout),
+                stderr=_decode(exc.stderr),
+                returncode=-1,
+                timed_out=True,
+            )
+
     def _container_exists(self) -> bool:
-        result = subprocess.run(
+        result = self._run_process(
             [
                 "docker",
                 "ps",
@@ -101,14 +207,17 @@ class WordPressEnvironment:
                 "--filter",
                 f"name={self.config.container_name}",
             ],
-            capture_output=True,
-            text=True,
-            check=False,
+            timeout=CONTAINER_QUERY_TIMEOUT_SECONDS,
         )
+        if result.timed_out:
+            raise EnvironmentSetupTimeout(
+                "Timed out querying Docker for existing containers after "
+                f"{CONTAINER_QUERY_TIMEOUT_SECONDS}s. Is the Docker daemon responsive?"
+            )
         return self.config.container_name in result.stdout.split()
 
     def _start_container(self) -> None:
-        subprocess.run(
+        result = self._run_process(
             [
                 "docker",
                 "run",
@@ -117,47 +226,66 @@ class WordPressEnvironment:
                 self.config.container_name,
                 self.config.image,
             ],
-            check=True,
+            timeout=self.config.timeout_seconds,
         )
+        if result.timed_out:
+            raise EnvironmentSetupTimeout(
+                f"Timed out starting container '{self.config.container_name}' after "
+                f"{self.config.timeout_seconds}s (grader.timeout_seconds)."
+            )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to start container '{self.config.container_name}': {result.stderr.strip()}"
+            )
 
-    def _exec(self, command: list[str]) -> tuple[str, str, int]:
+    def _exec(self, command: list[str]) -> tuple[str, str, int, bool]:
+        """Execute a command in the WordPress runtime.
+
+        Returns:
+            Tuple of (stdout, stderr, returncode, timed_out). All paths are
+            bounded by ``grader.timeout_seconds``.
+        """
+        timeout = self.config.timeout_seconds
         if self.config.wp_env_dir:
-            proc = subprocess.run(
+            result = self._run_process(
                 ["npx", "wp-env", "run", "cli", *command],
-                capture_output=True,
-                text=True,
-                check=False,
                 cwd=str(self.config.wp_env_dir),
+                timeout=timeout,
             )
-            return proc.stdout, proc.stderr, proc.returncode
-
-        if self.config.kind == "cli":
-            proc = subprocess.run(
-                command,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            return proc.stdout, proc.stderr, proc.returncode
-
-        docker_cmd = [
-            "docker",
-            "exec",
-            "-i",
-            self.config.container_name,
-            *command,
-        ]
-        proc = subprocess.run(
-            docker_cmd,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        return proc.stdout, proc.stderr, proc.returncode
+        elif self.config.kind == "cli":
+            result = self._run_process(command, timeout=timeout)
+        else:
+            docker_cmd = [
+                "docker",
+                "exec",
+                "-i",
+                self.config.container_name,
+                *command,
+            ]
+            result = self._run_process(docker_cmd, timeout=timeout)
+        return result.stdout, result.stderr, result.returncode, result.timed_out
 
     def _run_wp_env(self, command: list[str]) -> None:
-        subprocess.run(
+        """Run a wp-env management command (setup/reset path).
+
+        Raises:
+            EnvironmentSetupTimeout: If the command exceeds the configured
+                timeout. Setup problems must fail fast and loudly rather
+                than being recorded as test results.
+            RuntimeError: If the command exits nonzero.
+        """
+        result = self._run_process(
             command,
-            check=True,
             cwd=str(self.config.wp_env_dir),
+            timeout=self.config.setup_timeout_seconds,
+            capture_output=False,
         )
+        if result.timed_out:
+            raise EnvironmentSetupTimeout(
+                f"Timed out running {' '.join(command)} after "
+                f"{self.config.setup_timeout_seconds}s (grader.setup_timeout_seconds)."
+            )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Command failed with exit code {result.returncode}: {' '.join(command)}"
+            )

--- a/wp-bench.example.yaml
+++ b/wp-bench.example.yaml
@@ -25,6 +25,10 @@ models:
 grader:
   kind: docker
   wp_env_dir: ./runtime  # path to wp-env project
+  # timeout_seconds: 90        # hard cap per runtime execution; a timed-out
+  #                            # test scores 0.0 and is marked timeout: true
+  # setup_timeout_seconds: 600 # hard cap for environment setup (wp-env start);
+  #                            # setup timeout aborts the run with a clear error
 
 # Run configuration
 run:


### PR DESCRIPTION
## Why this matters

WP-Bench executes arbitrary model-generated PHP. Sooner or later a completion will contain an infinite loop, a blocking call, or code that wedges `wp eval-file` — and today that hangs the entire benchmark run forever, because `grader.timeout_seconds` exists in config but was never actually passed to any subprocess call. For a provider running hundreds of tests unattended, a single bad completion currently means a dead run and no results. Timeouts also have scoring semantics: a snippet that never finishes is a *failing answer*, and it should be recorded that way — deterministically and visibly — rather than crashing the harness or silently stalling. This change makes runs survivable and makes timeout outcomes part of the auditable record.

## Changes

- **`_run_process()` helper**: single chokepoint for all subprocess execution in `WordPressEnvironment`. Hard timeout on every call; preserves partial stdout/stderr from `subprocess.TimeoutExpired`.
- **Execution paths**: `grader.timeout_seconds` now bounds all three `_exec()` paths (wp-env / CLI / docker exec) and container start. `docker ps` gets a short fixed 30s timeout.
- **Setup vs. execution semantics**: runtime execution timeout → structured per-test failure (`ExecutionResult.timed_out=True`, synthetic zero-score runtime payload with a `timeout` assertion and `timeout: true`), and the run continues to the next test. Environment setup timeout → `EnvironmentSetupTimeout` raised with an actionable message, run aborts — an environment that won't boot is a harness failure, not a model result. New `grader.setup_timeout_seconds` (default 600s) for slow wp-env boots.
- **API change**: `_exec()` returns `(stdout, stderr, returncode, timed_out)`; existing test fake updated.
- **`_run_wp_env`**: `check=True` replaced with an explicit nonzero-exit `RuntimeError` so timeout and failure produce distinct, clear errors.
- **Docs**: timeout semantics in README + example YAML (timeout = 0.0 score, marked in results).

## Verification

- `pytest python`: **49 passed** (8 new: timeout forwarding, timed-out state with partial output, structured `execute_code` timeout result shape, setup/container/query timeout errors, nonzero-exit handling)
- `ruff check python`: clean
- `mypy python`: 3 pre-existing trunk errors only

## Notes

- Stacked on #25.
- Finer-grained timeout knobs beyond execution/setup are deliberately deferred to keep the first fix simple.