### PR TITLE
refactor: pass verifier payload via stdin instead of base64 argv

### DIFF
--- a/python/tests/test_environment.py
+++ b/python/tests/test_environment.py
@@ -1,20 +1,21 @@
 from __future__ import annotations
 
-import base64
 import json
 from pathlib import Path
+from typing import Optional
 
 from wp_bench.config import GraderConfig
 from wp_bench.environment import WordPressEnvironment
 
 
 def test_execute_code_uses_internal_runtime_verifier_for_wp_env() -> None:
-    calls: list[list[str]] = []
+    calls: list[tuple[list[str], Optional[str]]] = []
     environment = WordPressEnvironment(GraderConfig(kind="docker", wp_env_dir=Path("runtime")))
 
-    def fake_exec(command: list[str]) -> tuple[str, str, int, bool]:
-        calls.append(command)
-        payload = json.loads(base64.b64decode(command[3]).decode("utf-8"))
+    def fake_exec(command: list[str], *, stdin: Optional[str] = None) -> tuple[str, str, int, bool]:
+        calls.append((command, stdin))
+        assert stdin is not None
+        payload = json.loads(stdin)
         assert payload["code"] == "function demo() { return true; }"
         assert payload["static_checks"] == {"required_patterns": []}
         assert payload["runtime_checks"] == {"assertions": []}
@@ -31,11 +32,8 @@ def test_execute_code_uses_internal_runtime_verifier_for_wp_env() -> None:
     )
 
     assert result.success is True
