### PR TITLE
feat: capture token usage, latency, and estimated cost per model call

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Shared test helpers."""
+from __future__ import annotations
+
+from wp_bench.models import ModelGeneration
+
+
+def fake_generation(text: str) -> ModelGeneration:
+    """A ModelGeneration for tests that stub out the provider call."""
+    return ModelGeneration(
+        text=text,
+        raw_response=None,
+        retry_count=0,
+        latency_ms=1.0,
+        provider_response_id="test-response",
+    )

--- a/python/tests/test_dataset_metadata.py
+++ b/python/tests/test_dataset_metadata.py
@@ -24,6 +24,8 @@ from wp_bench.datasets import (
 )
 from wp_bench.environment import ExecutionResult
 
+from conftest import fake_generation
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -173,7 +175,9 @@ def test_result_record_includes_task_metadata(
         return ExecutionResult(success=True, raw=raw, stdout="", stderr="")
 
     runner.environment.execute_code = fake_execute  # type: ignore[method-assign]
-    monkeypatch.setattr(runner.model, "generate", lambda prompt: "```php\ncode\n```")
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", lambda prompt: fake_generation("```php\ncode\n```")
+    )
 
     payload = runner.run()
 

--- a/python/tests/test_execution_isolation.py
+++ b/python/tests/test_execution_isolation.py
@@ -18,6 +18,8 @@ from wp_bench.core import BenchmarkRunner, MultiModelRunner
 from wp_bench.datasets import ExecutionTest
 from wp_bench.environment import ExecutionResult
 
+from conftest import fake_generation
+
 
 def _execution_test(test_id: str) -> ExecutionTest:
     return ExecutionTest(
@@ -87,7 +89,9 @@ def test_execution_runner_resets_between_tests(
     runner = BenchmarkRunner(config)
     spy = SpyEnvironment()
     runner.environment = spy  # type: ignore[assignment]
-    monkeypatch.setattr(runner.model, "generate", lambda prompt: "```php\ncode\n```")
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", lambda prompt: fake_generation("```php\ncode\n```")
+    )
 
     runner.run()
 
@@ -142,7 +146,9 @@ def test_multi_model_runner_resets_between_models(
     monkeypatch.setattr(
         "wp_bench.core.ModelInterface",
         lambda model_config: type(
-            "FakeModel", (), {"generate": staticmethod(lambda prompt: "```php\ncode\n```")}
+            "FakeModel",
+            (),
+            {"generate_with_metadata": staticmethod(lambda prompt: fake_generation("```php\ncode\n```"))},
         )(),
     )
 
@@ -182,7 +188,9 @@ def test_result_metadata_records_isolation_mode(
     runner = BenchmarkRunner(config)
     spy = SpyEnvironment()
     runner.environment = spy  # type: ignore[assignment]
-    monkeypatch.setattr(runner.model, "generate", lambda prompt: "```php\ncode\n```")
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", lambda prompt: fake_generation("```php\ncode\n```")
+    )
 
     payload = runner.run()
 
@@ -203,7 +211,9 @@ def test_isolation_none_still_runs_all_tests(
     runner = BenchmarkRunner(config)
     spy = SpyEnvironment()
     runner.environment = spy  # type: ignore[assignment]
-    monkeypatch.setattr(runner.model, "generate", lambda prompt: "```php\ncode\n```")
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", lambda prompt: fake_generation("```php\ncode\n```")
+    )
 
     payload = runner.run()
 

--- a/python/tests/test_result_schema.py
+++ b/python/tests/test_result_schema.py
@@ -20,6 +20,8 @@ from wp_bench.datasets import ExecutionTest, KnowledgeTest
 from wp_bench.environment import ExecutionResult
 from wp_bench.records import RESULT_SCHEMA_VERSION
 
+from conftest import fake_generation
+
 
 def _execution_test(test_id: str = "e-one") -> ExecutionTest:
     return ExecutionTest(
@@ -88,7 +90,7 @@ def _single_model_records(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> li
     runner.environment.setup = lambda: None  # type: ignore[method-assign]
     runner.environment.reset = lambda: None  # type: ignore[method-assign]
     runner.environment.execute_code = lambda code, verification_spec: _passing_result()  # type: ignore[method-assign]
-    monkeypatch.setattr(runner.model, "generate", lambda prompt: "init")
+    monkeypatch.setattr(runner.model, "generate_with_metadata", lambda prompt: fake_generation("init"))
     runner.run()
     return runner.records
 
@@ -115,7 +117,7 @@ def _multi_model_records(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> lis
         environment=FakeEnvironment(),  # type: ignore[arg-type]
         tests={"execution": [_execution_test()], "knowledge": [_knowledge_test()]},
     )
-    monkeypatch.setattr(runner.model, "generate", lambda prompt: "init")
+    monkeypatch.setattr(runner.model, "generate_with_metadata", lambda prompt: fake_generation("init"))
     runner.run()
     return runner.records
 
@@ -179,11 +181,14 @@ def test_reference_solution_record_uses_canonical_schema(
 
     assert record["mode"] == "reference_solution"
     assert record["model"] is None
-    # model is intentionally null in reference mode, so nested model.* paths
-    # exist only in model mode; the record shape must match otherwise.
-    reference_paths = {p for p in _key_paths(record) if not p.startswith("model.")}
-    model_paths = {p for p in _key_paths(model_execution) if not p.startswith("model.")}
-    assert reference_paths == model_paths
+    # model and model_call are intentionally null in reference mode, so their
+    # nested paths exist only in model mode; the shape must match otherwise.
+    def _comparable(paths: set) -> set:
+        return {
+            p for p in paths if not p.startswith("model.") and not p.startswith("model_call.")
+        }
+
+    assert _comparable(_key_paths(record)) == _comparable(_key_paths(model_execution))
 
 
 def test_jsonl_records_match_json_results(
@@ -205,7 +210,7 @@ def test_jsonl_records_match_json_results(
     runner.environment.setup = lambda: None  # type: ignore[method-assign]
     runner.environment.reset = lambda: None  # type: ignore[method-assign]
     runner.environment.execute_code = lambda code, verification_spec: _passing_result()  # type: ignore[method-assign]
-    monkeypatch.setattr(runner.model, "generate", lambda prompt: "init")
+    monkeypatch.setattr(runner.model, "generate_with_metadata", lambda prompt: fake_generation("init"))
 
     runner.run()
 
@@ -242,7 +247,9 @@ def test_records_are_sorted_for_stable_output(
     runner.environment.setup = lambda: None  # type: ignore[method-assign]
     runner.environment.reset = lambda: None  # type: ignore[method-assign]
     runner.environment.execute_code = lambda code, verification_spec: _passing_result()  # type: ignore[method-assign]
-    monkeypatch.setattr(runner.model, "generate", lambda prompt: "```php\ncode\n```")
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", lambda prompt: fake_generation("```php\ncode\n```")
+    )
 
     payload = runner.run()
 

--- a/python/tests/test_usage_capture.py
+++ b/python/tests/test_usage_capture.py
@@ -1,0 +1,170 @@
+"""Tests for token usage, latency, and cost capture."""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import wp_bench.models as models_module
+from wp_bench.config import (
+    DatasetConfig,
+    GraderConfig,
+    HarnessConfig,
+    ModelConfig,
+    OutputConfig,
+    RunConfig,
+)
+from wp_bench.core import BenchmarkRunner
+from wp_bench.datasets import KnowledgeTest
+from wp_bench.models import ModelInterface
+from wp_bench.scoring import UsageAggregator
+
+
+def _response(with_usage: bool = True) -> SimpleNamespace:
+    usage = SimpleNamespace(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message={"content": "answer"})],
+        id="resp-1",
+        usage=usage if with_usage else None,
+    )
+
+
+def test_generate_with_metadata_extracts_usage(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(models_module, "completion", lambda **kwargs: _response())
+    monkeypatch.setattr(models_module, "completion_cost", lambda response: 0.0123)
+    model = ModelInterface(ModelConfig(name="gpt-4o-mini"))
+
+    generation = model.generate_with_metadata("hello")
+
+    assert generation.prompt_tokens == 100
+    assert generation.completion_tokens == 50
+    assert generation.total_tokens == 150
+    assert generation.cost_usd == 0.0123
+    assert generation.latency_ms >= 0
+
+
+def test_generate_with_metadata_handles_missing_usage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(models_module, "completion", lambda **kwargs: _response(with_usage=False))
+    monkeypatch.setattr(models_module, "completion_cost", lambda response: 0.0)
+    model = ModelInterface(ModelConfig(name="gpt-4o-mini"))
+
+    generation = model.generate_with_metadata("hello")
+
+    assert generation.prompt_tokens is None
+    assert generation.completion_tokens is None
+    assert generation.total_tokens is None
+
+
+def test_cost_estimation_failure_does_not_abort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def broken_cost(response: object) -> float:
+        raise RuntimeError("no pricing for model")
+
+    monkeypatch.setattr(models_module, "completion", lambda **kwargs: _response())
+    monkeypatch.setattr(models_module, "completion_cost", broken_cost)
+    model = ModelInterface(ModelConfig(name="local/unknown-model"))
+
+    generation = model.generate_with_metadata("hello")
+
+    assert generation.text == "answer"
+    assert generation.cost_usd is None
+
+
+def test_usage_dict_shape_matches_canonical_records(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(models_module, "completion", lambda **kwargs: _response())
+    monkeypatch.setattr(models_module, "completion_cost", lambda response: 0.01)
+    model = ModelInterface(ModelConfig(name="gpt-4o-mini"))
+
+    usage = model.generate_with_metadata("hello").usage_dict()
+
+    assert set(usage.keys()) == {
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "cost_usd",
+        "latency_ms",
+    }
+
+
+def test_usage_aggregator_sums_and_percentiles() -> None:
+    aggregator = UsageAggregator()
+    for latency in (100.0, 200.0, 300.0, 400.0, 500.0):
+        aggregator.add(
+            {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+                "cost_usd": 0.01,
+                "latency_ms": latency,
+            }
+        )
+
+    summary = aggregator.summary()
+
+    assert summary["prompt_tokens"] == 50
+    assert summary["completion_tokens"] == 25
+    assert summary["total_tokens"] == 75
+    assert summary["estimated_cost_usd"] == 0.05
+    assert summary["median_latency_ms"] == 300.0
+    assert summary["p95_latency_ms"] == 500.0
+
+
+def test_usage_aggregator_tolerates_missing_fields() -> None:
+    aggregator = UsageAggregator()
+    aggregator.add({"latency_ms": 100.0})
+    aggregator.add(None)
+    aggregator.add({"prompt_tokens": None, "cost_usd": None})
+
+    summary = aggregator.summary()
+
+    assert summary["total_tokens"] == 0
+    assert summary["estimated_cost_usd"] is None
+    assert summary["median_latency_ms"] == 100.0
+
+
+def test_result_record_contains_usage_and_model_call(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    test = KnowledgeTest(
+        id="k-one",
+        suite="wp-core-v1",
+        prompt="What hook runs on init?",
+        test_type="knowledge",
+        category="hooks",
+        difficulty="basic",
+        correct_answer="init",
+        answer_type="short_answer",
+    )
+    config = HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        model=ModelConfig(name="gpt-4o-mini"),
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(test_type="knowledge"),
+        output=OutputConfig(path=tmp_path / "results.json", jsonl_path=None),
+    )
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": [], "knowledge": [test]},
+    )
+    monkeypatch.setattr(models_module, "completion", lambda **kwargs: _response())
+    monkeypatch.setattr(models_module, "completion_cost", lambda response: 0.002)
+    runner = BenchmarkRunner(config)
+
+    payload = runner.run()
+
+    record = payload["results"][0]
+    assert record["usage"]["prompt_tokens"] == 100
+    assert record["usage"]["cost_usd"] == 0.002
+    assert record["usage"]["latency_ms"] >= 0
+    assert record["model_call"]["retry_count"] == 0
+    assert record["model_call"]["provider_response_id"] == "resp-1"
+    run_usage = payload["metadata"]["usage"]
+    assert run_usage["total_tokens"] == 150
+    assert run_usage["estimated_cost_usd"] == 0.002

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -38,7 +38,7 @@ from .records import (
     execution_record_passed,
     sort_records,
 )
-from .scoring import SCORING_VERSION, ScoreAggregator
+from .scoring import SCORING_VERSION, ScoreAggregator, UsageAggregator
 from .selection import select_tests
 from .utils import ensure_dir, sha256, strip_code_fences
 
@@ -109,6 +109,15 @@ def _build_verification_spec(test: Any, config: HarnessConfig) -> Dict[str, Any]
     }
 
 
+def _model_call_info(generation: Any) -> Dict[str, Any]:
+    """Call-reliability metadata recorded alongside each test result."""
+    return {
+        "retry_count": generation.retry_count,
+        "provider_response_id": generation.provider_response_id,
+        "temperature_fallback": generation.temperature_fallback,
+    }
+
+
 def _run_isolated_execution_loop(
     *,
     tests_to_run: List[Any],
@@ -176,6 +185,7 @@ class BenchmarkRunner:
         self.model = ModelInterface(config.model or config.get_models()[0])
         self.environment = WordPressEnvironment(config.grader)
         self.aggregator = ScoreAggregator()
+        self.usage_aggregator = UsageAggregator()
         self.records: List[Dict[str, Any]] = []
         self._lock = threading.Lock()
 
@@ -236,6 +246,7 @@ class BenchmarkRunner:
                 "selected_test_ids": sorted(
                     {record["test_id"] for record in self.records}
                 ),
+                "usage": self.usage_aggregator.summary(),
                 "scores": {
                     "knowledge": summary.knowledge,
                     "execution_pass_rate": summary.execution_pass_rate,
@@ -292,17 +303,19 @@ class BenchmarkRunner:
         def process_test(test: KnowledgeTest) -> Dict[str, Any]:
             try:
                 prompt = self._render_knowledge_prompt(test)
-                raw_completion = self.model.generate(prompt)
-                answer = strip_code_fences(raw_completion).strip()
+                generation = self.model.generate_with_metadata(prompt)
+                answer = strip_code_fences(generation.text).strip()
                 correct = score_knowledge_answer(test, answer)
                 return build_knowledge_record(
                     test=test,
                     mode="model",
                     model_config=self.config.model,
                     prompt_hash=sha256(prompt),
-                    raw_completion=raw_completion,
+                    raw_completion=generation.text,
                     answer=answer,
                     knowledge_score=correct,
+                    usage=generation.usage_dict(),
+                    model_call=_model_call_info(generation),
                 )
             except Exception as e:
                 raise TestError(test.id, "knowledge", e) from e
@@ -316,6 +329,7 @@ class BenchmarkRunner:
                         result = future.result()
                         with self._lock:
                             self.aggregator.add_knowledge(result["scores"]["knowledge"])
+                            self.usage_aggregator.add(result.get("usage"))
                             self.records.append(result)
                         progress.update(task, advance=1)
                     except TestError:
@@ -341,8 +355,8 @@ class BenchmarkRunner:
             """Process a single execution test."""
             try:
                 prompt = self._render_execution_prompt(test)
-                completion = self.model.generate(prompt)
-                code = strip_code_fences(completion)
+                generation = self.model.generate_with_metadata(prompt)
+                code = strip_code_fences(generation.text)
                 verification_spec = _build_verification_spec(test, self.config)
                 env_result = self.environment.execute_code(code, verification_spec)
                 scores = self._score_execution(
@@ -356,10 +370,12 @@ class BenchmarkRunner:
                     mode="model",
                     model_config=self.config.model,
                     prompt_hash=sha256(prompt),
-                    raw_completion=completion,
+                    raw_completion=generation.text,
                     code=code,
                     env_result=env_result,
                     scores=scores,
+                    usage=generation.usage_dict(),
+                    model_call=_model_call_info(generation),
                 )
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
@@ -367,6 +383,7 @@ class BenchmarkRunner:
         def on_result(result: Dict[str, Any]) -> None:
             with self._lock:
                 self.aggregator.add_execution(result["scores"])
+                self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
 
         _run_isolated_execution_loop(
@@ -410,6 +427,7 @@ class BenchmarkRunner:
         def on_result(result: Dict[str, Any]) -> None:
             with self._lock:
                 self.aggregator.add_execution(result["scores"])
+                self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
 
         _run_isolated_execution_loop(
@@ -720,6 +738,7 @@ class SingleModelRunner:
         self.environment = environment
         self.tests = tests
         self.aggregator = ScoreAggregator()
+        self.usage_aggregator = UsageAggregator()
         self.records: List[Dict[str, Any]] = []
         self._lock = threading.Lock()
 
@@ -738,6 +757,7 @@ class SingleModelRunner:
         return {
             "model_config": self.model_config.model_dump(mode="json"),
             "scoring_version": SCORING_VERSION,
+            "usage": self.usage_aggregator.summary(),
             "scores": {
                 "knowledge": summary.knowledge,
                 "execution_pass_rate": summary.execution_pass_rate,
@@ -757,17 +777,19 @@ class SingleModelRunner:
         def process_test(test: KnowledgeTest) -> Dict[str, Any]:
             try:
                 prompt = BenchmarkRunner._render_knowledge_prompt(test)
-                raw_completion = self.model.generate(prompt)
-                answer = strip_code_fences(raw_completion).strip()
+                generation = self.model.generate_with_metadata(prompt)
+                answer = strip_code_fences(generation.text).strip()
                 correct = score_knowledge_answer(test, answer)
                 return build_knowledge_record(
                     test=test,
                     mode="model",
                     model_config=self.model_config,
                     prompt_hash=sha256(prompt),
-                    raw_completion=raw_completion,
+                    raw_completion=generation.text,
                     answer=answer,
                     knowledge_score=correct,
+                    usage=generation.usage_dict(),
+                    model_call=_model_call_info(generation),
                 )
             except Exception as e:
                 raise TestError(test.id, "knowledge", e) from e
@@ -781,6 +803,7 @@ class SingleModelRunner:
                         result = future.result()
                         with self._lock:
                             self.aggregator.add_knowledge(result["scores"]["knowledge"])
+                            self.usage_aggregator.add(result.get("usage"))
                             self.records.append(result)
                         progress.update(task, advance=1)
                     except TestError:
@@ -795,8 +818,8 @@ class SingleModelRunner:
         def process_test(test: ExecutionTest) -> Dict[str, Any]:
             try:
                 prompt = BenchmarkRunner._render_execution_prompt(test)
-                completion = self.model.generate(prompt)
-                code = strip_code_fences(completion)
+                generation = self.model.generate_with_metadata(prompt)
+                code = strip_code_fences(generation.text)
                 verification_spec = _build_verification_spec(test, self.config)
                 env_result = self.environment.execute_code(code, verification_spec)
                 scores = BenchmarkRunner._score_execution(
@@ -810,10 +833,12 @@ class SingleModelRunner:
                     mode="model",
                     model_config=self.model_config,
                     prompt_hash=sha256(prompt),
-                    raw_completion=completion,
+                    raw_completion=generation.text,
                     code=code,
                     env_result=env_result,
                     scores=scores,
+                    usage=generation.usage_dict(),
+                    model_call=_model_call_info(generation),
                 )
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
@@ -821,6 +846,7 @@ class SingleModelRunner:
         def on_result(result: Dict[str, Any]) -> None:
             with self._lock:
                 self.aggregator.add_execution(result["scores"])
+                self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
 
         _run_isolated_execution_loop(

--- a/python/wp_bench/models.py
+++ b/python/wp_bench/models.py
@@ -53,6 +53,20 @@ class ModelGeneration:
     latency_ms: float
     provider_response_id: Optional[str]
     temperature_fallback: bool = False
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    cost_usd: Optional[float] = None
+
+    def usage_dict(self) -> dict[str, Any]:
+        """Usage object in the canonical result-record shape."""
+        return {
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+            "cost_usd": self.cost_usd,
+            "latency_ms": round(self.latency_ms, 1),
+        }
 
 
 class ModelInterface:
@@ -121,6 +135,7 @@ class ModelInterface:
         assert response is not None  # Retrying(reraise=True) raises otherwise
         latency_ms = (time.perf_counter() - started) * 1000
         choice = response.choices[0]
+        usage = _extract_usage(response)
         return ModelGeneration(
             text=choice.message["content"],  # type: ignore[union-attr, index]
             raw_response=response,
@@ -128,6 +143,10 @@ class ModelInterface:
             latency_ms=latency_ms,
             provider_response_id=getattr(response, "id", None),
             temperature_fallback=temperature_fallback,
+            prompt_tokens=usage["prompt_tokens"],
+            completion_tokens=usage["completion_tokens"],
+            total_tokens=usage["total_tokens"],
+            cost_usd=_estimate_cost_safe(response),
         )
 
     def _retry_enabled_for(self, error: BaseException) -> bool:
@@ -156,3 +175,38 @@ class ModelInterface:
 
 def _is_deprecated_temperature_error(error: BadRequestError) -> bool:
     return "`temperature` is deprecated" in str(error)
+
+
+def _extract_usage(response: Any) -> dict[str, Optional[int]]:
+    """Read token usage defensively; providers may omit any field."""
+    usage = getattr(response, "usage", None)
+    if usage is None and isinstance(response, dict):
+        usage = response.get("usage")
+
+    def _read(field: str) -> Optional[int]:
+        if usage is None:
+            return None
+        value = getattr(usage, field, None)
+        if value is None and isinstance(usage, dict):
+            value = usage.get(field)
+        return int(value) if isinstance(value, (int, float)) else None
+
+    return {
+        "prompt_tokens": _read("prompt_tokens"),
+        "completion_tokens": _read("completion_tokens"),
+        "total_tokens": _read("total_tokens"),
+    }
+
+
+def _estimate_cost_safe(response: Any) -> Optional[float]:
+    """Best-effort cost estimate via LiteLLM; None when unpriceable.
+
+    Cost is an estimate, not billing truth: unknown models, custom
+    endpoints, and local providers have no pricing data, and estimation
+    failures must never abort a benchmark run.
+    """
+    try:
+        cost = completion_cost(response)
+    except Exception:
+        return None
+    return float(cost) if isinstance(cost, (int, float)) else None

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -84,18 +84,29 @@ def print_comparison_table(results: Dict[str, Dict[str, Any]]) -> None:
     table.add_column("Execution Pass", justify="right")
     table.add_column("Runtime Partial", justify="right")
     table.add_column("Overall", justify="right", style="bold")
+    table.add_column("Est. Cost", justify="right")
+    table.add_column("Median Latency", justify="right")
 
     def _fmt_score(value: float | None) -> str:
         return f"{value*100:.1f}%" if value is not None else "N/A"
 
+    def _fmt_cost(value: float | None) -> str:
+        return f"${value:.4f}" if value is not None else "N/A"
+
+    def _fmt_latency(value: float | None) -> str:
+        return f"{value:.0f}ms" if value is not None else "N/A"
+
     for model_name, result in results.items():
         scores = result["scores"]
+        usage = result.get("usage") or {}
         table.add_row(
             model_name,
             _fmt_score(scores.get("knowledge")),
             _fmt_score(scores.get("execution_pass_rate")),
             _fmt_score(scores.get("runtime")),
             f"{scores['overall']*100:.1f}%",
+            _fmt_cost(usage.get("estimated_cost_usd")),
+            _fmt_latency(usage.get("median_latency_ms")),
         )
 
     console.print(table)

--- a/python/wp_bench/records.py
+++ b/python/wp_bench/records.py
@@ -48,6 +48,8 @@ def build_knowledge_record(
     raw_completion: str,
     answer: str,
     knowledge_score: float,
+    usage: Optional[Dict[str, Any]] = None,
+    model_call: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build the canonical record for a knowledge test result."""
     return {
@@ -74,7 +76,8 @@ def build_knowledge_record(
             "static_policy_pass": None,
         },
         "grader": None,
-        "usage": _empty_usage(),
+        "usage": usage if usage is not None else _empty_usage(),
+        "model_call": model_call,
         "error": None,
     }
 
