### PR TITLE
feat: add model-call retries with backoff and rate-limit handling

### DIFF
--- a/python/tests/test_model_retries.py
+++ b/python/tests/test_model_retries.py
@@ -1,0 +1,176 @@
+"""Tests for model-call retry, backoff, and rate-limit handling."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from litellm.exceptions import BadRequestError, RateLimitError, Timeout
+
+import wp_bench.models as models_module
+from wp_bench.config import ModelConfig
+from wp_bench.models import ModelInterface
+
+
+def _ok_response(text: str = "ok") -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message={"content": text})],
+        id="resp-123",
+    )
+
+
+def _rate_limit() -> RateLimitError:
+    return RateLimitError(message="rate limited", llm_provider="openai", model="gpt-4o-mini")
+
+
+def _timeout() -> Timeout:
+    return Timeout(message="timed out", model="gpt-4o-mini", llm_provider="openai")
+
+
+def _fast_config(**overrides: object) -> ModelConfig:
+    """Retry config with sub-second backoff so tests stay fast."""
+    defaults: dict = dict(
+        name="gpt-4o-mini",
+        max_retries=3,
+        retry_min_seconds=0.01,
+        retry_max_seconds=0.02,
+    )
+    defaults.update(overrides)
+    return ModelConfig.model_validate(defaults)
+
+
+def test_generate_retries_transient_error_then_succeeds(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        if len(calls) <= 2:
+            raise _rate_limit()
+        return _ok_response()
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+    model = ModelInterface(_fast_config())
+
+    generation = model.generate_with_metadata("hello")
+
+    assert generation.text == "ok"
+    assert generation.retry_count == 2
+    assert generation.provider_response_id == "resp-123"
+    assert generation.latency_ms >= 0
+    assert len(calls) == 3
+
+
+def test_generate_text_wrapper_still_works(monkeypatch) -> None:
+    monkeypatch.setattr(models_module, "completion", lambda **kwargs: _ok_response("text"))
+    model = ModelInterface(_fast_config())
+
+    assert model.generate("hello") == "text"
+
+
+def test_retry_exhaustion_raises_original_error(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        raise _rate_limit()
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+    model = ModelInterface(_fast_config(max_retries=2))
+
+    with pytest.raises(RateLimitError):
+        model.generate_with_metadata("hello")
+
+    assert len(calls) == 3  # first attempt + 2 retries
+
+
+def test_non_retryable_bad_request_fails_fast(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        raise BadRequestError(
+            message="invalid model name",
+            model="gpt-4o-mini",
+            llm_provider="openai",
+        )
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+    model = ModelInterface(_fast_config())
+
+    with pytest.raises(BadRequestError):
+        model.generate_with_metadata("hello")
+
+    assert len(calls) == 1
+
+
+def test_rate_limit_retry_can_be_disabled(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        raise _rate_limit()
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+    model = ModelInterface(_fast_config(retry_on_rate_limit=False))
+
+    with pytest.raises(RateLimitError):
+        model.generate_with_metadata("hello")
+
+    assert len(calls) == 1
+
+
+def test_timeout_retry_can_be_disabled(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        raise _timeout()
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+    model = ModelInterface(_fast_config(retry_on_timeout=False))
+
+    with pytest.raises(Timeout):
+        model.generate_with_metadata("hello")
+
+    assert len(calls) == 1
+
+
+def test_deprecated_temperature_fallback_is_flagged_not_counted(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise BadRequestError(
+                message="`temperature` is deprecated for this model.",
+                model="gpt-4o-mini",
+                llm_provider="openai",
+            )
+        return _ok_response()
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+    model = ModelInterface(_fast_config())
+
+    generation = model.generate_with_metadata("hello")
+
+    assert generation.text == "ok"
+    assert generation.temperature_fallback is True
+    assert generation.retry_count == 0  # fallback is not a transient retry
+    assert "temperature" not in calls[1]
+
+
+def test_retry_config_from_values() -> None:
+    config = ModelConfig(
+        max_retries=5,
+        retry_min_seconds=2.0,
+        retry_max_seconds=60.0,
+        retry_on_rate_limit=False,
+    )
+    assert config.max_retries == 5
+    assert config.retry_on_rate_limit is False
+
+
+def test_retry_config_rejects_invalid_bounds() -> None:
+    with pytest.raises(ValueError, match="cannot exceed"):
+        ModelConfig(retry_min_seconds=10.0, retry_max_seconds=1.0)
+    with pytest.raises(ValueError, match="must be >= 0"):
+        ModelConfig(max_retries=-1)

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -44,12 +44,31 @@ class ModelConfig(StrictModel):
     max_tokens: Optional[int] = None
     top_p: Optional[float] = None
     request_timeout: float = 300.0
+    #: Additional attempts after the first call fails with a transient
+    #: provider error (rate limit, timeout, connection, 5xx).
+    max_retries: int = 3
+    retry_min_seconds: float = 1.0
+    retry_max_seconds: float = 30.0
+    retry_on_rate_limit: bool = True
+    retry_on_timeout: bool = True
 
     @validator("temperature")
     def _clamp_temperature(cls, value: float) -> float:
         if value < 0 or value > 2:
             raise ValueError("temperature must be between 0 and 2")
         return value
+
+    @model_validator(mode="after")
+    def _validate_retry_policy(self) -> "ModelConfig":
+        if self.max_retries < 0:
+            raise ValueError("model.max_retries must be >= 0")
+        if self.retry_min_seconds <= 0 or self.retry_max_seconds <= 0:
+            raise ValueError("model retry backoff bounds must be positive")
+        if self.retry_min_seconds > self.retry_max_seconds:
+            raise ValueError(
+                "model.retry_min_seconds cannot exceed model.retry_max_seconds"
+            )
+        return self
 
 
 class GraderConfig(StrictModel):

--- a/python/wp_bench/models.py
+++ b/python/wp_bench/models.py
@@ -1,13 +1,58 @@
-"""Model interface leveraging LiteLLM providers."""
+"""Model interface leveraging LiteLLM providers.
+
+Model calls are wrapped in a bounded, configurable retry policy
+(tenacity, exponential backoff with jitter). Only transient provider
+failures are retried — rate limits, timeouts, connection drops, and
+5xx/internal errors. Deterministic request errors (bad model name, bad
+API key, context overflow, malformed request) fail fast so systemic
+problems are not hidden behind retries.
+"""
 from __future__ import annotations
 
-from typing import Any
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
 
 from litellm import completion, completion_cost
-from litellm.exceptions import BadRequestError
+from litellm.exceptions import (
+    APIConnectionError,
+    BadRequestError,
+    InternalServerError,
+    RateLimitError,
+    ServiceUnavailableError,
+    Timeout,
+)
 from litellm.utils import ModelResponse
+from tenacity import (
+    RetryCallState,
+    Retrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_random_exponential,
+)
 
 from .config import ModelConfig
+
+#: Exception types that indicate a transient provider problem.
+_TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
+    RateLimitError,
+    Timeout,
+    APIConnectionError,
+    InternalServerError,
+    ServiceUnavailableError,
+)
+
+
+@dataclass
+class ModelGeneration:
+    """A completion plus the call metadata needed for audit and reporting."""
+
+    text: str
+    raw_response: Optional[ModelResponse]
+    retry_count: int
+    latency_ms: float
+    provider_response_id: Optional[str]
+    temperature_fallback: bool = False
 
 
 class ModelInterface:
@@ -17,24 +62,81 @@ class ModelInterface:
         self.config = config
 
     def generate(self, prompt: str) -> str:
-        """Generate a completion for the given prompt.
+        """Generate a completion for the given prompt (text only).
 
-        Args:
-            prompt: The user prompt to send to the model.
+        Compatibility wrapper over generate_with_metadata().
+        """
+        return self.generate_with_metadata(prompt).text
 
