### PR TITLE
feat: make runtime behavior the primary execution score

### DIFF
--- a/python/tests/test_config_behavior.py
+++ b/python/tests/test_config_behavior.py
@@ -119,7 +119,8 @@ def test_skipped_dimension_not_scored() -> None:
     # Runtime skipped: raw has no runtime result, static passed fully.
     raw = {"success": True, "static": {"score": 1.0, "details": {"total_weight": 1}}}
 
-    score = BenchmarkRunner._score_correctness(raw, test, skip_runtime=True)
+    scores = BenchmarkRunner._score_execution(raw, test, skip_runtime=True)
 
-    # Without the skip flag this would crash-detect (no runtime weight) -> 0.0.
-    assert score == 1.0
+    # Without the skip flag this would crash-detect (no runtime weight) -> fail.
+    assert scores["execution_pass"] is True
+    assert scores["correctness"] == 1.0

--- a/python/tests/test_reference_solution_mode.py
+++ b/python/tests/test_reference_solution_mode.py
@@ -131,7 +131,10 @@ def test_reference_solution_mode_exits_nonzero_on_failed_reference(
 
     assert exc.value.code == 1
     assert execution_record_passed(runner.records[0]) is False
-    assert runner.records[0]["scores"]["correctness"] == 0.5
+    # v2 scoring: runtime is the behavioral signal; a full static match no
+    # longer contributes correctness credit when runtime fails.
+    assert runner.records[0]["scores"]["correctness"] == 0.0
+    assert runner.records[0]["scores"]["static"] == 1.0
 
 
 def test_reference_solution_mode_rejects_non_execution_test_ids(

--- a/python/tests/test_scoring.py
+++ b/python/tests/test_scoring.py
@@ -1,9 +1,11 @@
+"""Tests for runtime-primary execution scoring (SCORING_VERSION 2.0)."""
 from __future__ import annotations
 
 from typing import Any, Dict
 
 from wp_bench.core import BenchmarkRunner
 from wp_bench.datasets import ExecutionTest
+from wp_bench.scoring import ScoreAggregator
 
 
 def _make_test(
@@ -27,65 +29,113 @@ def _make_test(
     )
 
 
-def test_correctness_averages_static_and_runtime_dimensions() -> None:
-    test = _make_test(
+def _both_dimensions_test() -> ExecutionTest:
+    return _make_test(
         static_checks={"required_patterns": [{"pattern": "add_filter", "weight": 1.0}]},
         runtime_checks={"assertions": [{"type": "hook_registered", "target": "x"}]},
     )
+
+
+def test_runtime_pass_static_required_miss_still_passes() -> None:
+    """Valid alternate implementations are not punished by regex misses."""
+    test = _both_dimensions_test()
     raw = {
-        "static": {"score": 0.5},
+        "static": {"score": 0.5, "details": {"forbidden": []}},
         "runtime": {"score": 1.0, "details": {"total_weight": 1.0}},
     }
 
-    assert BenchmarkRunner._score_correctness(raw, test) == 0.75
+    scores = BenchmarkRunner._score_execution(raw, test)
+
+    assert scores["execution_pass"] is True
+    assert scores["correctness"] == 1.0
+    assert scores["runtime"] == 1.0
+    assert scores["static"] == 0.5  # diagnostic preserved
+    assert scores["static_policy_pass"] is True
 
 
-def test_correctness_uses_only_runtime_when_no_static_checks() -> None:
-    test = _make_test(
-        runtime_checks={"assertions": [{"type": "hook_registered", "target": "x"}]},
-    )
-    # Runtime returns 1.0 for absent static checks, which must NOT inflate the score.
+def test_runtime_fail_static_match_does_not_pass() -> None:
+    """Regex matches cannot rescue code whose behavior is wrong."""
+    test = _both_dimensions_test()
     raw = {
-        "static": {"score": 1.0},
-        "runtime": {"score": 0.4, "details": {"total_weight": 1.0}},
+        "static": {"score": 1.0, "details": {"forbidden": []}},
+        "runtime": {"score": 0.0, "details": {"total_weight": 1.0}},
     }
 
-    assert BenchmarkRunner._score_correctness(raw, test) == 0.4
+    scores = BenchmarkRunner._score_execution(raw, test)
+
+    assert scores["execution_pass"] is False
+    assert scores["correctness"] == 0.0
+    assert scores["runtime"] == 0.0
 
 
-def test_correctness_uses_only_static_when_no_runtime_checks() -> None:
-    test = _make_test(
-        static_checks={"required_patterns": [{"pattern": "esc_html", "weight": 1.0}]},
-    )
-    # Runtime returns 0.0 when no assertions are defined; it must be ignored here.
-    raw = {"static": {"score": 0.8}, "runtime": {"score": 0.0}}
+def test_partial_runtime_gives_partial_correctness_but_no_pass() -> None:
+    test = _both_dimensions_test()
+    raw = {
+        "static": {"score": 1.0, "details": {"forbidden": []}},
+        "runtime": {"score": 0.5, "details": {"total_weight": 2.0}},
+    }
 
-    assert BenchmarkRunner._score_correctness(raw, test) == 0.8
+    scores = BenchmarkRunner._score_execution(raw, test)
+
+    assert scores["execution_pass"] is False
+    assert scores["correctness"] == 0.5
+    assert scores["runtime"] == 0.5
 
 
-def test_correctness_respects_forbidden_pattern_hard_fail() -> None:
+def test_forbidden_static_error_blocks_pass() -> None:
+    """A hard policy guardrail failure fails the task even with perfect runtime."""
     test = _make_test(
         static_checks={"forbidden_patterns": [{"pattern": "eval\\(", "severity": "error"}]},
         runtime_checks={"assertions": [{"type": "hook_registered", "target": "x"}]},
     )
-    # Static hard-failed to 0.0 via a forbidden pattern; runtime passed fully.
     raw = {
-        "static": {"score": 0.0},
+        "static": {
+            "score": 0.0,
+            "details": {
+                "forbidden": [
+                    {"pattern": "eval\\(", "found": True, "severity": "error"}
+                ],
+                "failure_reason": "Forbidden pattern found: eval(",
+            },
+        },
         "runtime": {"score": 1.0, "details": {"total_weight": 1.0}},
     }
 
-    assert BenchmarkRunner._score_correctness(raw, test) == 0.5
+    scores = BenchmarkRunner._score_execution(raw, test)
+
+    assert scores["static_policy_pass"] is False
+    assert scores["execution_pass"] is False
 
 
-def test_correctness_hard_zeroes_on_crash_despite_perfect_static() -> None:
+def test_forbidden_warning_severity_does_not_block_pass() -> None:
+    """Only severity=error forbidden patterns are guardrail failures."""
     test = _make_test(
-        static_checks={"required_patterns": [{"pattern": "add_filter", "weight": 1.0}]},
+        static_checks={"forbidden_patterns": [{"pattern": "extract\\(", "severity": "warning"}]},
         runtime_checks={"assertions": [{"type": "hook_registered", "target": "x"}]},
     )
-    # Static is perfect, but the code crashed before any assertion ran
-    # (runtime accumulated no weight). Static must not rescue unrunnable code.
     raw = {
-        "static": {"score": 1.0},
+        "static": {
+            "score": 1.0,
+            "details": {
+                "forbidden": [
+                    {"pattern": "extract\\(", "found": True, "severity": "warning"}
+                ],
+            },
+        },
+        "runtime": {"score": 1.0, "details": {"total_weight": 1.0}},
+    }
+
+    scores = BenchmarkRunner._score_execution(raw, test)
+
+    assert scores["static_policy_pass"] is True
+    assert scores["execution_pass"] is True
+
+
+def test_runtime_crash_forces_execution_fail() -> None:
+    """Crash handling is preserved: static cannot rescue unrunnable code."""
+    test = _both_dimensions_test()
+    raw = {
+        "static": {"score": 1.0, "details": {"forbidden": []}},
         "runtime": {
             "score": 0.0,
             "details": {
@@ -95,14 +145,17 @@ def test_correctness_hard_zeroes_on_crash_despite_perfect_static() -> None:
         },
     }
 
-    assert BenchmarkRunner._score_correctness(raw, test) == 0.0
+    scores = BenchmarkRunner._score_execution(raw, test)
+
+    assert scores["execution_pass"] is False
+    assert scores["correctness"] == 0.0
+    assert scores["runtime"] == 0.0
 
 
-def test_correctness_crash_detected_by_error_assertion_type() -> None:
+def test_crash_detected_by_error_assertion_type() -> None:
     test = _make_test(
         runtime_checks={"assertions": [{"type": "hook_registered", "target": "x"}]},
     )
-    # An execution_error entry signals a crash even if some weight accumulated.
     raw = {
         "runtime": {
             "score": 0.5,
@@ -116,38 +169,101 @@ def test_correctness_crash_detected_by_error_assertion_type() -> None:
         },
     }
 
-    assert BenchmarkRunner._score_correctness(raw, test) == 0.0
+    scores = BenchmarkRunner._score_execution(raw, test)
+
+    assert scores["execution_pass"] is False
+    assert scores["correctness"] == 0.0
 
 
-def test_correctness_keeps_partial_credit_when_code_runs() -> None:
+def test_static_only_test_scored_on_static() -> None:
+    """Tests without runtime assertions remain gradable on static score."""
     test = _make_test(
-        runtime_checks={
-            "assertions": [
-                {"type": "hook_registered", "target": "x"},
-                {"type": "hook_registered", "target": "y"},
-            ]
-        },
+        static_checks={"required_patterns": [{"pattern": "esc_html", "weight": 1.0}]},
     )
-    # Code ran fine but only half the assertions passed: partial credit stays.
+    raw = {"static": {"score": 1.0, "details": {"forbidden": []}}, "runtime": {"score": 0.0}}
+
+    scores = BenchmarkRunner._score_execution(raw, test)
+
+    assert scores["execution_pass"] is True
+    assert scores["correctness"] == 1.0
+    assert scores["runtime"] is None
+
+
+def test_static_only_partial_score_no_pass() -> None:
+    test = _make_test(
+        static_checks={"required_patterns": [{"pattern": "esc_html", "weight": 1.0}]},
+    )
+    raw = {"static": {"score": 0.8, "details": {"forbidden": []}}}
+
+    scores = BenchmarkRunner._score_execution(raw, test)
+
+    assert scores["execution_pass"] is False
+    assert scores["correctness"] == 0.8
+
+
+def test_empty_raw_scores_zero() -> None:
+    test = _both_dimensions_test()
+
+    scores = BenchmarkRunner._score_execution({}, test)
+
+    assert scores["execution_pass"] is False
+    assert scores["correctness"] == 0.0
+
+
+def test_timeout_raw_scores_zero() -> None:
+    """The timeout payload from the environment scores as a failed test."""
+    test = _both_dimensions_test()
     raw = {
+        "success": False,
+        "timeout": True,
         "runtime": {
-            "score": 0.5,
+            "score": 0.0,
             "details": {
-                "assertions": [
-                    {"type": "hook_registered", "passed": True, "weight": 1.0},
-                    {"type": "hook_registered", "passed": False, "weight": 1.0},
-                ],
-                "total_weight": 2.0,
+                "assertions": [{"type": "timeout", "passed": False}],
+                "total_weight": 0,
+                "passed_weight": 0,
             },
         },
+        "static": {"score": 0.0, "details": {}},
     }
 
-    assert BenchmarkRunner._score_correctness(raw, test) == 0.5
+    scores = BenchmarkRunner._score_execution(raw, test)
+
+    assert scores["execution_pass"] is False
+    assert scores["correctness"] == 0.0
 
 
-def test_correctness_returns_zero_for_empty_raw() -> None:
-    test = _make_test(
-        runtime_checks={"assertions": [{"type": "hook_registered", "target": "x"}]},
+def test_aggregator_reports_strict_pass_rate() -> None:
+    aggregator = ScoreAggregator()
+    aggregator.add_execution(
+        {"correctness": 1.0, "execution_pass": True, "runtime": 1.0, "static_policy_pass": True}
+    )
+    aggregator.add_execution(
+        {"correctness": 0.5, "execution_pass": False, "runtime": 0.5, "static_policy_pass": True}
+    )
+    aggregator.add_execution(
+        {"correctness": 0.0, "execution_pass": False, "runtime": 1.0, "static_policy_pass": False}
     )
 
-    assert BenchmarkRunner._score_correctness({}, test) == 0.0
+    summary = aggregator.finalize()
+
+    assert summary.execution_pass_rate == round(1 / 3, 4)
+    assert summary.runtime == round((1.0 + 0.5 + 1.0) / 3, 4)
+    assert summary.static_policy_pass_rate == round(2 / 3, 4)
+    assert summary.correctness == 0.5
+
+
+def test_overall_uses_strict_pass_rate() -> None:
+    aggregator = ScoreAggregator()
+    aggregator.add_knowledge(1.0)
+    aggregator.add_execution(
+        {"correctness": 1.0, "execution_pass": True, "runtime": 1.0, "static_policy_pass": True}
+    )
+    aggregator.add_execution(
+        {"correctness": 0.9, "execution_pass": False, "runtime": 0.9, "static_policy_pass": True}
+    )
+
+    summary = aggregator.finalize()
+
+    # overall = 0.3 * 1.0 + 0.7 * 0.5 = 0.65
+    assert summary.overall() == 0.65

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -7,7 +7,6 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
-from statistics import mean
 from typing import Any, Dict, List
 
 import orjson
@@ -39,7 +38,7 @@ from .records import (
     execution_record_passed,
     sort_records,
 )
-from .scoring import ScoreAggregator
+from .scoring import SCORING_VERSION, ScoreAggregator
 from .utils import ensure_dir, sha256, strip_code_fences
 
 
@@ -228,8 +227,12 @@ class BenchmarkRunner:
                 "grader": self.config.grader.model_dump(mode="json"),
                 "dataset": self.config.dataset.model_dump(mode="json"),
                 "runtime_isolation": self.config.run.execution_isolation,
+                "scoring_version": SCORING_VERSION,
                 "scores": {
                     "knowledge": summary.knowledge,
+                    "execution_pass_rate": summary.execution_pass_rate,
+                    "runtime": summary.runtime,
+                    "static_policy_pass_rate": summary.static_policy_pass_rate,
                     "correctness": summary.correctness,
                     "overall": summary.overall(),
                 },
@@ -334,7 +337,7 @@ class BenchmarkRunner:
                 code = strip_code_fences(completion)
                 verification_spec = _build_verification_spec(test, self.config)
                 env_result = self.environment.execute_code(code, verification_spec)
-                correctness = self._score_correctness(
+                scores = self._score_execution(
                     env_result.raw,
                     test,
                     skip_runtime=self.config.run.skip_runtime,
@@ -348,14 +351,14 @@ class BenchmarkRunner:
                     raw_completion=completion,
                     code=code,
                     env_result=env_result,
-                    correctness=correctness,
+                    scores=scores,
                 )
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
 
         def on_result(result: Dict[str, Any]) -> None:
             with self._lock:
-                self.aggregator.add_execution(result["scores"]["correctness"])
+                self.aggregator.add_execution(result["scores"])
                 self.records.append(result)
 
         _run_isolated_execution_loop(
@@ -377,7 +380,7 @@ class BenchmarkRunner:
                     raise ValueError("Missing reference_solution")
                 verification_spec = _build_verification_spec(test, self.config)
                 env_result = self.environment.execute_code(test.reference_solution, verification_spec)
-                correctness = self._score_correctness(
+                scores = self._score_execution(
                     env_result.raw,
                     test,
                     skip_runtime=self.config.run.skip_runtime,
@@ -391,14 +394,14 @@ class BenchmarkRunner:
                     raw_completion=None,
                     code=test.reference_solution,
                     env_result=env_result,
-                    correctness=correctness,
+                    scores=scores,
                 )
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
 
         def on_result(result: Dict[str, Any]) -> None:
             with self._lock:
-                self.aggregator.add_execution(result["scores"]["correctness"])
+                self.aggregator.add_execution(result["scores"])
                 self.records.append(result)
 
         _run_isolated_execution_loop(
@@ -444,65 +447,105 @@ class BenchmarkRunner:
         return "\n".join(lines)
 
     @staticmethod
-    def _score_correctness(
+    def _score_execution(
         raw: Dict[str, Any],
         test: ExecutionTest,
         *,
         skip_runtime: bool = False,
         skip_static: bool = False,
-    ) -> float:
-        """Combine static-analysis and runtime-assertion scores into correctness.
+    ) -> Dict[str, Any]:
+        """Score an execution test with runtime behavior as the primary signal.
 
-        Both sub-scores are already weighted by the WordPress runtime
-        (Static_Analysis::check and Sandbox::execute_and_verify), including the
-        per-pattern/per-assertion weights and the forbidden-pattern hard fail.
-        A dimension contributes only when the test actually defines checks for
-        it, so a test with only runtime assertions is scored purely on runtime,
-        and vice versa. Applicability is read from the test definition rather
-        than the runtime output, since a crash before assertions run leaves the
-        runtime weight at zero even though the dimension was meant to count.
+        Scoring model (SCORING_VERSION 2.0):
 
-        When the code is supposed to run but crashes (a fatal or execution
-        error before any assertion executes), correctness is forced to 0.0:
-        the runtime is ground truth, and static pattern matches must not rescue
-        code that does not run. This applies only to hard crashes, not to code
-        that runs but fails some assertions, which still earns partial credit.
+        - ``execution_pass`` (bool, primary): the code executed without a
+          hard crash/timeout, its runtime assertions effectively all passed
+          (runtime score >= 0.999), and no forbidden static pattern with
+          severity ``error`` matched. When runtime assertions are skipped or
+          absent, the runtime requirement falls back to the static score so
+          static-only tests remain gradable.
+        - ``runtime_score`` (float): weighted partial runtime assertion
+          score, 0.0 unless the code actually ran.
+        - ``static_score`` (float): regex diagnostic score. Never grants
+          correctness credit on its own; kept for authoring/diagnostics.
+        - ``static_policy_pass`` (bool): False when a forbidden pattern with
+          severity ``error`` matched (a hard guardrail failure).
+        - ``correctness`` (float, legacy): 1.0 on strict pass, otherwise
+          partial runtime credit (0.0 on crash/policy failure semantics
+          preserved through the runtime score). Kept one release for
+          consumers of the old key.
 
-        Args:
-            raw: Raw result dict from the WordPress runtime (static/runtime).
-            test: The execution test, used to know which dimensions apply.
-
-        Returns:
-            Float between 0.0 and 1.0 averaging the applicable dimensions.
+        Rationale: regex checks are gameable and can punish valid alternate
+        implementations. Behavior is ground truth; static checks remain as
+        diagnostics and hard security/policy guardrails only.
         """
-        if not raw:
-            return 0.0
-
         static_checks = test.static_checks or {}
         runtime_checks = test.runtime_checks or {}
-        applicable = {
-            "static": not skip_static
-            and bool(
-                static_checks.get("required_patterns")
-                or static_checks.get("forbidden_patterns")
-            ),
-            "runtime": not skip_runtime and bool(runtime_checks.get("assertions")),
+        runtime_applicable = not skip_runtime and bool(runtime_checks.get("assertions"))
+        static_applicable = not skip_static and bool(
+            static_checks.get("required_patterns") or static_checks.get("forbidden_patterns")
+        )
+
+        static_result = raw.get("static") if isinstance(raw, dict) else None
+        static_score = None
+        if static_applicable and isinstance(static_result, dict):
+            value = static_result.get("score")
+            static_score = float(value) if isinstance(value, (int, float)) else 0.0
+
+        static_policy_pass = not (
+            static_applicable
+            and BenchmarkRunner._forbidden_error_found(static_result)
+        )
+
+        crashed = runtime_applicable and (not raw or BenchmarkRunner._runtime_crashed(raw))
+        runtime_score = 0.0
+        if runtime_applicable and not crashed and isinstance(raw, dict):
+            runtime_result = raw.get("runtime")
+            value = runtime_result.get("score") if isinstance(runtime_result, dict) else None
+            runtime_score = float(value) if isinstance(value, (int, float)) else 0.0
+
+        if runtime_applicable:
+            behavior_passed = not crashed and runtime_score >= 0.999
+        elif static_applicable:
+            # Static-only tests: behavior cannot be observed, so the static
+            # score is the only gradable dimension.
+            behavior_passed = (static_score or 0.0) >= 0.999
+        else:
+            behavior_passed = False
+
+        execution_pass = behavior_passed and static_policy_pass
+
+        if execution_pass:
+            correctness = 1.0
+        elif runtime_applicable:
+            correctness = 0.0 if crashed else round(runtime_score, 4)
+        else:
+            correctness = round(static_score or 0.0, 4)
+
+        return {
+            "knowledge": None,
+            "correctness": correctness,
+            "execution_pass": execution_pass,
+            "runtime": round(runtime_score, 4) if runtime_applicable else None,
+            "static": round(static_score, 4) if static_score is not None else None,
+            "static_policy_pass": static_policy_pass if static_applicable else None,
         }
 
-        if applicable["runtime"] and BenchmarkRunner._runtime_crashed(raw):
-            return 0.0
-
-        scores: List[float] = []
-        for dimension, is_applicable in applicable.items():
-            if not is_applicable:
-                continue
-            result = raw.get(dimension)
-            score = result.get("score") if isinstance(result, dict) else None
-            scores.append(float(score) if isinstance(score, (int, float)) else 0.0)
-
-        if not scores:
-            return 0.0
-        return round(mean(scores), 4)
+    @staticmethod
+    def _forbidden_error_found(static_result: Any) -> bool:
+        """Whether the static analysis found a forbidden pattern with severity error."""
+        if not isinstance(static_result, dict):
+            return False
+        details = static_result.get("details") or {}
+        if details.get("failure_reason"):
+            return True
+        forbidden = details.get("forbidden") or []
+        return any(
+            isinstance(entry, dict)
+            and entry.get("found")
+            and entry.get("severity") == "error"
+            for entry in forbidden
+        )
 
     @staticmethod
     def _runtime_crashed(raw: Dict[str, Any]) -> bool:
@@ -621,6 +664,7 @@ class MultiModelRunner:
             "metadata": {
                 "suite": self.config.run.suite,
                 "result_schema_version": RESULT_SCHEMA_VERSION,
+                "scoring_version": SCORING_VERSION,
                 "grader": self.config.grader.model_dump(mode="json"),
                 "dataset": self.config.dataset.model_dump(mode="json"),
                 "runtime_isolation": self.config.run.execution_isolation,
@@ -685,8 +729,12 @@ class SingleModelRunner:
         summary = self.aggregator.finalize()
         return {
             "model_config": self.model_config.model_dump(mode="json"),
+            "scoring_version": SCORING_VERSION,
             "scores": {
                 "knowledge": summary.knowledge,
+                "execution_pass_rate": summary.execution_pass_rate,
+                "runtime": summary.runtime,
+                "static_policy_pass_rate": summary.static_policy_pass_rate,
                 "correctness": summary.correctness,
                 "overall": summary.overall(),
             },
@@ -743,7 +791,7 @@ class SingleModelRunner:
                 code = strip_code_fences(completion)
                 verification_spec = _build_verification_spec(test, self.config)
                 env_result = self.environment.execute_code(code, verification_spec)
-                correctness = BenchmarkRunner._score_correctness(
+                scores = BenchmarkRunner._score_execution(
                     env_result.raw,
                     test,
                     skip_runtime=self.config.run.skip_runtime,
@@ -757,14 +805,14 @@ class SingleModelRunner:
                     raw_completion=completion,
                     code=code,
                     env_result=env_result,
-                    correctness=correctness,
+                    scores=scores,
                 )
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
 
         def on_result(result: Dict[str, Any]) -> None:
             with self._lock:
-                self.aggregator.add_execution(result["scores"]["correctness"])
+                self.aggregator.add_execution(result["scores"])
                 self.records.append(result)
 
         _run_isolated_execution_loop(

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -81,7 +81,8 @@ def print_comparison_table(results: Dict[str, Dict[str, Any]]) -> None:
     table = Table(title="WP-Bench Results")
     table.add_column("Model", style="cyan")
     table.add_column("Knowledge", justify="right")
-    table.add_column("Correctness", justify="right")
+    table.add_column("Execution Pass", justify="right")
+    table.add_column("Runtime Partial", justify="right")
     table.add_column("Overall", justify="right", style="bold")
 
     def _fmt_score(value: float | None) -> str:
@@ -91,8 +92,9 @@ def print_comparison_table(results: Dict[str, Dict[str, Any]]) -> None:
         scores = result["scores"]
         table.add_row(
             model_name,
-            _fmt_score(scores["knowledge"]),
-            _fmt_score(scores["correctness"]),
+            _fmt_score(scores.get("knowledge")),
+            _fmt_score(scores.get("execution_pass_rate")),
+            _fmt_score(scores.get("runtime")),
             f"{scores['overall']*100:.1f}%",
         )
 

--- a/python/wp_bench/records.py
+++ b/python/wp_bench/records.py
@@ -39,17 +39,6 @@ def _empty_usage() -> Dict[str, Any]:
     }
 
 
-def _dimension_score(raw: Optional[Dict[str, Any]], dimension: str) -> Optional[float]:
-    """Extract a dimension score (runtime/static) from the raw grader result."""
-    if not isinstance(raw, dict):
-        return None
-    result = raw.get(dimension)
-    if not isinstance(result, dict):
-        return None
-    score = result.get("score")
-    return float(score) if isinstance(score, (int, float)) else None
-
-
 def build_knowledge_record(
     *,
     test: Any,
@@ -78,8 +67,10 @@ def build_knowledge_record(
         "scores": {
             "knowledge": knowledge_score,
             "correctness": None,
+            "execution_pass": None,
             "runtime": None,
             "static": None,
+            "static_policy_pass": None,
         },
         "grader": None,
         "usage": _empty_usage(),
@@ -96,9 +87,15 @@ def build_execution_record(
     raw_completion: Optional[str],
     code: str,
     env_result: Any,
-    correctness: float,
+    scores: Dict[str, Any],
 ) -> Dict[str, Any]:
-    """Build the canonical record for an execution test result."""
+    """Build the canonical record for an execution test result.
+
+    Args:
+        scores: Scores object from BenchmarkRunner._score_execution, carrying
+            correctness (legacy), execution_pass (primary), runtime, static,
+            and static_policy_pass.
+    """
     raw = env_result.raw or {}
     return {
         "test_id": test.id,
@@ -114,12 +111,7 @@ def build_execution_record(
             "code": code,
             "answer": None,
         },
-        "scores": {
-            "knowledge": None,
-            "correctness": correctness,
-            "runtime": _dimension_score(raw, "runtime"),
-            "static": _dimension_score(raw, "static"),
-        },
+        "scores": scores,
         "grader": {
             "success": env_result.success,
             "raw": raw,
@@ -135,12 +127,10 @@ def build_execution_record(
 def execution_record_passed(record: Dict[str, Any]) -> bool:
     """Whether an execution record represents a strict pass.
 
-    Used by reference-solution mode to decide failures: the grader must
-    report success and correctness must be effectively 1.0.
+    Reads the primary execution_pass metric (SCORING_VERSION 2.0). Used by
+    reference-solution mode to decide failures.
     """
-    grader = record.get("grader") or {}
-    correctness = (record.get("scores") or {}).get("correctness")
-    return bool(grader.get("success")) and isinstance(correctness, (int, float)) and correctness >= 0.999
+    return bool((record.get("scores") or {}).get("execution_pass"))
 
 
 def sort_records(records: list) -> list:

--- a/python/wp_bench/scoring.py
+++ b/python/wp_bench/scoring.py
@@ -1,20 +1,46 @@
-"""Score aggregation utilities."""
+"""Score aggregation utilities.
+
+Scoring model (SCORING_VERSION 2.0): runtime behavior is the primary
+execution signal. A task passes strictly (``execution_pass``) when the
+code runs without crash/timeout, passes its runtime assertions, and
+triggers no forbidden static pattern with severity ``error``. Static
+required-pattern scores are diagnostics; they no longer grant or deny
+correctness credit on their own.
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from statistics import mean
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
+
+#: Bump when the meaning of any aggregate or per-test score changes.
+SCORING_VERSION = "2.0"
 
 
 @dataclass
 class ScoreBreakdown:
     knowledge: Optional[float] = None
+    #: Legacy compatibility score (see records: 1.0 on strict pass, else
+    #: partial runtime credit). Kept one release for consumers of the old key.
     correctness: Optional[float] = None
+    #: Strict pass rate: fraction of execution tests with execution_pass=True.
+    #: This is the primary execution ranking metric.
+    execution_pass_rate: Optional[float] = None
+    #: Mean partial runtime assertion score (0.0-1.0).
+    runtime: Optional[float] = None
+    #: Fraction of execution tests without a hard static policy failure.
+    static_policy_pass_rate: Optional[float] = None
     weights: Dict[str, float] = field(
-        default_factory=lambda: {"knowledge": 0.3, "correctness": 0.7}
+        default_factory=lambda: {"knowledge": 0.3, "execution_pass_rate": 0.7}
     )
 
     def overall(self) -> float:
+        """Weighted overall score (formula versioned by SCORING_VERSION).
+
+        v2.0: 0.3 * knowledge + 0.7 * strict execution pass rate, over the
+        dimensions actually present. Prefer the separate metrics for any
+        official comparison; overall is a convenience summary only.
+        """
         active = {k: w for k, w in self.weights.items() if getattr(self, k) is not None}
         if not active:
             return 0.0
@@ -27,9 +53,22 @@ class ScoreAggregator:
     def __init__(self) -> None:
         self.knowledge_scores: List[float] = []
         self.correctness_scores: List[float] = []
+        self.execution_passes: List[bool] = []
+        self.runtime_scores: List[float] = []
+        self.static_policy_passes: List[bool] = []
 
-    def add_execution(self, correctness: float) -> None:
-        self.correctness_scores.append(correctness)
+    def add_execution(self, scores: Dict[str, Any]) -> None:
+        """Record an execution test's scores object (canonical record shape)."""
+        correctness = scores.get("correctness")
+        if isinstance(correctness, (int, float)):
+            self.correctness_scores.append(float(correctness))
+        self.execution_passes.append(bool(scores.get("execution_pass")))
+        runtime = scores.get("runtime")
+        if isinstance(runtime, (int, float)):
+            self.runtime_scores.append(float(runtime))
+        policy = scores.get("static_policy_pass")
+        if policy is not None:
+            self.static_policy_passes.append(bool(policy))
 
     def add_knowledge(self, score: float) -> None:
         self.knowledge_scores.append(score)
@@ -40,4 +79,14 @@ class ScoreAggregator:
             breakdown.knowledge = mean(self.knowledge_scores)
         if self.correctness_scores:
             breakdown.correctness = mean(self.correctness_scores)
+        if self.execution_passes:
+            breakdown.execution_pass_rate = round(
+                sum(self.execution_passes) / len(self.execution_passes), 4
+            )
+        if self.runtime_scores:
+            breakdown.runtime = round(mean(self.runtime_scores), 4)
+        if self.static_policy_passes:
+            breakdown.static_policy_pass_rate = round(
+                sum(self.static_policy_passes) / len(self.static_policy_passes), 4
+            )
         return breakdown


### PR DESCRIPTION
## Why this matters

WP-Bench's core promise is answering: *does this model write WordPress code that actually works?* The current score can't cleanly answer that, because it averages two very different signals — runtime assertions (did the code behave correctly in a real WordPress?) and regex pattern checks (does the source text look like we expected?). Averaging them means a model can lose points for solving a task a valid but different way, and gain points for code that *looks* right but doesn't run. Both failure modes are poison for a leaderboard: the first is unfair to models, the second is misleading to users, and the whole metric is gameable by optimizing for the regexes. This change makes observed runtime behavior the ranking signal, while keeping static checks in the two roles they're actually good at: authoring diagnostics and hard security guardrails (e.g. `eval(` is disqualifying no matter what the code does).

## Changes

**Scoring model v2.0** (`scoring_version` now recorded in result metadata):

- **`execution_pass` (bool, primary)** — code ran without crash/timeout, runtime assertions effectively all passed (≥ 0.999), and no forbidden static pattern with severity `error` matched. Static-only tests (no runtime assertions) fall back to the static score so they remain gradable.
- **`runtime`** — weighted partial runtime assertion score; 0.0 on crash.
- **`static`** — regex score preserved as a *diagnostic*; grants no correctness credit on its own.
- **`static_policy_pass` (bool)** — hard guardrail; false when an error-severity forbidden pattern matched.
- **`correctness` (legacy)** — kept one release for existing consumers: 1.0 on strict pass, else partial runtime credit; crash still forces 0.0.

**Aggregates**: `execution_pass_rate` (the primary execution ranking metric), mean `runtime`, `static_policy_pass_rate`; `overall()` is versioned (0.3 × knowledge + 0.7 × strict pass rate) and documented as a convenience summary — official comparisons should use the separate metrics.

**Surfaces**: terminal table now shows Knowledge / Execution Pass / Runtime Partial / Overall; reference-solution mode requires strict `execution_pass`, so a reference solution that merely pattern-matches its own checks can no longer pass silently.

## Behavior changes reviewers should know

- A run with full static match but failed runtime now scores `correctness` 0.0 (was 0.5) — this is the intended semantic shift, and the raw static diagnostic is still in the record.
- Warning-severity forbidden patterns do **not** block a pass; only `error` severity does.

## Verification

- `pytest python`: **68 passed** — scoring suite rewritten (14 tests): runtime-pass/static-miss passes, runtime-fail/static-match fails, forbidden error blocks pass, forbidden warning doesn't, crash forces fail, static-only tests gradable, timeout payload scores zero, aggregate pass rates
- `ruff check python`: clean
- `mypy python`: 3 pre-existing trunk errors only

## Notes

- Stacked on #28.
- Replacing regex checks with PHPCS/PHPStan-grade tooling is a natural follow-up but out of scope here.