@@ -89,6 +92,8 @@ def build_execution_record(
     code: str,
     env_result: Any,
     scores: Dict[str, Any],
+    usage: Optional[Dict[str, Any]] = None,
+    model_call: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build the canonical record for an execution test result.
 
@@ -121,7 +126,8 @@ def build_execution_record(
             "stderr": env_result.stderr,
             "timeout": bool(raw.get("timeout", False)) or getattr(env_result, "timed_out", False),
         },
-        "usage": _empty_usage(),
+        "usage": usage if usage is not None else _empty_usage(),
+        "model_call": model_call,
         "error": None,
     }
 

--- a/python/wp_bench/scoring.py
+++ b/python/wp_bench/scoring.py
@@ -49,6 +49,55 @@ class ScoreBreakdown:
         return round(total / total_weight, 4)
 
 
+def _percentile(values: List[float], fraction: float) -> float:
+    """Nearest-rank percentile; values need not be pre-sorted."""
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, round(fraction * (len(ordered) - 1))))
+    return ordered[index]
+
+
+class UsageAggregator:
+    """Accumulates per-call usage into a run-level summary."""
+
+    def __init__(self) -> None:
+        self.prompt_tokens = 0
+        self.completion_tokens = 0
+        self.total_tokens = 0
+        self.cost_usd = 0.0
+        self.has_cost = False
+        self.latencies_ms: List[float] = []
+
+    def add(self, usage: Optional[Dict[str, Any]]) -> None:
+        if not isinstance(usage, dict):
+            return
+        for token_field in ("prompt_tokens", "completion_tokens", "total_tokens"):
+            value = usage.get(token_field)
+            if isinstance(value, (int, float)):
+                setattr(self, token_field, getattr(self, token_field) + int(value))
+        cost = usage.get("cost_usd")
+        if isinstance(cost, (int, float)):
+            self.cost_usd += float(cost)
+            self.has_cost = True
+        latency = usage.get("latency_ms")
+        if isinstance(latency, (int, float)):
+            self.latencies_ms.append(float(latency))
+
+    def summary(self) -> Dict[str, Any]:
+        """Run-level usage summary; cost is an estimate, not billing truth."""
+        return {
+            "prompt_tokens": self.prompt_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+            "estimated_cost_usd": round(self.cost_usd, 6) if self.has_cost else None,
+            "median_latency_ms": (
+                round(_percentile(self.latencies_ms, 0.5), 1) if self.latencies_ms else None
+            ),
+            "p95_latency_ms": (
+                round(_percentile(self.latencies_ms, 0.95), 1) if self.latencies_ms else None
+            ),
+        }
+
+
 class ScoreAggregator:
     def __init__(self) -> None:
         self.knowledge_scores: List[float] = []