-    assert calls == [
-        [
-            "wp",
-            "eval-file",
-            "/var/www/html/wp-content/plugins/runtime/verify-runtime.php",
-            calls[0][3],
-        ]
+    assert calls[0][0] == [
+        "wp",
+        "eval-file",
+        "/var/www/html/wp-content/plugins/runtime/verify-runtime.php",
     ]

--- a/python/tests/test_payload_transport.py
+++ b/python/tests/test_payload_transport.py
@@ -1,0 +1,75 @@
+"""Tests for the stdin payload transport to the runtime verifier."""
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+
+import pytest
+
+from wp_bench.config import GraderConfig
+from wp_bench.environment import WordPressEnvironment
+
+
+def _capture_run(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Stub subprocess.run and capture how it was invoked."""
+    seen: dict[str, Any] = {}
+
+    def fake_run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess:
+        seen["command"] = command
+        seen["input"] = kwargs.get("input")
+        return subprocess.CompletedProcess(
+            args=command, returncode=0, stdout='{"success": true}', stderr=""
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return seen
+
+
+def test_execute_code_sends_payload_via_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _capture_run(monkeypatch)
+    environment = WordPressEnvironment(GraderConfig(kind="cli"))
+
+    environment.execute_code("function demo() {}", {"static_checks": {}, "runtime_checks": {}})
+
+    payload = json.loads(seen["input"])
+    assert payload["code"] == "function demo() {}"
+    assert payload["payload_version"] == "1.0"
+    # Payload must not appear in argv.
+    assert all("demo" not in part for part in seen["command"])
+
+
+def test_command_stays_small_for_large_payloads(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A payload far beyond argv limits must not grow the command line."""
+    seen = _capture_run(monkeypatch)
+    environment = WordPressEnvironment(GraderConfig(kind="cli"))
+    huge_code = "x" * 2_000_000  # ~2MB, well past typical ARG_MAX
+
+    environment.execute_code(huge_code, {"static_checks": {}, "runtime_checks": {}})
+
+    command_size = sum(len(part) for part in seen["command"])
+    assert command_size < 1024
+    assert len(seen["input"]) > 2_000_000
+
+
+def test_payload_is_plain_json_not_base64(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = _capture_run(monkeypatch)
+    environment = WordPressEnvironment(GraderConfig(kind="cli"))
+
+    environment.execute_code("code", {"static_checks": {"a": 1}, "runtime_checks": {}})
+
+    # Directly parseable as JSON: no base64 layer.
+    payload = json.loads(seen["input"])
+    assert payload["static_checks"] == {"a": 1}
+
+
+def test_docker_path_pipes_stdin_through_docker_exec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = _capture_run(monkeypatch)
+    environment = WordPressEnvironment(GraderConfig(kind="docker"))
+
+    environment.execute_code("code", {})
+
+    assert seen["command"][:3] == ["docker", "exec", "-i"]
+    assert json.loads(seen["input"])["code"] == "code"

--- a/python/wp_bench/environment.py
+++ b/python/wp_bench/environment.py
@@ -1,7 +1,6 @@
 """Bridge between Python harness and WordPress runtime."""
 from __future__ import annotations
 
-import base64
 import json
 import subprocess
 from dataclasses import dataclass
@@ -93,18 +92,17 @@ class WordPressEnvironment:
         timeout and continues with the next test.
         """
         payload = {
+            "payload_version": "1.0",
             "code": code,
             **verification_spec,
         }
-        encoded = base64.b64encode(json.dumps(payload).encode("utf-8")).decode("utf-8")
         verifier_path = self._runtime_verifier_path()
         cmd = [
             "wp",
             "eval-file",
             verifier_path,
-            encoded,
         ]
-        stdout, stderr, rc, timed_out = self._exec(cmd)
+        stdout, stderr, rc, timed_out = self._exec(cmd, stdin=json.dumps(payload))
         if timed_out:
             return ExecutionResult(
                 success=False,
@@ -158,6 +156,7 @@ class WordPressEnvironment:
         cwd: Optional[str] = None,
         timeout: Optional[float] = None,
         capture_output: bool = True,
+        stdin: Optional[str] = None,
     ) -> ProcessResult:
         """Run a subprocess with a hard timeout.
 
@@ -174,6 +173,7 @@ class WordPressEnvironment:
                 check=False,
                 cwd=cwd,
                 timeout=timeout,
+                input=stdin,
             )
             return ProcessResult(
                 stdout=proc.stdout if capture_output else "",
@@ -238,8 +238,19 @@ class WordPressEnvironment:
                 f"Failed to start container '{self.config.container_name}': {result.stderr.strip()}"
             )
 
-    def _exec(self, command: list[str]) -> tuple[str, str, int, bool]:
+    def _exec(
+        self,
+        command: list[str],
+        *,
+        stdin: Optional[str] = None,
+    ) -> tuple[str, str, int, bool]:
         """Execute a command in the WordPress runtime.
+
+        Args:
+            command: WP-CLI command to run inside the runtime.
+            stdin: Optional data piped to the process. Used for verifier
+                payloads, which must not travel as command arguments
+                (argv size limits, visible in process listings).
 
         Returns:
             Tuple of (stdout, stderr, returncode, timed_out). All paths are
@@ -251,9 +262,10 @@ class WordPressEnvironment:
                 ["npx", "wp-env", "run", "cli", *command],
                 cwd=str(self.config.wp_env_dir),
                 timeout=timeout,
+                stdin=stdin,
             )
         elif self.config.kind == "cli":
-            result = self._run_process(command, timeout=timeout)
+            result = self._run_process(command, timeout=timeout, stdin=stdin)
         else:
             docker_cmd = [
                 "docker",
@@ -262,7 +274,7 @@ class WordPressEnvironment:
                 self.config.container_name,
                 *command,
             ]
-            result = self._run_process(docker_cmd, timeout=timeout)
+            result = self._run_process(docker_cmd, timeout=timeout, stdin=stdin)
         return result.stdout, result.stderr, result.returncode, result.timed_out
 
     def _run_wp_env(self, command: list[str]) -> None:

--- a/runtime/verify-runtime.php
+++ b/runtime/verify-runtime.php
@@ -1,6 +1,11 @@
 <?php
 /**
  * Internal WP-Bench verifier entrypoint for wp eval-file.
+ *
+ * Payload transport: JSON on stdin (preferred). A base64-encoded JSON
+ * command argument is still accepted as a deprecated fallback; it is
+ * limited by OS argv size and leaks payload content into process
+ * listings, so new callers must use stdin.
  */
 
 use WPBench\Runtime\Verifier;
@@ -9,20 +14,41 @@ require_once __DIR__ . '/src/class-sandbox.php';
 require_once __DIR__ . '/src/class-static-analysis.php';
 require_once __DIR__ . '/src/class-verifier.php';
 
-$payload_b64 = $args[0] ?? '';
-if ( ! is_string( $payload_b64 ) || '' === $payload_b64 ) {
-	WP_CLI::error( 'Missing payload argument.' );
+/**
+ * Read the verification payload from stdin or the legacy argument.
+ *
+ * @param array<int, mixed> $args Positional args from WP-CLI.
+ * @return array<string, mixed> Decoded payload.
+ */
+function wp_bench_read_payload( array $args ): array {
+	$stdin_json = file_get_contents( 'php://stdin' );
+	if ( is_string( $stdin_json ) && '' !== trim( $stdin_json ) ) {
+		$payload = json_decode( $stdin_json, true );
+		if ( ! is_array( $payload ) ) {
+			WP_CLI::error( 'Stdin payload is not valid JSON.' );
+		}
+		return $payload;
+	}
+
+	// Deprecated: base64 argument transport.
+	$payload_b64 = $args[0] ?? '';
+	if ( ! is_string( $payload_b64 ) || '' === $payload_b64 ) {
+		WP_CLI::error( 'Missing payload: pass JSON via stdin (preferred) or a base64 argument (deprecated).' );
+	}
+
+	$payload_json = base64_decode( $payload_b64, true );
+	if ( false === $payload_json ) {
+		WP_CLI::error( 'Invalid payload encoding.' );
+	}
+
+	$payload = json_decode( $payload_json, true );
+	if ( ! is_array( $payload ) ) {
+		WP_CLI::error( 'Payload is not valid JSON.' );
+	}
+
+	return $payload;
 }
 
-$payload_json = base64_decode( $payload_b64, true );
-if ( false === $payload_json ) {
-	WP_CLI::error( 'Invalid payload encoding.' );
-}
-
-$payload = json_decode( $payload_json, true );
-if ( ! is_array( $payload ) ) {
-	WP_CLI::error( 'Payload is not valid JSON.' );
-}
-
+$payload  = wp_bench_read_payload( $args );
 $verifier = new Verifier();
 WP_CLI::line( wp_json_encode( $verifier->verify_payload( $payload ), JSON_PRETTY_PRINT ) );

--- a/runtime/verify-runtime.php
+++ b/runtime/verify-runtime.php
@@ -2,10 +2,9 @@
 /**
  * Internal WP-Bench verifier entrypoint for wp eval-file.
  *
- * Payload transport: JSON on stdin (preferred). A base64-encoded JSON
- * command argument is still accepted as a deprecated fallback; it is
- * limited by OS argv size and leaks payload content into process
- * listings, so new callers must use stdin.
+ * Payload transport: JSON on stdin. Payloads must not travel as command
+ * arguments — argv has OS size limits and leaks payload content into
+ * process listings.
  */
 
 use WPBench\Runtime\Verifier;
@@ -14,41 +13,15 @@ require_once __DIR__ . '/src/class-sandbox.php';
 require_once __DIR__ . '/src/class-static-analysis.php';
 require_once __DIR__ . '/src/class-verifier.php';
 
-/**
- * Read the verification payload from stdin or the legacy argument.
- *
- * @param array<int, mixed> $args Positional args from WP-CLI.
- * @return array<string, mixed> Decoded payload.
- */
-function wp_bench_read_payload( array $args ): array {
-	$stdin_json = file_get_contents( 'php://stdin' );
-	if ( is_string( $stdin_json ) && '' !== trim( $stdin_json ) ) {
-		$payload = json_decode( $stdin_json, true );
-		if ( ! is_array( $payload ) ) {
-			WP_CLI::error( 'Stdin payload is not valid JSON.' );
-		}
-		return $payload;
-	}
-
-	// Deprecated: base64 argument transport.
-	$payload_b64 = $args[0] ?? '';
-	if ( ! is_string( $payload_b64 ) || '' === $payload_b64 ) {
-		WP_CLI::error( 'Missing payload: pass JSON via stdin (preferred) or a base64 argument (deprecated).' );
-	}
-
-	$payload_json = base64_decode( $payload_b64, true );
-	if ( false === $payload_json ) {
-		WP_CLI::error( 'Invalid payload encoding.' );
-	}
-
-	$payload = json_decode( $payload_json, true );
-	if ( ! is_array( $payload ) ) {
-		WP_CLI::error( 'Payload is not valid JSON.' );
-	}
-
-	return $payload;
+$payload_json = file_get_contents( 'php://stdin' );
+if ( ! is_string( $payload_json ) || '' === trim( $payload_json ) ) {
+	WP_CLI::error( 'Missing payload: pass JSON via stdin.' );
 }
 
-$payload  = wp_bench_read_payload( $args );
+$payload = json_decode( $payload_json, true );
+if ( ! is_array( $payload ) ) {
+	WP_CLI::error( 'Stdin payload is not valid JSON.' );
+}
+
 $verifier = new Verifier();
 WP_CLI::line( wp_json_encode( $verifier->verify_payload( $payload ), JSON_PRETTY_PRINT ) );


### PR DESCRIPTION
## Why this matters

Every execution test ships its payload — the model's generated code plus all verification checks — to the WordPress runtime as a single base64 command-line argument. That transport has two hard problems. First, argv has an OS-level size cap, which silently bounds how large a candidate solution can be; that's tolerable for one-function snippets but a dead end for where the benchmark is headed (multi-file plugins, block plugins, themes). Second, command arguments are visible to anyone who can read a process listing, so the full payload — including checks a task author may not want exposed — leaks on any shared machine. Moving transport to stdin removes both constraints now, so the upcoming artifact-execution work builds on a transport that can already carry it.

## Changes

- **Python side**: the payload is now plain JSON (tagged `payload_version: 1.0`) piped through stdin; the command line carries only the `wp eval-file <verifier>` invocation. Stdin plumbing runs through all three runtime paths (wp-env, local CLI, `docker exec -i`).
- **PHP verifier**: reads `php://stdin` exclusively and errors clearly when the payload is missing or not valid JSON. The base64-argument transport is **removed entirely** — the project is early alpha with a single in-tree caller, so carrying a legacy path would preserve exactly the flaws (argv cap, process-listing leak) this PR exists to eliminate.
- **No base64 anywhere**: payloads are directly inspectable JSON at both ends, which also makes debugging verifier issues simpler.

## Verification

- `pytest python`: **106 passed** (4 new: payload arrives via stdin and never in argv, a ~2MB payload keeps the command line under 1KB, payload is plain JSON with no base64 layer, docker path pipes through `docker exec -i`)
- `php -l runtime/verify-runtime.php`: no syntax errors
- `ruff check python`: clean
- `mypy python`: 2 pre-existing trunk errors only
- Live wp-env round-trip not run here (no local runtime up); the artifact-mode PR that follows exercises this transport further, and the release checklist gates official runs on a full runtime verification.

## Notes

- Stacked on #33.
- **Breaking change** to the verifier invocation contract (stdin-only): fine at this stage — early alpha, no external callers to migrate.
- Transport only: payload schema is unchanged apart from the added `payload_version` field.