### PR TITLE
fix: implement or reject unsupported config fields

### DIFF
--- a/python/tests/test_config_behavior.py
+++ b/python/tests/test_config_behavior.py
@@ -1,0 +1,125 @@
+"""Tests for config-means-behavior: no silent no-op fields."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from wp_bench.config import (
+    GraderConfig,
+    HarnessConfig,
+    OutputConfig,
+    RunConfig,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_http_grader_rejected_until_implemented() -> None:
+    with pytest.raises(ValidationError, match="not supported yet"):
+        GraderConfig(kind="http")  # type: ignore[arg-type]
+
+
+def test_unknown_grader_field_rejected() -> None:
+    """Removed fields (url, concurrency) fail loudly instead of no-oping."""
+    with pytest.raises(ValidationError):
+        GraderConfig(url="http://example.com")  # type: ignore[call-arg]
+    with pytest.raises(ValidationError):
+        GraderConfig(concurrency=4)  # type: ignore[call-arg]
+
+
+def test_removed_output_fields_rejected() -> None:
+    with pytest.raises(ValidationError):
+        OutputConfig(save_prompts=True)  # type: ignore[call-arg]
+    with pytest.raises(ValidationError):
+        OutputConfig(save_artifacts_dir="artifacts")  # type: ignore[call-arg]
+
+
+def test_unknown_top_level_field_rejected() -> None:
+    with pytest.raises(ValidationError):
+        HarnessConfig(unknown_section={"a": 1})  # type: ignore[call-arg]
+
+
+def test_skip_both_dimensions_rejected() -> None:
+    with pytest.raises(ValidationError, match="cannot both be true"):
+        RunConfig(skip_runtime=True, skip_static=True)
+
+
+def test_skip_runtime_alone_is_valid() -> None:
+    config = RunConfig(skip_runtime=True)
+    assert config.skip_runtime is True
+    assert config.skip_static is False
+
+
+def test_example_config_loads() -> None:
+    """The shipped example must only use supported fields."""
+    example = PROJECT_ROOT / "wp-bench.example.yaml"
+    config = HarnessConfig.from_file(example)
+    assert config.run.suite == "wp-core-v1"
+    assert config.grader.kind in ("docker", "cli")
+
+
+def test_skip_runtime_controls_verification_payload() -> None:
+    """skip_runtime must actually strip runtime checks from the verifier spec."""
+    from wp_bench.core import _build_verification_spec
+    from wp_bench.datasets import ExecutionTest
+
+    test = ExecutionTest(
+        id="e-one",
+        suite="wp-core-v1",
+        prompt="Prompt",
+        expected_behavior="expected",
+        test_type="execution",
+        category="general",
+        difficulty="basic",
+        requirements=[],
+        test_function=None,
+        static_checks={"required_patterns": [{"pattern": "x", "weight": 1}]},
+        runtime_checks={"assertions": [{"type": "custom_assertion", "code": "return true;", "weight": 1}]},
+        reference_solution=None,
+        metadata={},
+    )
+
+    default_spec = _build_verification_spec(test, HarnessConfig())
+    assert default_spec["static_checks"] == test.static_checks
+    assert default_spec["runtime_checks"] == test.runtime_checks
+
+    skip_runtime = HarnessConfig(run=RunConfig(skip_runtime=True))
+    spec = _build_verification_spec(test, skip_runtime)
+    assert spec["runtime_checks"] == {}
+    assert spec["static_checks"] == test.static_checks
+
+    skip_static = HarnessConfig(run=RunConfig(skip_static=True))
+    spec = _build_verification_spec(test, skip_static)
+    assert spec["static_checks"] == {}
+    assert spec["runtime_checks"] == test.runtime_checks
+
+
+def test_skipped_dimension_not_scored() -> None:
+    """A skipped dimension is not applicable: it cannot zero the score."""
+    from wp_bench.core import BenchmarkRunner
+    from wp_bench.datasets import ExecutionTest
+
+    test = ExecutionTest(
+        id="e-one",
+        suite="wp-core-v1",
+        prompt="Prompt",
+        expected_behavior="expected",
+        test_type="execution",
+        category="general",
+        difficulty="basic",
+        requirements=[],
+        test_function=None,
+        static_checks={"required_patterns": [{"pattern": "x", "weight": 1}]},
+        runtime_checks={"assertions": [{"type": "custom_assertion", "code": "return true;", "weight": 1}]},
+        reference_solution=None,
+        metadata={},
+    )
+    # Runtime skipped: raw has no runtime result, static passed fully.
+    raw = {"success": True, "static": {"score": 1.0, "details": {"total_weight": 1}}}
+
+    score = BenchmarkRunner._score_correctness(raw, test, skip_runtime=True)
+
+    # Without the skip flag this would crash-detect (no runtime weight) -> 0.0.
+    assert score == 1.0

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -1,10 +1,15 @@
-"""Typed configuration models for the WP-Bench harness."""
+"""Typed configuration models for the WP-Bench harness.
+
+Every field on these models is either implemented or rejected loudly.
+``extra="forbid"`` on all models means unknown (or removed) fields fail
+at load time instead of becoming silent no-ops: config means behavior.
+"""
 from __future__ import annotations
 
 from pathlib import Path
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, Field, HttpUrl, model_validator, validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator, validator
 
 ArtifactKind = Literal[
     "php_snippet",
@@ -16,7 +21,13 @@ ArtifactKind = Literal[
 ]
 
 
-class DatasetConfig(BaseModel):
+class StrictModel(BaseModel):
+    """Base for config models: unknown fields are errors, not no-ops."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class DatasetConfig(StrictModel):
     source: Literal["huggingface", "local"] = "huggingface"
     name: str = "WordPress/wp-bench-v1"
     revision: Optional[str] = None