### PR DESCRIPTION
## Why this matters

For the people WP-Bench is ultimately for — WordPress users and agencies picking a model to build with — quality is only half the decision. A model that scores 2% higher but costs 10× more and responds 3× slower is the wrong default for most WordPress automation, and right now the benchmark can't surface that trade-off at all. Providers have the mirror-image need: when their model is ranked publicly, they want the usage records (tokens, response IDs) to reproduce and validate the run against their own logs. The unified result schema already reserved a `usage` object on every record; this PR fills it with real data and rolls it up per run, turning WP-Bench from a pure quality leaderboard into a quality/cost/latency comparison.

## Changes

- **Per-call capture**: every model call now records prompt/completion/total tokens (read defensively — providers may omit any field), wall-clock latency across all retry attempts, and estimated cost via LiteLLM's pricing tables. Cost is explicitly labeled *estimated*: unknown or local models yield `null`, and a cost-estimation failure can never abort a benchmark run.
- **Per-record audit trail**: each result includes `usage` plus a `model_call` object (`retry_count`, `provider_response_id`, `temperature_fallback`) so any individual score can be cross-checked against provider logs. Reference-solution mode records `model_call: null`, consistent with its `model: null`.
- **Run-level rollups**: token totals, `estimated_cost_usd`, median and p95 latency — in single-model payload metadata and per-model results in multi-model mode.
- **Comparison table** gains Est. Cost and Median Latency columns (N/A when unavailable), so the cost/quality trade-off is visible at a glance without cluttering the score columns.

## Verification

- `pytest python`: **102 passed** (7 new: usage extraction, missing-usage nulls, cost-failure tolerance, canonical usage shape, aggregation sums and percentile math, end-to-end presence in records and run metadata)
- `ruff check python`: clean
- `mypy python`: 2 pre-existing trunk errors only

## Notes

- Stacked on #32, which introduced the `ModelGeneration` metadata seam this consumes.
- Exact billing parity with providers is a non-goal; estimates are best-effort and clearly labeled.