-        Returns:
-            The model's response text.
+    def generate_with_metadata(self, prompt: str) -> ModelGeneration:
+        """Generate a completion with retry, latency, and call metadata.
+
+        Transient provider errors (rate limit, timeout, connection, 5xx)
+        are retried up to ``config.max_retries`` additional attempts with
+        exponential backoff and jitter. Non-retryable errors propagate
+        immediately, preserving the original exception for the caller.
+
+        Latency covers all attempts, including backoff waits, because that
+        is the wall-clock cost of obtaining the completion.
         """
         kwargs = self._completion_kwargs(prompt)
-        try:
-            response: ModelResponse = completion(**kwargs)
-        except BadRequestError as error:
-            if not _is_deprecated_temperature_error(error) or "temperature" not in kwargs:
-                raise
-            kwargs.pop("temperature")
-            response = completion(**kwargs)
+        started = time.perf_counter()
+        attempt_count = 0
+        temperature_fallback = False
+
+        def _should_retry(error: BaseException) -> bool:
+            if not self._retry_enabled_for(error):
+                return False
+            return isinstance(error, _TRANSIENT_ERRORS)
+
+        def _before(retry_state: RetryCallState) -> None:
+            nonlocal attempt_count
+            attempt_count = retry_state.attempt_number
+
+        response: Optional[ModelResponse] = None
+        for attempt in Retrying(
+            stop=stop_after_attempt(self.config.max_retries + 1),
+            wait=wait_random_exponential(
+                multiplier=self.config.retry_min_seconds,
+                max=self.config.retry_max_seconds,
+            ),
+            retry=retry_if_exception(_should_retry),
+            before=_before,
+            reraise=True,
+        ):
+            with attempt:
+                try:
+                    response = completion(**kwargs)
+                except BadRequestError as error:
+                    # Deterministic error, except the known deprecated-
+                    # temperature case which is fixable by dropping the
+                    # parameter. That fallback is intentional behavior,
+                    # not a retry, and is flagged separately.
+                    if not _is_deprecated_temperature_error(error) or "temperature" not in kwargs:
+                        raise
+                    kwargs.pop("temperature")
+                    temperature_fallback = True
+                    response = completion(**kwargs)
+
+        assert response is not None  # Retrying(reraise=True) raises otherwise
+        latency_ms = (time.perf_counter() - started) * 1000
         choice = response.choices[0]