@@ -24,7 +35,9 @@ class DatasetConfig(BaseModel):
     cache_dir: Optional[Path] = None
 
 
-class ModelConfig(BaseModel):
+class ModelConfig(StrictModel):
+    #: Informational provider family, recorded in result records for audit.
+    #: Routing itself is driven by ``name`` (a LiteLLM model string).
     kind: Literal["openai", "anthropic", "ollama", "openai-compatible"] = "openai"
     name: str = "gpt-4o-mini"
     temperature: float = 0.0
@@ -39,33 +52,52 @@ class ModelConfig(BaseModel):
         return value
 
 
-class GraderConfig(BaseModel):
-    kind: Literal["docker", "http", "cli"] = "docker"
+class GraderConfig(StrictModel):
+    kind: Literal["docker", "cli"] = "docker"
     image: str = "ghcr.io/wordpress/wp-bench-grader:latest"
     container_name: str = "wp-bench-grader"
-    url: Optional[HttpUrl] = None
     base_url: str = "http://localhost:8888"
-    concurrency: int = 4
     timeout_seconds: int = 90
     setup_timeout_seconds: int = 600
     wp_env_dir: Optional[Path] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_unsupported_kinds(cls, data: object) -> object:
+        """Fail early with a clear message for the unimplemented HTTP grader.
+
+        A Literal error alone ('input should be docker or cli') would be
+        confusing for users following older docs that mentioned 'http'.
+        """
+        if isinstance(data, dict) and data.get("kind") == "http":
+            raise ValueError(
+                "grader.kind='http' is not supported yet. Use 'docker' (default) "
+                "or 'cli'. Remote HTTP grading is planned but not implemented."
+            )
+        return data
 
 
 ExecutionIsolation = Literal["reset_per_test", "none"]
 
 
-class RunConfig(BaseModel):
+class RunConfig(StrictModel):
     suite: str = "wp-core-v1"
     test_type: Optional[Literal["knowledge", "execution"]] = None
     limit: Optional[int] = None
     test_ids: List[str] = Field(default_factory=list)
+    #: Reserved for deterministic subset selection; wired by seeded
+    #: stratified test limiting. Not yet consumed elsewhere.
     seed: int = 1337
     concurrency: int = 5
     execution_isolation: ExecutionIsolation = "reset_per_test"
     execution_concurrency: int = 1
     dry_run: bool = False
     check_reference_solution: bool = False
+    #: Skip runtime assertions (diagnostic runs only). Official leaderboard
+    #: runs must not skip grading dimensions.
     skip_runtime: bool = False
+    #: Skip static checks (diagnostic runs only). Official leaderboard
+    #: runs must not skip grading dimensions.
     skip_static: bool = False
 
     @model_validator(mode="after")
@@ -89,15 +121,22 @@ class RunConfig(BaseModel):
             )
         return self
 
+    @model_validator(mode="after")
+    def _validate_skips(self) -> "RunConfig":
+        if self.skip_runtime and self.skip_static:
+            raise ValueError(
+                "run.skip_runtime and run.skip_static cannot both be true: "
+                "execution tests would have no grading dimension left."
+            )
+        return self
 
-class OutputConfig(BaseModel):
+
+class OutputConfig(StrictModel):
     path: Path = Path("results.json")
     jsonl_path: Optional[Path] = Field(default=Path("results.jsonl"))
-    save_prompts: bool = True
-    save_artifacts_dir: Optional[Path] = Field(default=Path("artifacts"))
 
 
-class HarnessConfig(BaseModel):
+class HarnessConfig(StrictModel):
     dataset: DatasetConfig = DatasetConfig()
     model: Optional[ModelConfig] = None  # Single model (legacy)
     models: Optional[List[ModelConfig]] = None  # Multiple models
