### PR TITLE
refactor: unify single/multi/reference result schemas

### DIFF
--- a/python/tests/test_reference_solution_mode.py
+++ b/python/tests/test_reference_solution_mode.py
@@ -16,6 +16,7 @@ from wp_bench.config import (
 from wp_bench.core import BenchmarkRunner
 from wp_bench.datasets import ExecutionTest, KnowledgeTest
 from wp_bench.environment import ExecutionResult
+from wp_bench.records import execution_record_passed
 
 
 def _config(tmp_path: Path, test_ids: list[str] | None = None) -> HarnessConfig:
@@ -101,7 +102,10 @@ def test_reference_solution_mode_executes_reference_solution(
     ]
     assert result["metadata"]["mode"] == "reference_solution"
     assert result["metadata"]["scores"]["correctness"] == 1.0
-    assert result["results"][0]["passed"] is True
+    record = result["results"][0]
+    assert record["mode"] == "reference_solution"
+    assert record["model"] is None
+    assert execution_record_passed(record) is True
 
 
 def test_reference_solution_mode_exits_nonzero_on_failed_reference(
@@ -126,8 +130,8 @@ def test_reference_solution_mode_exits_nonzero_on_failed_reference(
         runner.run()
 
     assert exc.value.code == 1
-    assert runner.records[0]["passed"] is False
-    assert runner.records[0]["correctness"] == 0.5
+    assert execution_record_passed(runner.records[0]) is False
+    assert runner.records[0]["scores"]["correctness"] == 0.5
 
 
 def test_reference_solution_mode_rejects_non_execution_test_ids(

--- a/python/tests/test_result_schema.py
+++ b/python/tests/test_result_schema.py
@@ -1,0 +1,250 @@
+"""Tests asserting the canonical per-test record schema across run modes."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Set
+
+import pytest
+
+from wp_bench.config import (
+    DatasetConfig,
+    GraderConfig,
+    HarnessConfig,
+    ModelConfig,
+    OutputConfig,
+    RunConfig,
+)
+from wp_bench.core import BenchmarkRunner, SingleModelRunner
+from wp_bench.datasets import ExecutionTest, KnowledgeTest
+from wp_bench.environment import ExecutionResult
+from wp_bench.records import RESULT_SCHEMA_VERSION
+
+
+def _execution_test(test_id: str = "e-one") -> ExecutionTest:
+    return ExecutionTest(
+        id=test_id,
+        suite="wp-core-v1",
+        prompt="Prompt",
+        expected_behavior="expected",
+        test_type="execution",
+        category="hooks",
+        difficulty="basic",
+        requirements=["Requirement"],
+        test_function=None,
+        static_checks={"required_patterns": [{"pattern": "ref", "weight": 1}]},
+        runtime_checks={"assertions": [{"type": "custom_assertion", "code": "return true;", "weight": 1}]},
+        reference_solution="function ref() { return true; }",
+        metadata={},
+    )
+
+
+def _knowledge_test(test_id: str = "k-one") -> KnowledgeTest:
+    return KnowledgeTest(
+        id=test_id,
+        suite="wp-core-v1",
+        prompt="What hook runs on init?",
+        test_type="knowledge",
+        category="hooks",
+        difficulty="basic",
+        correct_answer="init",
+        answer_type="short_answer",
+    )
+
+
+def _passing_result() -> ExecutionResult:
+    raw = {
+        "success": True,
+        "static": {"score": 1.0, "details": {"total_weight": 1}},
+        "runtime": {"score": 1.0, "details": {"total_weight": 1}},
+    }
+    return ExecutionResult(success=True, raw=raw, stdout="out", stderr="")
+
+
+def _key_paths(record: Dict[str, Any], prefix: str = "") -> Set[str]:
+    """Flatten a record into dotted key paths for structural comparison."""
+    paths: Set[str] = set()
+    for key, value in record.items():
+        path = f"{prefix}{key}"
+        paths.add(path)
+        if isinstance(value, dict) and key != "raw":
+            paths.update(_key_paths(value, prefix=f"{path}."))
+    return paths
+
+
+def _single_model_records(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list:
+    config = HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        model=ModelConfig(name="test-model"),
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(),
+        output=OutputConfig(path=tmp_path / "single.json", jsonl_path=None),
+    )
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": [_execution_test()], "knowledge": [_knowledge_test()]},
+    )
+    runner = BenchmarkRunner(config)
+    runner.environment.setup = lambda: None  # type: ignore[method-assign]
+    runner.environment.reset = lambda: None  # type: ignore[method-assign]
+    runner.environment.execute_code = lambda code, verification_spec: _passing_result()  # type: ignore[method-assign]
+    monkeypatch.setattr(runner.model, "generate", lambda prompt: "init")
+    runner.run()
+    return runner.records
+
+
+def _multi_model_records(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> list:
+    config = HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        models=[ModelConfig(name="model-a")],
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(),
+        output=OutputConfig(path=tmp_path / "multi.json", jsonl_path=None),
+    )
+
+    class FakeEnvironment:
+        def setup(self) -> None: ...
+        def reset(self) -> None: ...
+
+        def execute_code(self, code: str, spec: dict) -> ExecutionResult:
+            return _passing_result()
+
+    runner = SingleModelRunner(
+        config=config,
+        model_config=config.get_models()[0],
+        environment=FakeEnvironment(),  # type: ignore[arg-type]
+        tests={"execution": [_execution_test()], "knowledge": [_knowledge_test()]},
+    )
+    monkeypatch.setattr(runner.model, "generate", lambda prompt: "init")
+    runner.run()
+    return runner.records
+
+
+def test_single_and_multi_model_records_have_same_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    single = _single_model_records(monkeypatch, tmp_path)
+    multi = _multi_model_records(monkeypatch, tmp_path)
+
+    single_by_type = {record["type"]: record for record in single}
+    multi_by_type = {record["type"]: record for record in multi}
+
+    for test_type in ("knowledge", "execution"):
+        assert _key_paths(single_by_type[test_type]) == _key_paths(multi_by_type[test_type]), (
+            f"{test_type} record shape differs between single- and multi-model modes"
+        )
+
+
+def test_multi_model_execution_records_include_audit_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    records = _multi_model_records(monkeypatch, tmp_path)
+    execution = next(record for record in records if record["type"] == "execution")
+
+    assert execution["prompt_hash"]
+    assert execution["category"] == "hooks"
+    assert execution["difficulty"] == "basic"
+    assert execution["mode"] == "model"
+    assert execution["grader"]["raw"]["runtime"]["score"] == 1.0
+    assert execution["grader"]["stdout"] == "out"
+    assert execution["output"]["raw_completion"] == "init"
+
+
+def test_reference_solution_record_uses_canonical_schema(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        model=ModelConfig(name="test-model"),
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(check_reference_solution=True),
+        output=OutputConfig(path=tmp_path / "ref.json", jsonl_path=None),
+    )
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": [_execution_test()], "knowledge": []},
+    )
+    runner = BenchmarkRunner(config)
+    runner.environment.setup = lambda: None  # type: ignore[method-assign]
+    runner.environment.reset = lambda: None  # type: ignore[method-assign]
+    runner.environment.execute_code = lambda code, verification_spec: _passing_result()  # type: ignore[method-assign]
+
+    runner.run()
+    record = runner.records[0]
+    single = _single_model_records(monkeypatch, tmp_path)
+    model_execution = next(r for r in single if r["type"] == "execution")
+
+    assert record["mode"] == "reference_solution"
+    assert record["model"] is None
+    # model is intentionally null in reference mode, so nested model.* paths
+    # exist only in model mode; the record shape must match otherwise.
+    reference_paths = {p for p in _key_paths(record) if not p.startswith("model.")}
+    model_paths = {p for p in _key_paths(model_execution) if not p.startswith("model.")}
+    assert reference_paths == model_paths
+
+
+def test_jsonl_records_match_json_results(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        model=ModelConfig(name="test-model"),
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(),
+        output=OutputConfig(path=tmp_path / "results.json", jsonl_path=tmp_path / "results.jsonl"),
+    )
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": [_execution_test()], "knowledge": [_knowledge_test()]},
+    )
+    runner = BenchmarkRunner(config)
+    runner.environment.setup = lambda: None  # type: ignore[method-assign]
+    runner.environment.reset = lambda: None  # type: ignore[method-assign]
+    runner.environment.execute_code = lambda code, verification_spec: _passing_result()  # type: ignore[method-assign]
+    monkeypatch.setattr(runner.model, "generate", lambda prompt: "init")
+
+    runner.run()
+
+    json_files = sorted(tmp_path.glob("results_*.json"))
+    jsonl_files = sorted(tmp_path.glob("results_*.jsonl"))
+    assert json_files and jsonl_files
+    payload = json.loads(json_files[-1].read_text())
+    jsonl_records = [
+        json.loads(line) for line in jsonl_files[-1].read_text().splitlines() if line
+    ]
+
+    assert payload["results"] == jsonl_records
+    assert payload["metadata"]["result_schema_version"] == RESULT_SCHEMA_VERSION
+
+
+def test_records_are_sorted_for_stable_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config = HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        model=ModelConfig(name="test-model"),
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(test_type="execution"),
+        output=OutputConfig(path=tmp_path / "results.json", jsonl_path=None),
+    )
+    # Deliberately out-of-order test IDs.
+    tests = [_execution_test("e-zebra"), _execution_test("e-alpha"), _execution_test("e-mid")]
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": tests, "knowledge": []},
+    )
+    runner = BenchmarkRunner(config)
+    runner.environment.setup = lambda: None  # type: ignore[method-assign]
+    runner.environment.reset = lambda: None  # type: ignore[method-assign]
+    runner.environment.execute_code = lambda code, verification_spec: _passing_result()  # type: ignore[method-assign]
+    monkeypatch.setattr(runner.model, "generate", lambda prompt: "```php\ncode\n```")
+
+    payload = runner.run()
+
+    ids = [record["test_id"] for record in payload["results"]]
+    assert ids == ["e-alpha", "e-mid", "e-zebra"]

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -32,6 +32,13 @@ from .output import (
     print_results_path,
     print_test_error,
 )
+from .records import (
+    RESULT_SCHEMA_VERSION,
+    build_execution_record,
+    build_knowledge_record,
+    execution_record_passed,
+    sort_records,
+)
 from .scoring import ScoreAggregator
 from .utils import ensure_dir, sha256, strip_code_fences
 
@@ -177,6 +184,7 @@ class BenchmarkRunner:
             "metadata": {
                 "suite": self.config.run.suite,
                 "mode": "reference_solution" if reference_mode else "model",
+                "result_schema_version": RESULT_SCHEMA_VERSION,
                 "model": model_config,
                 "grader": self.config.grader.model_dump(mode="json"),
                 "dataset": self.config.dataset.model_dump(mode="json"),
@@ -187,11 +195,13 @@ class BenchmarkRunner:
                     "overall": summary.overall(),
                 },
             },
-            "results": self.records,
+            "results": sort_records(self.records),
         }
         self._write_outputs(payload)
         if reference_mode:
-            failures = [record for record in self.records if not record.get("passed", False)]
+            failures = [
+                record for record in self.records if not execution_record_passed(record)
+            ]
             if failures:
                 print_reference_solution_failures(failures)
                 raise SystemExit(1)
@@ -232,16 +242,18 @@ class BenchmarkRunner:
         def process_test(test: KnowledgeTest) -> Dict[str, Any]:
             try:
                 prompt = self._render_knowledge_prompt(test)
-                answer = strip_code_fences(self.model.generate(prompt)).strip()
+                raw_completion = self.model.generate(prompt)
+                answer = strip_code_fences(raw_completion).strip()
                 correct = score_knowledge_answer(test, answer)
-                return {
-                    "test_id": test.id,
-                    "type": "knowledge",
-                    "prompt_hash": sha256(prompt),
-                    "answer": answer,
-                    "correct": bool(correct),
-                    "score": correct,
-                }
+                return build_knowledge_record(
+                    test=test,
+                    mode="model",
+                    model_config=self.config.model,
+                    prompt_hash=sha256(prompt),
+                    raw_completion=raw_completion,
+                    answer=answer,
+                    knowledge_score=correct,
+                )
             except Exception as e:
                 raise TestError(test.id, "knowledge", e) from e
 
@@ -253,7 +265,7 @@ class BenchmarkRunner:
                     try:
                         result = future.result()
                         with self._lock:
-                            self.aggregator.add_knowledge(result["score"])
+                            self.aggregator.add_knowledge(result["scores"]["knowledge"])
                             self.records.append(result)
                         progress.update(task, advance=1)
                     except TestError:
@@ -284,22 +296,22 @@ class BenchmarkRunner:
                 verification_spec = self._build_verification_spec(test)
                 env_result = self.environment.execute_code(code, verification_spec)
                 correctness = self._score_correctness(env_result.raw, test)
-                return {
-                    "test_id": test.id,
-                    "type": "execution",
-                    "prompt_hash": sha256(prompt),
-                    "code": code,
-                    "result": env_result.raw,
-                    "stdout": env_result.stdout,
-                    "stderr": env_result.stderr,
-                    "correctness": correctness,
-                }
+                return build_execution_record(
+                    test=test,
+                    mode="model",
+                    model_config=self.config.model,
+                    prompt_hash=sha256(prompt),
+                    raw_completion=completion,
+                    code=code,
+                    env_result=env_result,
+                    correctness=correctness,
+                )
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
 
         def on_result(result: Dict[str, Any]) -> None:
             with self._lock:
-                self.aggregator.add_execution(result["correctness"])
+                self.aggregator.add_execution(result["scores"]["correctness"])
                 self.records.append(result)
 
         _run_isolated_execution_loop(
@@ -322,23 +334,22 @@ class BenchmarkRunner:
                 verification_spec = self._build_verification_spec(test)
                 env_result = self.environment.execute_code(test.reference_solution, verification_spec)
                 correctness = self._score_correctness(env_result.raw, test)
-                return {
-                    "test_id": test.id,
-                    "type": "execution",
-                    "mode": "reference_solution",
-                    "code": test.reference_solution,
-                    "result": env_result.raw,
-                    "stdout": env_result.stdout,
-                    "stderr": env_result.stderr,
-                    "correctness": correctness,
-                    "passed": env_result.success and correctness >= 0.999,
-                }
+                return build_execution_record(
+                    test=test,
+                    mode="reference_solution",
+                    model_config=None,
+                    prompt_hash=None,
+                    raw_completion=None,
+                    code=test.reference_solution,
+                    env_result=env_result,
+                    correctness=correctness,
+                )
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
 
         def on_result(result: Dict[str, Any]) -> None:
             with self._lock:
-                self.aggregator.add_execution(result["correctness"])
+                self.aggregator.add_execution(result["scores"]["correctness"])
                 self.records.append(result)
 
         _run_isolated_execution_loop(
@@ -513,7 +524,7 @@ class BenchmarkRunner:
             jsonl_path = _timestamped_path(self.config.output.jsonl_path)
             ensure_dir(jsonl_path.parent)
             with jsonl_path.open("w", encoding="utf-8") as handle:
-                for record in self.records:
+                for record in payload["results"]:
                     handle.write(orjson.dumps(record).decode("utf-8"))
                     handle.write("\n")
 
@@ -586,6 +597,7 @@ class MultiModelRunner:
         payload = {
             "metadata": {
                 "suite": self.config.run.suite,
+                "result_schema_version": RESULT_SCHEMA_VERSION,
                 "grader": self.config.grader.model_dump(mode="json"),
                 "dataset": self.config.dataset.model_dump(mode="json"),
                 "runtime_isolation": self.config.run.execution_isolation,
@@ -655,7 +667,7 @@ class SingleModelRunner:
                 "correctness": summary.correctness,
                 "overall": summary.overall(),
             },
-            "results": self.records,
+            "results": sort_records(self.records),
         }
 
     def _run_knowledge_tests(self, tests: List[KnowledgeTest]) -> None:
@@ -666,15 +678,18 @@ class SingleModelRunner:
         def process_test(test: KnowledgeTest) -> Dict[str, Any]:
             try:
                 prompt = BenchmarkRunner._render_knowledge_prompt(test)
-                answer = strip_code_fences(self.model.generate(prompt)).strip()
+                raw_completion = self.model.generate(prompt)
+                answer = strip_code_fences(raw_completion).strip()
                 correct = score_knowledge_answer(test, answer)
-                return {
-                    "test_id": test.id,
-                    "type": "knowledge",
-                    "answer": answer,
-                    "correct": bool(correct),
-                    "score": correct,
-                }
+                return build_knowledge_record(
+                    test=test,
+                    mode="model",
+                    model_config=self.model_config,
+                    prompt_hash=sha256(prompt),
+                    raw_completion=raw_completion,
+                    answer=answer,
+                    knowledge_score=correct,
+                )
             except Exception as e:
                 raise TestError(test.id, "knowledge", e) from e
 
@@ -686,7 +701,7 @@ class SingleModelRunner:
                     try:
                         result = future.result()
                         with self._lock:
-                            self.aggregator.add_knowledge(result["score"])
+                            self.aggregator.add_knowledge(result["scores"]["knowledge"])
                             self.records.append(result)
                         progress.update(task, advance=1)
                     except TestError:
@@ -706,18 +721,22 @@ class SingleModelRunner:
                 verification_spec = BenchmarkRunner._build_verification_spec(test)
                 env_result = self.environment.execute_code(code, verification_spec)
                 correctness = BenchmarkRunner._score_correctness(env_result.raw, test)
-                return {
-                    "test_id": test.id,
-                    "type": "execution",
-                    "code": code,
-                    "correctness": correctness,
-                }
+                return build_execution_record(
+                    test=test,
+                    mode="model",
+                    model_config=self.model_config,
+                    prompt_hash=sha256(prompt),
+                    raw_completion=completion,
+                    code=code,
+                    env_result=env_result,
+                    correctness=correctness,
+                )
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
 
         def on_result(result: Dict[str, Any]) -> None:
             with self._lock:
-                self.aggregator.add_execution(result["correctness"])
+                self.aggregator.add_execution(result["scores"]["correctness"])
                 self.records.append(result)
 
         _run_isolated_execution_loop(

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -111,12 +111,14 @@ def print_reference_solution_failures(records: list[Dict[str, Any]]) -> None:
         return f"{value*100:.1f}%" if isinstance(value, (int, float)) else "N/A"
 
     for record in records:
-        result = record.get("result") or {}
+        grader = record.get("grader") or {}
+        raw = grader.get("raw") or {}
+        scores = record.get("scores") or {}
         table.add_row(
             str(record.get("test_id", "")),
-            _fmt_score(record.get("correctness")),
-            _fmt_score((result.get("static") or {}).get("score")),
-            _fmt_score((result.get("runtime") or {}).get("score")),
+            _fmt_score(scores.get("correctness")),
+            _fmt_score((raw.get("static") or {}).get("score")),
+            _fmt_score((raw.get("runtime") or {}).get("score")),
         )
 
     console.print(table)

--- a/python/wp_bench/records.py
+++ b/python/wp_bench/records.py
@@ -1,0 +1,148 @@
+"""Canonical per-test result records shared by every run mode.
+
+Single-model, multi-model, and reference-solution runs must produce
+structurally identical per-test records so any WP-Bench run can serve as a
+leaderboard artifact. Build records exclusively through the helpers here;
+do not hand-roll record dicts in runner code.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from .config import ModelConfig
+
+#: Bump when the per-test record shape changes. Recorded in payload metadata.
+RESULT_SCHEMA_VERSION = "1.0"
+
+
+def _model_info(model_config: Optional[ModelConfig]) -> Optional[Dict[str, Any]]:
+    """Serialize the model configuration relevant to reproducibility."""
+    if model_config is None:
+        return None
+    return {
+        "name": model_config.name,
+        "kind": model_config.kind,
+        "temperature": model_config.temperature,
+        "top_p": model_config.top_p,
+        "max_tokens": model_config.max_tokens,
+    }
+
+
+def _empty_usage() -> Dict[str, Any]:
+    """Usage placeholders; populated when usage capture is implemented."""
+    return {
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "total_tokens": None,
+        "cost_usd": None,
+        "latency_ms": None,
+    }
+
+
+def _dimension_score(raw: Optional[Dict[str, Any]], dimension: str) -> Optional[float]:
+    """Extract a dimension score (runtime/static) from the raw grader result."""
+    if not isinstance(raw, dict):
+        return None
+    result = raw.get(dimension)
+    if not isinstance(result, dict):
+        return None
+    score = result.get("score")
+    return float(score) if isinstance(score, (int, float)) else None
+
+
+def build_knowledge_record(
+    *,
+    test: Any,
+    mode: str,
+    model_config: Optional[ModelConfig],
+    prompt_hash: str,
+    raw_completion: str,
+    answer: str,
+    knowledge_score: float,
+) -> Dict[str, Any]:
+    """Build the canonical record for a knowledge test result."""
+    return {
+        "test_id": test.id,
+        "suite": test.suite,
+        "type": "knowledge",
+        "category": test.category,
+        "difficulty": test.difficulty,
+        "mode": mode,
+        "prompt_hash": prompt_hash,
+        "model": _model_info(model_config),
+        "output": {
+            "raw_completion": raw_completion,
+            "code": None,
+            "answer": answer,
+        },
+        "scores": {
+            "knowledge": knowledge_score,
+            "correctness": None,
+            "runtime": None,
+            "static": None,
+        },
+        "grader": None,
+        "usage": _empty_usage(),
+        "error": None,
+    }
+
+
+def build_execution_record(
+    *,
+    test: Any,
+    mode: str,
+    model_config: Optional[ModelConfig],
+    prompt_hash: Optional[str],
+    raw_completion: Optional[str],
+    code: str,
+    env_result: Any,
+    correctness: float,
+) -> Dict[str, Any]:
+    """Build the canonical record for an execution test result."""
+    raw = env_result.raw or {}
+    return {
+        "test_id": test.id,
+        "suite": test.suite,
+        "type": "execution",
+        "category": test.category,
+        "difficulty": test.difficulty,
+        "mode": mode,
+        "prompt_hash": prompt_hash,
+        "model": _model_info(model_config),
+        "output": {
+            "raw_completion": raw_completion,
+            "code": code,
+            "answer": None,
+        },
+        "scores": {
+            "knowledge": None,
+            "correctness": correctness,
+            "runtime": _dimension_score(raw, "runtime"),
+            "static": _dimension_score(raw, "static"),
+        },
+        "grader": {
+            "success": env_result.success,
+            "raw": raw,
+            "stdout": env_result.stdout,
+            "stderr": env_result.stderr,
+            "timeout": bool(raw.get("timeout", False)) or getattr(env_result, "timed_out", False),
+        },
+        "usage": _empty_usage(),
+        "error": None,
+    }
+
+
+def execution_record_passed(record: Dict[str, Any]) -> bool:
+    """Whether an execution record represents a strict pass.
+
+    Used by reference-solution mode to decide failures: the grader must
+    report success and correctness must be effectively 1.0.
+    """
+    grader = record.get("grader") or {}
+    correctness = (record.get("scores") or {}).get("correctness")
+    return bool(grader.get("success")) and isinstance(correctness, (int, float)) and correctness >= 0.999
+
+
+def sort_records(records: list) -> list:
+    """Order records deterministically for stable output diffs."""
+    return sorted(records, key=lambda record: (record.get("type", ""), record.get("test_id", "")))


### PR DESCRIPTION
## Why this matters

A benchmark result file is an artifact people need to trust and build on: providers audit why a test failed, reviewers reproduce runs, and tooling aggregates scores across runs. Right now the shape of a per-test record depends on *which mode produced it* — single-model records carry prompt hashes, generated code, raw runtime output, and stdout/stderr, while multi-model records (the mode used for actual comparisons!) silently drop most of that, and reference-solution mode uses a third shape. That means the most important runs are the least auditable, and any downstream consumer needs three parsers. Unifying on one canonical, versioned schema makes every run mode equally usable as a leaderboard artifact and gives future changes (usage capture, scoring rework) a stable place to land without breaking consumers.

## Changes

- **New `wp_bench/records.py`**: canonical record builders used by every mode — `build_knowledge_record()`, `build_execution_record()`, `execution_record_passed()`, `sort_records()`, and `RESULT_SCHEMA_VERSION = \"1.0\"`.
- **Canonical shape**: `test_id`, `suite`, `type`, `category`, `difficulty`, `mode`, `prompt_hash`, `model` (null in reference mode), `output {raw_completion, code, answer}`, `scores {knowledge, correctness, runtime, static}`, `grader {success, raw, stdout, stderr, timeout}`, `usage` placeholders, `error`.
- **Multi-model mode** now preserves raw runtime results, stdout/stderr, prompt hashes, category, difficulty — comparison runs are fully auditable.
- **Reference-solution mode** derives pass/fail from the canonical record via `execution_record_passed()` (grader success + correctness ≥ 0.999) instead of a bespoke `passed` key.
- **Payload metadata** gains `result_schema_version` in both single- and multi-model outputs so consumers can detect shape changes.
- **Deterministic output**: records sorted by `(type, test_id)` for stable diffs; JSONL rows are byte-identical to the JSON payload's records.
- Terminal comparison table and reference-failure table behavior unchanged.

## Verification

- `pytest python`: **54 passed** — 6 new tests assert: single vs multi-model key-path equality (nested), multi-model audit fields present, reference records match canonical shape with `model: null`, JSONL == JSON records, schema version present, deterministic sort order
- `ruff check python`: clean
- `mypy python`: 3 pre-existing trunk errors only

## Notes

- Stacked on #26.
- `usage` fields are intentionally null placeholders — usage/latency/cost capture later in this series fills them without another schema change.