### PR TITLE
feat: seeded stratified test selection for limited runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ grader:
 
 run:
   suite: wp-core-v1
-  limit: 10                  # limit tests (null = all)
+  limit: 10                  # limit tests (null = all); seeded stratified selection
+  seed: 1337                 # selection seed (same seed = same subset)
   test_ids: []               # optional explicit test IDs to run
   dry_run: false             # load/filter tests without calling models
   concurrency: 4             # model-call concurrency (knowledge tests)
@@ -100,7 +101,8 @@ output:
 ```bash
 # Run from project root
 wp-bench run --config wp-bench.yaml          # run with config file
-wp-bench run --model-name gpt-4o --limit 5   # quick single-model test
+wp-bench run --model-name gpt-4o --limit 5   # quick single-model test (stratified subset)
+wp-bench run --limit 5 --seed 42             # different deterministic subset
 wp-bench run --test-type knowledge           # run only knowledge tests (no WordPress env needed)
 wp-bench run --test-type execution           # run only execution tests
 wp-bench run --test-type execution --test-id e-abilities-api-001

--- a/python/tests/test_selection.py
+++ b/python/tests/test_selection.py
@@ -1,0 +1,118 @@
+"""Tests for seeded, stratified test selection on limited runs."""
+from __future__ import annotations
+
+from wp_bench.datasets import ExecutionTest
+from wp_bench.selection import select_tests, selected_test_ids
+
+
+def _test(test_id: str, category: str, difficulty: str = "basic") -> ExecutionTest:
+    return ExecutionTest(
+        id=test_id,
+        suite="wp-core-v1",
+        prompt="Prompt",
+        expected_behavior="expected",
+        test_type="execution",
+        category=category,
+        difficulty=difficulty,
+        requirements=[],
+        test_function=None,
+        static_checks={},
+        runtime_checks={},
+        reference_solution=None,
+        metadata={},
+    )
+
+
+def _fixture() -> list[ExecutionTest]:
+    """Tests ordered by category so first-N would only see 'aaa'."""
+    tests = []
+    for i in range(10):
+        tests.append(_test(f"e-aaa-{i:03d}", "aaa"))
+    for i in range(10):
+        tests.append(_test(f"e-bbb-{i:03d}", "bbb"))
+    for i in range(10):
+        tests.append(_test(f"e-ccc-{i:03d}", "ccc", difficulty="advanced"))
+    return tests
+
+
+def test_limit_selection_is_seeded_and_deterministic() -> None:
+    tests = _fixture()
+
+    first = select_tests(tests, limit=6, test_ids=[], seed=1337)
+    second = select_tests(tests, limit=6, test_ids=[], seed=1337)
+
+    assert selected_test_ids(first) == selected_test_ids(second)
+    assert len(first) == 6
+
+
+def test_limit_selection_changes_with_seed() -> None:
+    tests = _fixture()
+
+    a = select_tests(tests, limit=6, test_ids=[], seed=1)
+    b = select_tests(tests, limit=6, test_ids=[], seed=2)
+
+    assert selected_test_ids(a) != selected_test_ids(b)
+
+
+def test_selection_is_not_first_n() -> None:
+    """A limited subset must not be dominated by the first-sorted category."""
+    tests = _fixture()
+
+    selected = select_tests(tests, limit=6, test_ids=[], seed=1337)
+
+    categories = {test.category for test in selected}
+    assert categories == {"aaa", "bbb", "ccc"}
+
+
+def test_stratified_selection_balances_groups() -> None:
+    tests = _fixture()
+
+    selected = select_tests(tests, limit=6, test_ids=[], seed=1337)
+
+    per_category = {
+        category: sum(1 for t in selected if t.category == category)
+        for category in ("aaa", "bbb", "ccc")
+    }
+    assert per_category == {"aaa": 2, "bbb": 2, "ccc": 2}
+
+
+def test_explicit_test_ids_ignore_limit_and_seed() -> None:
+    tests = [_test("e-aaa-001", "aaa"), _test("e-bbb-001", "bbb")]
+
+    selected = select_tests(tests, limit=1, test_ids=["e-aaa-001", "e-bbb-001"], seed=1)
+
+    assert selected_test_ids(selected) == ["e-aaa-001", "e-bbb-001"]
+
+
+def test_no_limit_returns_all_in_dataset_order() -> None:
+    tests = _fixture()
+
+    selected = select_tests(tests, limit=None, test_ids=[], seed=1337)
+
+    assert selected is tests
+
+
+def test_limit_larger_than_dataset_returns_all() -> None:
+    tests = _fixture()
+
+    selected = select_tests(tests, limit=999, test_ids=[], seed=1337)
+
+    assert selected is tests
+
+
+def test_limit_smaller_than_group_count_touches_distinct_groups() -> None:
+    tests = _fixture()
+
+    selected = select_tests(tests, limit=2, test_ids=[], seed=1337)
+
+    assert len(selected) == 2
+    assert len({test.category for test in selected}) == 2
+
+
+def test_selected_output_is_sorted_by_id() -> None:
+    tests = _fixture()
+
+    selected = select_tests(tests, limit=6, test_ids=[], seed=1337)
+
+    ids = selected_test_ids(selected)
+    assert ids == sorted(ids)

--- a/python/wp_bench/cli.py
+++ b/python/wp_bench/cli.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from .config import HarnessConfig, ModelConfig
 from .core import BenchmarkRunner, MultiModelRunner
 from .datasets import ensure_test_ids_match_type, filter_tests_by_ids, load_tests
+from .selection import select_tests
 
 # Load .env file for API keys
 load_dotenv()
@@ -52,19 +53,25 @@ def _load_filtered_tests(harness_config: HarnessConfig) -> dict[str, list[object
 
 
 def _count_selected_tests(tests: list[object], harness_config: HarnessConfig) -> int:
-    """Count tests selected by current run settings."""
-    if harness_config.run.test_ids:
-        return len(tests)
-    if harness_config.run.limit is None:
-        return len(tests)
-    return min(harness_config.run.limit, len(tests))
+    """Count tests selected by current run settings (uses the real selector)."""
+    return len(_select_for_config(tests, harness_config))
+
+
+def _select_for_config(tests: list[object], harness_config: HarnessConfig) -> list[object]:
+    """Run the seeded stratified selector with this config's settings."""
+    return select_tests(
+        tests,
+        limit=harness_config.run.limit,
+        test_ids=harness_config.run.test_ids,
+        seed=harness_config.run.seed,
+    )
 
 
 def _print_dry_run_counts(
     tests: dict[str, list[object]],
     harness_config: HarnessConfig,
 ) -> None:
-    """Print test counts for a dry run."""
+    """Print test counts (and selected IDs when limited) for a dry run."""
     test_type = harness_config.run.test_type
     if test_type == "knowledge":
         console.print(f"Knowledge tests: {_count_selected_tests(tests['knowledge'], harness_config)}")
@@ -76,6 +83,15 @@ def _print_dry_run_counts(
             f"{_count_selected_tests(tests['execution'], harness_config)}, "
             f"Knowledge tests: {_count_selected_tests(tests['knowledge'], harness_config)}"
         )
+    if harness_config.run.limit is not None and not harness_config.run.test_ids:
+        console.print(f"Selection seed: {harness_config.run.seed}")
+        for kind in ("execution", "knowledge"):
+            if test_type not in (None, kind):
+                continue
+            selected = _select_for_config(tests[kind], harness_config)
+            if selected:
+                ids = ", ".join(test.id for test in selected)  # type: ignore[attr-defined]
+                console.print(f"Selected {kind} ids: {ids}")
 
 
 @app.command()
@@ -83,7 +99,8 @@ def run(
     config: Optional[Path] = typer.Option(None, help="Path to wp-bench YAML config"),
     suite: Optional[str] = typer.Option(None, help="Override suite name"),
     model_name: Optional[str] = typer.Option(None, help="Override model name (single model mode)"),
-    limit: Optional[int] = typer.Option(None, help="Limit number of tests"),
+    limit: Optional[int] = typer.Option(None, help="Limit number of tests (seeded stratified selection)"),
+    seed: Optional[int] = typer.Option(None, help="Seed for deterministic limited-test selection"),
     test_type: Optional[str] = typer.Option(None, help="Run only 'knowledge' or 'execution' tests"),
     dry_run: bool = typer.Option(False, help="Load and filter tests without calling models"),
     check_reference_solution: bool = typer.Option(
@@ -103,6 +120,8 @@ def run(
         harness_config.dataset.name = suite if "/" not in suite else suite
     if limit is not None:
         harness_config.run.limit = limit
+    if seed is not None:
+        harness_config.run.seed = seed
     if dry_run:
         harness_config.run.dry_run = True
     if check_reference_solution:

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -39,6 +39,7 @@ from .records import (
     sort_records,
 )
 from .scoring import SCORING_VERSION, ScoreAggregator
+from .selection import select_tests
 from .utils import ensure_dir, sha256, strip_code_fences
 
 
@@ -60,11 +61,13 @@ def _timestamped_path(path: Path) -> Path:
 
 
 def _limit_tests(tests: List[Any], config: HarnessConfig) -> List[Any]:
-    """Apply run limit unless explicit test IDs are selected."""
-    if config.run.test_ids:
-        return tests
-    limit = config.run.limit or len(tests)
-    return tests[:limit]
+    """Select tests for this run (seeded stratified selection when limited)."""
+    return select_tests(
+        tests,
+        limit=config.run.limit,
+        test_ids=config.run.test_ids,
+        seed=config.run.seed,
+    )
 
 
 def _build_verification_spec(test: Any, config: HarnessConfig) -> Dict[str, Any]:
@@ -228,6 +231,11 @@ class BenchmarkRunner:
                 "dataset": self.config.dataset.model_dump(mode="json"),
                 "runtime_isolation": self.config.run.execution_isolation,
                 "scoring_version": SCORING_VERSION,
+                "seed": self.config.run.seed,
+                "limit": self.config.run.limit,
+                "selected_test_ids": sorted(
+                    {record["test_id"] for record in self.records}
+                ),
                 "scores": {
                     "knowledge": summary.knowledge,
                     "execution_pass_rate": summary.execution_pass_rate,

--- a/python/wp_bench/selection.py
+++ b/python/wp_bench/selection.py
@@ -1,0 +1,70 @@
+"""Deterministic, stratified test selection for limited runs.
+
+When a run is limited (``run.limit``), tests are selected with a seeded,
+category/difficulty-stratified strategy instead of "first N by file
+order". First-N overrepresents whichever files sort first, which makes
+quick provider comparisons biased and misleading. Seeded selection keeps
+limited runs deterministic (same seed = same subset), tunable (different
+seed = different subset), and representative (round-robin across
+category/difficulty groups).
+"""
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from typing import Any, Dict, List
+
+
+def select_tests(
+    tests: List[Any],
+    *,
+    limit: int | None,
+    test_ids: List[str],
+    seed: int,
+) -> List[Any]:
+    """Select tests for a run, deterministically.
+
+    Rules:
+    - Explicit ``test_ids`` win: the tests are returned in dataset order,
+      unaffected by limit or seed (filtering by ID happens upstream).
+    - No limit: all tests in dataset order (canonical full-run behavior).
+    - Limit: seeded stratified sampling. Tests are grouped by
+      (category, difficulty); each group is shuffled with the seed and
+      groups are drained round-robin (in deterministic group order) until
+      the limit is reached, so small subsets still touch as many groups
+      as possible. The final selection is sorted by test id for stable
+      output.
+    """
+    if test_ids:
+        return tests
+    if limit is None or limit >= len(tests):
+        return tests
+
+    groups: Dict[Any, List[Any]] = defaultdict(list)
+    for test in tests:
+        key = (getattr(test, "category", ""), getattr(test, "difficulty", ""))
+        groups[key].append(test)
+
+    rng = random.Random(seed)
+    ordered_keys = sorted(groups.keys())
+    for key in ordered_keys:
+        rng.shuffle(groups[key])
+
+    selected: List[Any] = []
+    while len(selected) < limit:
+        progressed = False
+        for key in ordered_keys:
+            if len(selected) >= limit:
+                break
+            if groups[key]:
+                selected.append(groups[key].pop())
+                progressed = True
+        if not progressed:
+            break
+
+    return sorted(selected, key=lambda test: test.id)
+
+
+def selected_test_ids(tests: List[Any]) -> List[str]:
+    """IDs of a selection, for dry-run output and result metadata."""
+    return [test.id for test in tests]

--- a/wp-bench.example.yaml
+++ b/wp-bench.example.yaml
@@ -33,7 +33,9 @@ grader:
 # Run configuration
 run:
   suite: wp-core-v1
-  # limit: 10            # limit tests per model (null = all)
+  # limit: 10            # limit tests per model (null = all); limited runs
+  #                      # use seeded stratified selection across categories
+  # seed: 1337           # selection seed (same seed = same subset)
   # test_ids: []         # optional explicit test IDs to run
   # dry_run: false       # load/filter tests without calling models
   concurrency: 5         # model-call concurrency (knowledge tests)


### PR DESCRIPTION
## Why this matters

Nobody runs the full suite while iterating — providers, contributors, and CI all use `--limit` for quick comparisons. Today a limited run silently takes the *first N tests in file order*, which means a `--limit 10` run might test nothing but the alphabetically-first category. Two consequences: quick comparisons between models are biased by dataset file layout rather than model ability, and two people running "the same" limited benchmark can quietly be running different distributions of work. Since limited runs are how most people first experience WP-Bench, they shape first impressions of whether the benchmark is trustworthy. This change makes limited runs deterministic (same seed = same subset, so results are comparable and reproducible), tunable (different seed = different subset), and representative (stratified across category and difficulty).

## Changes

- **New selection module**: when `run.limit` is set, tests are grouped by (category, difficulty), each group is shuffled with `random.Random(seed)`, and groups are drained round-robin until the limit is reached — so even `--limit 3` touches three different groups rather than three variants of the same topic. Final selection is sorted by test id for stable output.
- **Precedence rules**: explicit `--test-id` selections bypass limit and seed entirely; full runs (no limit) keep canonical dataset order — official full-suite behavior is unchanged.
- **`run.seed` now does something**: the config field existed but was never consumed (flagged in the earlier config-audit PR); it now drives selection, with a matching `--seed` CLI option.
- **Auditability**: dry-run prints the seed and the selected test IDs; single-model result metadata records `seed`, `limit`, and `selected_test_ids`, so any results file documents exactly which subset produced it.
- Dry-run counting now uses the real selector instead of a parallel reimplementation, so displayed counts can't drift from actual behavior.

## Verification

- `pytest python`: **86 passed** (9 new: same-seed determinism, different-seed divergence, not-first-N, per-group balance, explicit-ID bypass, no-limit and over-limit passthrough, small-limit group coverage, sorted output)
- `ruff check python`: clean
- `mypy python`: 3 pre-existing trunk errors only

## Notes

- Stacked on #30.
- Full statistical sampling (e.g. difficulty-weighted quotas) is out of scope; round-robin stratification is simple, explainable, and sufficient for dev/CI subsets.