@@ -140,7 +179,7 @@ class HarnessConfig(BaseModel):
                 data["grader"]["wp_env_dir"] = resolve_path(wp_env_dir)
 
         if "output" in data and isinstance(data["output"], dict):
-            for key in ("path", "jsonl_path", "save_artifacts_dir"):
+            for key in ("path", "jsonl_path"):
                 if key in data["output"] and data["output"][key]:
                     data["output"][key] = resolve_path(data["output"][key])
 

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -68,6 +68,45 @@ def _limit_tests(tests: List[Any], config: HarnessConfig) -> List[Any]:
     return tests[:limit]
 
 
+def _build_verification_spec(test: Any, config: HarnessConfig) -> Dict[str, Any]:
+    """Build the verifier payload honoring run.skip_runtime/skip_static.
+
+    A skipped dimension is sent as empty checks so the runtime does not
+    execute it; scoring treats it as not applicable (see _score_correctness).
+
+    When runtime checks run, a weight-0 ``function_exists`` assertion derived
+    from ``test.test_function`` is prepended. It is the harness's gateway for
+    invoking the submission -- shown to the model and checked at runtime, but
+    earning no score. A missing gateway fails the behavioral assertions on its
+    own; the derived check only makes that failure diagnosable.
+    """
+    static_checks = {} if config.run.skip_static else test.static_checks
+    if config.run.skip_runtime:
+        runtime_checks: Dict[str, Any] = {}
+    else:
+        runtime_checks = dict(test.runtime_checks)
+        if test.test_function:
+            match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", test.test_function.strip())
+            if not match:
+                raise ValueError(
+                    f"Cannot extract function name from test_function "
+                    f"signature: {test.test_function!r}"
+                )
+            name = match.group(0)
+            derived = {
+                "type": "function_exists",
+                "target": name,
+                "description": f"Defines test function {name}()",
+                "weight": 0,
+            }
+            existing = runtime_checks.get("assertions", [])
+            runtime_checks["assertions"] = [derived, *existing]
+    return {
+        "static_checks": static_checks,
+        "runtime_checks": runtime_checks,
+    }
+
+
 def _run_isolated_execution_loop(
     *,
     tests_to_run: List[Any],
@@ -293,9 +332,14 @@ class BenchmarkRunner:
                 prompt = self._render_execution_prompt(test)
                 completion = self.model.generate(prompt)
                 code = strip_code_fences(completion)
-                verification_spec = self._build_verification_spec(test)
+                verification_spec = _build_verification_spec(test, self.config)
                 env_result = self.environment.execute_code(code, verification_spec)
-                correctness = self._score_correctness(env_result.raw, test)
+                correctness = self._score_correctness(
+                    env_result.raw,
+                    test,
+                    skip_runtime=self.config.run.skip_runtime,
+                    skip_static=self.config.run.skip_static,
+                )
                 return build_execution_record(
                     test=test,
                     mode="model",
@@ -331,9 +375,14 @@ class BenchmarkRunner:
             try:
                 if not test.reference_solution:
                     raise ValueError("Missing reference_solution")
-                verification_spec = self._build_verification_spec(test)
+                verification_spec = _build_verification_spec(test, self.config)
                 env_result = self.environment.execute_code(test.reference_solution, verification_spec)
-                correctness = self._score_correctness(env_result.raw, test)
+                correctness = self._score_correctness(
+                    env_result.raw,
+                    test,
+                    skip_runtime=self.config.run.skip_runtime,
+                    skip_static=self.config.run.skip_static,
+                )
                 return build_execution_record(
                     test=test,
                     mode="reference_solution",
@@ -395,40 +444,13 @@ class BenchmarkRunner:
         return "\n".join(lines)
 
     @staticmethod
-    def _build_verification_spec(test: ExecutionTest) -> Dict[str, Any]:
-        """Build the verifier payload, deriving a check from test_function.
-
-        test_function is the PHP signature of the entry point the verifier
-        calls; it is shown to the model and checked at runtime with PHP's
-        native function_exists() at weight 0. The function is the harness's
-        gateway for invoking the submission, not a scored WordPress skill, so
-        it earns no credit. When it is missing the behavioral assertions fail
-        on their own; the derived check only makes that failure diagnosable.
-        """
-        runtime_checks = dict(test.runtime_checks)
-        if test.test_function:
-            match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", test.test_function.strip())
-            if not match:
-                raise ValueError(
-                    f"Cannot extract function name from test_function "
-                    f"signature: {test.test_function!r}"
-                )
-            name = match.group(0)
-            derived = {
-                "type": "function_exists",
-                "target": name,
-                "description": f"Defines test function {name}()",
-                "weight": 0,
-            }
-            existing = runtime_checks.get("assertions", [])
-            runtime_checks["assertions"] = [derived, *existing]
-        return {
-            "static_checks": test.static_checks,
-            "runtime_checks": runtime_checks,
-        }
-
-    @staticmethod
-    def _score_correctness(raw: Dict[str, Any], test: ExecutionTest) -> float:
+    def _score_correctness(
+        raw: Dict[str, Any],
+        test: ExecutionTest,
+        *,
+        skip_runtime: bool = False,
+        skip_static: bool = False,
+    ) -> float:
         """Combine static-analysis and runtime-assertion scores into correctness.
 
         Both sub-scores are already weighted by the WordPress runtime
@@ -459,11 +481,12 @@ class BenchmarkRunner:
         static_checks = test.static_checks or {}
         runtime_checks = test.runtime_checks or {}
         applicable = {
-            "static": bool(
+            "static": not skip_static
+            and bool(
                 static_checks.get("required_patterns")
                 or static_checks.get("forbidden_patterns")
             ),
-            "runtime": bool(runtime_checks.get("assertions")),
+            "runtime": not skip_runtime and bool(runtime_checks.get("assertions")),
         }
 
         if applicable["runtime"] and BenchmarkRunner._runtime_crashed(raw):
@@ -718,9 +741,14 @@ class SingleModelRunner:
                 prompt = BenchmarkRunner._render_execution_prompt(test)
                 completion = self.model.generate(prompt)
                 code = strip_code_fences(completion)
-                verification_spec = BenchmarkRunner._build_verification_spec(test)
+                verification_spec = _build_verification_spec(test, self.config)
                 env_result = self.environment.execute_code(code, verification_spec)
-                correctness = BenchmarkRunner._score_correctness(env_result.raw, test)
+                correctness = BenchmarkRunner._score_correctness(
+                    env_result.raw,
+                    test,
+                    skip_runtime=self.config.run.skip_runtime,
+                    skip_static=self.config.run.skip_static,
+                )
                 return build_execution_record(
                     test=test,
                     mode="model",

--- a/wp-bench.example.yaml
+++ b/wp-bench.example.yaml
@@ -43,6 +43,10 @@ run:
   # share mutable WordPress state (not valid for official benchmark runs).
   # execution_isolation: reset_per_test
   # execution_concurrency: 1
+  # Diagnostic-only switches. Official leaderboard runs must grade every
+  # dimension; skipping either invalidates a run for comparison purposes.
+  # skip_runtime: false  # skip runtime assertions (static checks only)
+  # skip_static: false   # skip static checks (runtime assertions only)
 
 # Output paths
 output:


### PR DESCRIPTION
## Why this matters

Config is the contract between a benchmark and the people running it. When a provider sets `grader.kind: http` and the harness silently ignores it, or sets `output.save_prompts: true` and no prompts appear, they lose confidence in every other knob — and worse, they may believe they ran a configuration they didn't (e.g. assuming artifacts were saved for audit when nothing was written). For a benchmark that wants providers to defend their scores publicly, silent no-ops are a credibility problem: an honest error is always better than quietly wrong behavior. After this change, every field either works as documented or refuses to load.

## Changes

- **`extra='forbid'` on all config models**: unknown or removed fields now fail at load time with a clear Pydantic error instead of being silently accepted.
- **Removed until real**: `grader.url`, `grader.concurrency` (conflicted with `run.concurrency`, did nothing), `output.save_prompts`, `output.save_artifacts_dir`. `grader.kind='http'` gets a dedicated early rejection — "not supported yet, use 'docker' or 'cli'" — instead of a bare Literal error, since older docs mentioned it.
- **Implemented**: `run.skip_runtime` / `run.skip_static` now actually strip the corresponding checks from the verifier payload and mark that dimension not-applicable in scoring (so skipping runtime doesn't zero the score via crash detection). Setting both is rejected — there'd be nothing left to grade. Documented as diagnostic-only: official runs must grade every dimension.
- **Retained & documented**: `run.seed` (reserved for deterministic subset selection, implemented in a follow-up), `ModelConfig.kind` (informational provider family recorded in result records; routing is driven by the LiteLLM `name`).
- **Example YAML** updated to advertise only supported behavior, with the official-run caveat on skip switches.

## Verification

- `pytest python`: **63 passed** (9 new: http-grader rejection, removed-field rejection at each level, both-skips rejection, skip flags controlling the verifier payload, skipped dimension not zeroing scores, example YAML loads)
- `ruff check python`: clean
- `mypy python`: 3 pre-existing trunk errors only

## Notes

- Stacked on #27.
- `extra='forbid'` is intentionally strict: if someone's private config used removed fields, they get an immediate, actionable error at load — which is the point.