-        return choice.message["content"]  # type: ignore[index]
+        return ModelGeneration(
+            text=choice.message["content"],  # type: ignore[union-attr, index]
+            raw_response=response,
+            retry_count=attempt_count - 1,
+            latency_ms=latency_ms,
+            provider_response_id=getattr(response, "id", None),
+            temperature_fallback=temperature_fallback,
+        )
+
+    def _retry_enabled_for(self, error: BaseException) -> bool:
+        """Apply per-category retry switches from config."""
+        if isinstance(error, RateLimitError):
+            return self.config.retry_on_rate_limit
+        if isinstance(error, Timeout):
+            return self.config.retry_on_timeout
+        return True
 
     @staticmethod
     def estimate_cost(response: ModelResponse) -> float:

--- a/wp-bench.example.yaml
+++ b/wp-bench.example.yaml
@@ -20,6 +20,13 @@ models:
 # Or use single model (legacy format):
 # model:
 #   name: gpt-4o
+#   # Retry policy for transient provider errors (rate limit, timeout,
+#   # connection, 5xx). Deterministic errors are never retried.
+#   # max_retries: 3
+#   # retry_min_seconds: 1.0
+#   # retry_max_seconds: 30.0
+#   # retry_on_rate_limit: true
+#   # retry_on_timeout: true
 
 # WordPress runtime grader
 grader:


### PR DESCRIPTION
## Why this matters

A full benchmark run means hundreds to thousands of LLM calls, often over hours. At that volume, transient provider failures are not an edge case — rate limits, timeouts, and 5xx blips are *guaranteed* to happen. Today a single one aborts the entire run: hours of compute and API spend lost, and worse, a subtle fairness problem — a provider whose endpoint hiccups once looks 'broken' while an identical model on a stabler endpoint completes. Reliability of the harness should never show up as a difference between models. At the same time, retries must not paper over real problems: a wrong model name or bad API key failing 'transiently' four times before erroring would hide systemic misconfiguration. This change draws that line explicitly.

## Changes

- **Bounded retry with backoff**: model calls are wrapped in tenacity with exponential backoff + jitter, defaulting to 3 additional attempts. Only genuinely transient errors retry — rate limit, timeout, connection failure, 5xx/internal, service unavailable.
- **Fail-fast for deterministic errors**: bad requests (invalid model, bad key, context overflow) raise immediately on the first attempt, preserving the original exception.
- **Configurable per model**: `max_retries`, `retry_min_seconds`/`retry_max_seconds` (validated: positive, min ≤ max), plus `retry_on_rate_limit` / `retry_on_timeout` switches for providers where you'd rather surface those immediately.
- **Observable**: new `generate_with_metadata()` returns a `ModelGeneration` with `retry_count`, wall-clock `latency_ms` across all attempts, `provider_response_id`, and a `temperature_fallback` flag. `generate()` stays as a text-only compatibility wrapper, so this PR changes no runner behavior — the metadata is consumed by the usage/cost capture PR that follows.
- **Existing behavior preserved**: the deprecated-temperature fallback still works, is flagged distinctly, and is not counted as a transient retry.
- Retry exhaustion re-raises the original provider exception, so run-abort semantics are unchanged (distinguishing infrastructure failures from model failures in results is deliberately left to a future resumable-runs effort).

## Verification

- `pytest python`: **95 passed** (9 new: retry-then-success with attempt counts, exhaustion re-raise, fail-fast on non-retryable, per-category disable switches, temperature-fallback flagging, backoff bound validation)
- `ruff check python`: clean
- `mypy python`: **2 errors, down from 3** — this change incidentally fixes a pre-existing union-attr error in the completion handling

## Notes

- Stacked on #31.