### PR TITLE
feat: add wp_plugin_files artifact execution mode

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -71,6 +71,15 @@ dataset:
 | `static_checks` | object | Regex patterns to check in generated code |
 | `runtime_checks` | object | Assertions to run in WordPress environment |
 | `reference_solution` | string | Example correct solution |
+| `artifact_kind` | string | What the model must produce: `php_snippet` (default) or `wp_plugin_files` |
+| `reference_files` | object | For `wp_plugin_files` tests: reference plugin files (relative path → contents) |
+
+For `wp_plugin_files` tasks the model must return a JSON object with a
+`files` map (relative paths → complete file contents), including one
+top-level PHP file with a `Plugin Name:` header. The runtime installs
+the files as a plugin, loads it, runs the task's assertions, and removes
+it. Artifacts are validated before install: no absolute paths, no `..`
+traversal, limited file count and total size.
 
 ### Knowledge Tests
 | Field | Type | Description |

--- a/datasets/export_dataset.py
+++ b/datasets/export_dataset.py
@@ -48,6 +48,8 @@ def load_suite(suite_name: str) -> list[dict]:
                     "runtime_checks": orjson.dumps(t.get("runtime_checks", {})).decode(),
                     "reference_solution": t.get("reference_solution", ""),
                     "metadata": orjson.dumps(t.get("metadata", {})).decode(),
+                    "artifact_kind": t.get("artifact_kind", "php_snippet"),
+                    "reference_files": orjson.dumps(t.get("reference_files") or {}).decode(),
                 })
 
     # Load all knowledge tests from knowledge/ directory
@@ -74,6 +76,8 @@ def load_suite(suite_name: str) -> list[dict]:
                     "runtime_checks": "{}",
                     "reference_solution": "",
                     "metadata": orjson.dumps(t.get("metadata", {})).decode(),
+                    "artifact_kind": "",
+                    "reference_files": "{}",
                 })
 
     return rows

--- a/python/tests/test_artifacts.py
+++ b/python/tests/test_artifacts.py
@@ -1,0 +1,267 @@
+"""Tests for artifact parsing, validation, and execution routing."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from conftest import fake_generation
+from wp_bench.artifacts import (
+    MAX_ARTIFACT_FILES,
+    Artifact,
+    ArtifactError,
+    parse_artifact,
+    render_artifact_instructions,
+)
+from wp_bench.config import (
+    DatasetConfig,
+    GraderConfig,
+    HarnessConfig,
+    ModelConfig,
+    OutputConfig,
+    RunConfig,
+)
+from wp_bench.core import BenchmarkRunner
+from wp_bench.datasets import ExecutionTest
+from wp_bench.environment import ExecutionResult
+
+PLUGIN_JSON = json.dumps(
+    {
+        "files": {
+            "demo-plugin.php": "<?php\n/*\nPlugin Name: Demo\n*/\nadd_action('init', 'demo_init');",
+            "includes/helpers.php": "<?php\nfunction demo_helper() { return true; }",
+        }
+    }
+)
+
+
+def _plugin_test(test_id: str = "e-plugin-001") -> ExecutionTest:
+    return ExecutionTest(
+        id=test_id,
+        suite="wp-core-v1",
+        prompt="Build a plugin.",
+        expected_behavior="expected",
+        test_type="execution",
+        category="plugins",
+        difficulty="intermediate",
+        requirements=[],
+        test_function=None,
+        static_checks={},
+        runtime_checks={"assertions": [{"type": "function_exists", "target": "demo_helper", "weight": 1}]},
+        reference_solution=None,
+        metadata={},
+        artifact_kind="wp_plugin_files",
+        reference_files={"demo-plugin.php": "<?php\n/*\nPlugin Name: Demo\n*/"},
+    )
+
+
+# --- Parsing ---------------------------------------------------------------
+
+
+def test_php_snippet_artifact_still_supported() -> None:
+    artifact = parse_artifact("```php\nfunction x() {}\n```", "php_snippet")
+
+    assert artifact.kind == "php_snippet"
+    assert artifact.code == "function x() {}"
+    assert artifact.files == {}
+    assert artifact.payload_fields() == {"artifact_kind": "php_snippet", "code": "function x() {}"}
+
+
+def test_parse_plugin_files_json_output() -> None:
+    artifact = parse_artifact(PLUGIN_JSON, "wp_plugin_files")
+
+    assert artifact.kind == "wp_plugin_files"
+    assert set(artifact.files) == {"demo-plugin.php", "includes/helpers.php"}
+    assert artifact.payload_fields()["files"] == artifact.files
+
+
+def test_parse_plugin_files_accepts_fenced_json() -> None:
+    artifact = parse_artifact(f"```json\n{PLUGIN_JSON}\n```", "wp_plugin_files")
+
+    assert "demo-plugin.php" in artifact.files
+
+
+def test_plugin_artifact_rejects_invalid_json() -> None:
+    with pytest.raises(ArtifactError, match="JSON"):
+        parse_artifact("here is your plugin: <?php ...", "wp_plugin_files")
+
+
+def test_plugin_artifact_rejects_path_traversal() -> None:
+    payload = json.dumps({"files": {"../evil.php": "<?php /* Plugin Name: X */"}})
+    with pytest.raises(ArtifactError, match="traversal"):
+        parse_artifact(payload, "wp_plugin_files")
+
+
+def test_plugin_artifact_rejects_absolute_paths() -> None:
+    payload = json.dumps({"files": {"/etc/evil.php": "<?php /* Plugin Name: X */"}})
+    with pytest.raises(ArtifactError, match="relative"):
+        parse_artifact(payload, "wp_plugin_files")
+
+
+def test_plugin_artifact_rejects_backslash_traversal() -> None:
+    payload = json.dumps({"files": {"..\\evil.php": "<?php /* Plugin Name: X */"}})
+    with pytest.raises(ArtifactError, match="traversal"):
+        parse_artifact(payload, "wp_plugin_files")
+
+
+def test_plugin_artifact_requires_main_plugin_file() -> None:
+    payload = json.dumps({"files": {"helpers.php": "<?php function x() {}"}})
+    with pytest.raises(ArtifactError, match="Plugin Name"):
+        parse_artifact(payload, "wp_plugin_files")
+
+
+def test_plugin_artifact_rejects_oversized_file() -> None:
+    payload = json.dumps(
+        {"files": {"demo.php": "<?php /* Plugin Name: X */" + "a" * 300_000}}
+    )
+    with pytest.raises(ArtifactError, match="too large"):
+        parse_artifact(payload, "wp_plugin_files")
+
+
+def test_plugin_artifact_rejects_too_many_files() -> None:
+    files = {f"f{i}.php": "<?php" for i in range(MAX_ARTIFACT_FILES + 1)}
+    files["demo.php"] = "<?php /* Plugin Name: X */"
+    with pytest.raises(ArtifactError, match="too many"):
+        parse_artifact(json.dumps({"files": files}), "wp_plugin_files")
+
+
+def test_unknown_artifact_kind_rejected() -> None:
+    with pytest.raises(ArtifactError, match="Unsupported artifact kind"):
+        parse_artifact("anything", "js_module")
+
+
+def test_prompt_instructions_differ_by_kind() -> None:
+    snippet = render_artifact_instructions("php_snippet")
+    plugin = render_artifact_instructions("wp_plugin_files")
+
+    assert "```php" in snippet
+    assert "files" in plugin
+    assert snippet != plugin
+
+
+# --- Runner integration ----------------------------------------------------
+
+
+def _config(tmp_path: Path, **run_overrides: object) -> HarnessConfig:
+    return HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        model=ModelConfig(name="test-model"),
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig.model_validate({"test_type": "execution", **run_overrides}),
+        output=OutputConfig(path=tmp_path / "results.json", jsonl_path=None),
+    )
+
+
+def _passing_result() -> ExecutionResult:
+    raw = {
+        "success": True,
+        "static": {"score": 1.0, "details": {}},
+        "runtime": {"score": 1.0, "details": {"total_weight": 1}},
+    }
+    return ExecutionResult(success=True, raw=raw, stdout="", stderr="")
+
+
+def test_plugin_artifact_payload_reaches_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A plugin completion is parsed and shipped as files, not code."""
+    test = _plugin_test()
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": [test], "knowledge": []},
+    )
+    runner = BenchmarkRunner(_config(tmp_path))
+    runner.environment.setup = lambda: None  # type: ignore[method-assign]
+    runner.environment.reset = lambda: None  # type: ignore[method-assign]
+    seen: dict = {}
+
+    def fake_execute_artifact(artifact: Artifact, verification_spec: dict) -> ExecutionResult:
+        seen["artifact"] = artifact
+        seen["spec"] = verification_spec
+        return _passing_result()
+
+    runner.environment.execute_artifact = fake_execute_artifact  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", lambda prompt: fake_generation(PLUGIN_JSON)
+    )
+
+    payload = runner.run()
+
+    assert seen["artifact"].kind == "wp_plugin_files"
+    assert "demo-plugin.php" in seen["artifact"].files
+    record = payload["results"][0]
+    assert record["scores"]["execution_pass"] is True
+
+
+def test_artifact_parse_failure_is_scored_failure_not_crash(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Unparseable completions fail the test and the run continues."""
+    tests = [_plugin_test("e-plugin-001"), _plugin_test("e-plugin-002")]
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": tests, "knowledge": []},
+    )
+    runner = BenchmarkRunner(_config(tmp_path))
+    runner.environment.setup = lambda: None  # type: ignore[method-assign]
+    runner.environment.reset = lambda: None  # type: ignore[method-assign]
+    runner.environment.execute_artifact = lambda artifact, verification_spec: _passing_result()  # type: ignore[method-assign]
+    completions = iter(["not json at all", PLUGIN_JSON])
+    monkeypatch.setattr(
+        runner.model,
+        "generate_with_metadata",
+        lambda prompt: fake_generation(next(completions)),
+    )
+
+    payload = runner.run()
+
+    records = {record["test_id"]: record for record in payload["results"]}
+    failed = records["e-plugin-001"]
+    passed = records["e-plugin-002"]
+    assert failed["scores"]["execution_pass"] is False
+    assert failed["scores"]["correctness"] == 0.0
+    assert "artifact_error" in failed["grader"]["raw"]
+    assert passed["scores"]["execution_pass"] is True
+
+
+def test_reference_solution_uses_reference_files_for_plugin_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    test = _plugin_test()
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": [test], "knowledge": []},
+    )
+    runner = BenchmarkRunner(_config(tmp_path, check_reference_solution=True))
+    runner.environment.setup = lambda: None  # type: ignore[method-assign]
+    runner.environment.reset = lambda: None  # type: ignore[method-assign]
+    seen: dict = {}
+
+    def fake_execute_artifact(artifact: Artifact, verification_spec: dict) -> ExecutionResult:
+        seen["artifact"] = artifact
+        return _passing_result()
+
+    runner.environment.execute_artifact = fake_execute_artifact  # type: ignore[method-assign]
+
+    runner.run()
+
+    assert seen["artifact"].kind == "wp_plugin_files"
+    assert seen["artifact"].files == test.reference_files
+
+
+def test_snippet_prompt_unchanged_plugin_prompt_asks_for_json(
+    tmp_path: Path,
+) -> None:
+    snippet_test = _plugin_test()
+    snippet_test.artifact_kind = "php_snippet"
+    plugin_test = _plugin_test()
+
+    snippet_prompt = BenchmarkRunner._render_execution_prompt(snippet_test)
+    plugin_prompt = BenchmarkRunner._render_execution_prompt(plugin_test)
+
+    assert "```php" in snippet_prompt
+    assert "files" in plugin_prompt

--- a/python/tests/test_dataset_metadata.py
+++ b/python/tests/test_dataset_metadata.py
@@ -167,14 +167,14 @@ def test_result_record_includes_task_metadata(
     runner.environment.setup = lambda: None  # type: ignore[method-assign]
     runner.environment.reset = lambda: None  # type: ignore[method-assign]
 
-    def fake_execute(code: str, verification_spec: dict) -> ExecutionResult:
+    def fake_execute(artifact: object, verification_spec: dict) -> ExecutionResult:
         raw: dict[str, Any] = {
             "success": True,
             "runtime": {"score": 1.0, "details": {"total_weight": 1}},
         }
         return ExecutionResult(success=True, raw=raw, stdout="", stderr="")
 
-    runner.environment.execute_code = fake_execute  # type: ignore[method-assign]
+    runner.environment.execute_artifact = fake_execute  # type: ignore[method-assign]
     monkeypatch.setattr(
         runner.model, "generate_with_metadata", lambda prompt: fake_generation("```php\ncode\n```")
     )

--- a/python/tests/test_execution_isolation.py
+++ b/python/tests/test_execution_isolation.py
@@ -70,7 +70,7 @@ class SpyEnvironment:
     def reset(self) -> None:
         self.calls.append("reset")
 
-    def execute_code(self, code: str, verification_spec: dict) -> ExecutionResult:
+    def execute_artifact(self, artifact: object, verification_spec: dict) -> ExecutionResult:
         self.calls.append("execute")
         return _passing_result()
 

--- a/python/tests/test_reference_solution_mode.py
+++ b/python/tests/test_reference_solution_mode.py
@@ -83,11 +83,11 @@ def test_reference_solution_mode_executes_reference_solution(
     runner = BenchmarkRunner(config)
     runner.environment.setup = lambda: None  # type: ignore[method-assign]
 
-    def fake_execute_code(code: str, verification_spec: dict) -> ExecutionResult:
-        calls.append((code, verification_spec))
+    def fake_execute_artifact(artifact: Any, verification_spec: dict) -> ExecutionResult:
+        calls.append((artifact.code, verification_spec))
         return _passing_result()
 
-    runner.environment.execute_code = fake_execute_code  # type: ignore[method-assign]
+    runner.environment.execute_artifact = fake_execute_artifact  # type: ignore[method-assign]
 
     result = runner.run()
 
@@ -121,10 +121,10 @@ def test_reference_solution_mode_exits_nonzero_on_failed_reference(
     runner = BenchmarkRunner(config)
     runner.environment.setup = lambda: None  # type: ignore[method-assign]
 
-    def fake_execute_code(code: str, verification_spec: dict[str, Any]) -> ExecutionResult:
+    def fake_execute_artifact(artifact: Any, verification_spec: dict[str, Any]) -> ExecutionResult:
         return _failing_result()
 
-    runner.environment.execute_code = fake_execute_code  # type: ignore[method-assign]
+    runner.environment.execute_artifact = fake_execute_artifact  # type: ignore[method-assign]
 
     with pytest.raises(SystemExit) as exc:
         runner.run()

--- a/python/tests/test_result_schema.py
+++ b/python/tests/test_result_schema.py
@@ -89,7 +89,7 @@ def _single_model_records(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> li
     runner = BenchmarkRunner(config)
     runner.environment.setup = lambda: None  # type: ignore[method-assign]
     runner.environment.reset = lambda: None  # type: ignore[method-assign]
-    runner.environment.execute_code = lambda code, verification_spec: _passing_result()  # type: ignore[method-assign]
+    runner.environment.execute_artifact = lambda artifact, verification_spec: _passing_result()  # type: ignore[method-assign]
     monkeypatch.setattr(runner.model, "generate_with_metadata", lambda prompt: fake_generation("init"))
     runner.run()
     return runner.records
@@ -108,7 +108,7 @@ def _multi_model_records(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> lis
         def setup(self) -> None: ...
         def reset(self) -> None: ...
 
-        def execute_code(self, code: str, spec: dict) -> ExecutionResult:
+        def execute_artifact(self, artifact: object, spec: dict) -> ExecutionResult:
             return _passing_result()
 
     runner = SingleModelRunner(
@@ -172,7 +172,7 @@ def test_reference_solution_record_uses_canonical_schema(
     runner = BenchmarkRunner(config)
     runner.environment.setup = lambda: None  # type: ignore[method-assign]
     runner.environment.reset = lambda: None  # type: ignore[method-assign]
-    runner.environment.execute_code = lambda code, verification_spec: _passing_result()  # type: ignore[method-assign]
+    runner.environment.execute_artifact = lambda artifact, verification_spec: _passing_result()  # type: ignore[method-assign]
 
     runner.run()
     record = runner.records[0]
@@ -209,7 +209,7 @@ def test_jsonl_records_match_json_results(
     runner = BenchmarkRunner(config)
     runner.environment.setup = lambda: None  # type: ignore[method-assign]
     runner.environment.reset = lambda: None  # type: ignore[method-assign]
-    runner.environment.execute_code = lambda code, verification_spec: _passing_result()  # type: ignore[method-assign]
+    runner.environment.execute_artifact = lambda artifact, verification_spec: _passing_result()  # type: ignore[method-assign]
     monkeypatch.setattr(runner.model, "generate_with_metadata", lambda prompt: fake_generation("init"))
 
     runner.run()
@@ -246,7 +246,7 @@ def test_records_are_sorted_for_stable_output(
     runner = BenchmarkRunner(config)
     runner.environment.setup = lambda: None  # type: ignore[method-assign]
     runner.environment.reset = lambda: None  # type: ignore[method-assign]
-    runner.environment.execute_code = lambda code, verification_spec: _passing_result()  # type: ignore[method-assign]
+    runner.environment.execute_artifact = lambda artifact, verification_spec: _passing_result()  # type: ignore[method-assign]
     monkeypatch.setattr(
         runner.model, "generate_with_metadata", lambda prompt: fake_generation("```php\ncode\n```")
     )

--- a/python/wp_bench/artifacts.py
+++ b/python/wp_bench/artifacts.py
@@ -1,0 +1,143 @@
+"""Artifact parsing and validation for execution tests.
+
+Execution tests can require artifact kinds beyond a single PHP snippet.
+This module turns raw model completions into validated artifacts:
+
+- ``php_snippet``: the existing behavior; fenced PHP code becomes one
+  code string.
+- ``wp_plugin_files``: the model must return a JSON object with a
+  ``files`` map of relative paths to file contents, which the runtime
+  installs as a plugin before running assertions.
+
+Parse and validation failures raise ArtifactError, which runners record
+as structured per-test failures — a model that cannot produce a valid
+artifact has failed the task, not crashed the harness.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from .utils import strip_code_fences
+
+#: Limits guarding the runtime filesystem against hostile artifacts.
+MAX_ARTIFACT_FILES = 20
+MAX_FILE_BYTES = 256 * 1024
+MAX_TOTAL_BYTES = 1024 * 1024
+
+_VALID_PATH_SEGMENT = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class ArtifactError(ValueError):
+    """A model completion could not be parsed into a valid artifact."""
+
+
+@dataclass
+class Artifact:
+    """A validated candidate artifact ready for runtime verification."""
+
+    kind: str
+    code: str = ""
+    files: Dict[str, str] = field(default_factory=dict)
+
+    def payload_fields(self) -> Dict[str, Any]:
+        """Fields merged into the runtime verification payload."""
+        fields: Dict[str, Any] = {"artifact_kind": self.kind, "code": self.code}
+        if self.files:
+            fields["files"] = self.files
+        return fields
+
+
+def parse_artifact(completion: str, artifact_kind: str) -> Artifact:
+    """Parse a model completion into a validated artifact.
+
+    Raises:
+        ArtifactError: When the completion cannot be parsed or the parsed
+            artifact violates path/size constraints.
+    """
+    if artifact_kind == "php_snippet":
+        return Artifact(kind="php_snippet", code=strip_code_fences(completion))
+    if artifact_kind == "wp_plugin_files":
+        return _parse_plugin_files(completion)
+    raise ArtifactError(f"Unsupported artifact kind: {artifact_kind}")
+
+
+def _parse_plugin_files(completion: str) -> Artifact:
+    """Parse a JSON files-object completion into a plugin artifact."""
+    text = strip_code_fences(completion)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise ArtifactError(
+            f"Plugin artifact must be a JSON object with a 'files' map: {error}"
+        ) from error
+
+    if not isinstance(data, dict) or not isinstance(data.get("files"), dict):
+        raise ArtifactError("Plugin artifact JSON must contain a 'files' object.")
+
+    files: Dict[str, str] = {}
+    total_bytes = 0
+    for raw_path, content in data["files"].items():
+        if not isinstance(raw_path, str) or not isinstance(content, str):
+            raise ArtifactError("Plugin artifact file paths and contents must be strings.")
+        path = _validate_relative_path(raw_path)
+        size = len(content.encode("utf-8"))
+        if size > MAX_FILE_BYTES:
+            raise ArtifactError(f"Artifact file too large: {path} ({size} bytes)")
+        total_bytes += size
+        files[path] = content
+
+    if not files:
+        raise ArtifactError("Plugin artifact contains no files.")
+    if len(files) > MAX_ARTIFACT_FILES:
+        raise ArtifactError(f"Plugin artifact has too many files ({len(files)}).")
+    if total_bytes > MAX_TOTAL_BYTES:
+        raise ArtifactError(f"Plugin artifact too large ({total_bytes} bytes).")
+
+    main_file = _find_main_plugin_file(files)
+    if main_file is None:
+        raise ArtifactError(
+            "Plugin artifact needs a top-level .php file with a 'Plugin Name:' header."
+        )
+
+    return Artifact(kind="wp_plugin_files", files=files)
+
+
+def _validate_relative_path(raw_path: str) -> str:
+    """Reject absolute paths, traversal, and hostile path segments."""
+    path = raw_path.strip().replace("\\", "/")
+    if not path:
+        raise ArtifactError("Artifact file path is empty.")
+    if path.startswith("/") or re.match(r"^[A-Za-z]:", path):
+        raise ArtifactError(f"Artifact file path must be relative: {raw_path}")
+    segments = path.split("/")
+    for segment in segments:
+        if segment in ("", ".", ".."):
+            raise ArtifactError(f"Artifact file path contains traversal: {raw_path}")
+        if not _VALID_PATH_SEGMENT.match(segment):
+            raise ArtifactError(f"Artifact file path contains invalid characters: {raw_path}")
+    return path
+
+
+def _find_main_plugin_file(files: Dict[str, str]) -> Optional[str]:
+    """Locate the top-level PHP file carrying the plugin header."""
+    for path, content in files.items():
+        if "/" in path or not path.endswith(".php"):
+            continue
+        if re.search(r"Plugin\s+Name\s*:", content, re.IGNORECASE):
+            return path
+    return None
+
+
+def render_artifact_instructions(artifact_kind: str) -> str:
+    """Prompt suffix telling the model what artifact format to return."""
+    if artifact_kind == "wp_plugin_files":
+        return (
+            "Return a JSON object with a `files` object. Keys are relative file "
+            "paths inside the plugin directory and values are complete file "
+            "contents. Include a top-level PHP file with a valid `Plugin Name:` "
+            "header. Do not include explanations or markdown fences."
+        )
+    return "Return only valid PHP code without explanations. Wrap the response in ```php fences."

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -31,6 +31,7 @@ from .output import (
     print_results_path,
     print_test_error,
 )
+from .artifacts import Artifact, ArtifactError, parse_artifact, render_artifact_instructions
 from .records import (
     RESULT_SCHEMA_VERSION,
     build_execution_record,
@@ -74,7 +75,7 @@ def _build_verification_spec(test: Any, config: HarnessConfig) -> Dict[str, Any]
     """Build the verifier payload honoring run.skip_runtime/skip_static.
 
     A skipped dimension is sent as empty checks so the runtime does not
-    execute it; scoring treats it as not applicable (see _score_correctness).
+    execute it; scoring treats it as not applicable (see _score_execution).
 
     When runtime checks run, a weight-0 ``function_exists`` assertion derived
     from ``test.test_function`` is prepended. It is the harness's gateway for
@@ -107,6 +108,34 @@ def _build_verification_spec(test: Any, config: HarnessConfig) -> Dict[str, Any]
         "static_checks": static_checks,
         "runtime_checks": runtime_checks,
     }
+
+
+def _artifact_failure_scores() -> Dict[str, Any]:
+    """Scores for a completion that failed artifact parsing/validation."""
+    return {
+        "knowledge": None,
+        "correctness": 0.0,
+        "execution_pass": False,
+        "runtime": 0.0,
+        "static": None,
+        "static_policy_pass": None,
+    }
+
+
+class _ArtifactFailureResult:
+    """Stand-in env result recording an artifact parse/validation failure."""
+
+    def __init__(self, error: ArtifactError):
+        self.success = False
+        self.stdout = ""
+        self.stderr = str(error)
+        self.timed_out = False
+        self.raw = {
+            "success": False,
+            "artifact_error": str(error),
+            "runtime": {"score": 0.0, "details": {"assertions": [], "total_weight": 0}},
+            "static": {"score": 0.0, "details": {}},
+        }
 
 
 def _model_call_info(generation: Any) -> Dict[str, Any]:
@@ -356,9 +385,24 @@ class BenchmarkRunner:
             try:
                 prompt = self._render_execution_prompt(test)
                 generation = self.model.generate_with_metadata(prompt)
-                code = strip_code_fences(generation.text)
+                artifact_kind = getattr(test, "artifact_kind", "php_snippet")
+                try:
+                    artifact = parse_artifact(generation.text, artifact_kind)
+                except ArtifactError as artifact_error:
+                    return build_execution_record(
+                        test=test,
+                        mode="model",
+                        model_config=self.config.model,
+                        prompt_hash=sha256(prompt),
+                        raw_completion=generation.text,
+                        code="",
+                        env_result=_ArtifactFailureResult(artifact_error),
+                        scores=_artifact_failure_scores(),
+                        usage=generation.usage_dict(),
+                        model_call=_model_call_info(generation),
+                    )
                 verification_spec = _build_verification_spec(test, self.config)
-                env_result = self.environment.execute_code(code, verification_spec)
+                env_result = self.environment.execute_artifact(artifact, verification_spec)
                 scores = self._score_execution(
                     env_result.raw,
                     test,
@@ -371,7 +415,7 @@ class BenchmarkRunner:
                     model_config=self.config.model,
                     prompt_hash=sha256(prompt),
                     raw_completion=generation.text,
-                    code=code,
+                    code=artifact.code,
                     env_result=env_result,
                     scores=scores,
                     usage=generation.usage_dict(),
@@ -401,10 +445,17 @@ class BenchmarkRunner:
 
         def process_test(test: ExecutionTest) -> Dict[str, Any]:
             try:
-                if not test.reference_solution:
-                    raise ValueError("Missing reference_solution")
+                artifact_kind = getattr(test, "artifact_kind", "php_snippet")
+                if artifact_kind == "wp_plugin_files":
+                    if not test.reference_files:
+                        raise ValueError("Missing reference_files for plugin artifact test")
+                    artifact = Artifact(kind="wp_plugin_files", files=test.reference_files)
+                else:
+                    if not test.reference_solution:
+                        raise ValueError("Missing reference_solution")
+                    artifact = Artifact(kind="php_snippet", code=test.reference_solution)
                 verification_spec = _build_verification_spec(test, self.config)
-                env_result = self.environment.execute_code(test.reference_solution, verification_spec)
+                env_result = self.environment.execute_artifact(artifact, verification_spec)
                 scores = self._score_execution(
                     env_result.raw,
                     test,
@@ -417,7 +468,7 @@ class BenchmarkRunner:
                     model_config=None,
                     prompt_hash=None,
                     raw_completion=None,
-                    code=test.reference_solution,
+                    code=artifact.code,
                     env_result=env_result,
                     scores=scores,
                 )
@@ -468,7 +519,7 @@ class BenchmarkRunner:
             lines.append("")
             lines.append(f"Define this function: {test.test_function}")
         lines.append(
-            "Return only valid PHP code without explanations. Wrap the response in ```php fences."
+            render_artifact_instructions(getattr(test, "artifact_kind", "php_snippet"))
         )
         return "\n".join(lines)
 
@@ -819,9 +870,24 @@ class SingleModelRunner:
             try:
                 prompt = BenchmarkRunner._render_execution_prompt(test)
                 generation = self.model.generate_with_metadata(prompt)
-                code = strip_code_fences(generation.text)
+                artifact_kind = getattr(test, "artifact_kind", "php_snippet")
+                try:
+                    artifact = parse_artifact(generation.text, artifact_kind)
+                except ArtifactError as artifact_error:
+                    return build_execution_record(
+                        test=test,
+                        mode="model",
+                        model_config=self.model_config,
+                        prompt_hash=sha256(prompt),
+                        raw_completion=generation.text,
+                        code="",
+                        env_result=_ArtifactFailureResult(artifact_error),
+                        scores=_artifact_failure_scores(),
+                        usage=generation.usage_dict(),
+                        model_call=_model_call_info(generation),
+                    )
                 verification_spec = _build_verification_spec(test, self.config)
-                env_result = self.environment.execute_code(code, verification_spec)
+                env_result = self.environment.execute_artifact(artifact, verification_spec)
                 scores = BenchmarkRunner._score_execution(
                     env_result.raw,
                     test,
@@ -834,7 +900,7 @@ class SingleModelRunner:
                     model_config=self.model_config,
                     prompt_hash=sha256(prompt),
                     raw_completion=generation.text,
-                    code=code,
+                    code=artifact.code,
                     env_result=env_result,
                     scores=scores,
                     usage=generation.usage_dict(),

--- a/python/wp_bench/datasets.py
+++ b/python/wp_bench/datasets.py
@@ -29,6 +29,11 @@ class ExecutionTest:
     runtime_checks: Dict[str, Any]
     reference_solution: Optional[str]
     metadata: Dict[str, Any]
+    #: What the model must produce: 'php_snippet' (default) or
+    #: 'wp_plugin_files' (JSON files map installed as a plugin).
+    artifact_kind: str = "php_snippet"
+    #: Reference files for wp_plugin_files reference-solution runs.
+    reference_files: Optional[Dict[str, str]] = None
 
 
 @dataclass
@@ -121,6 +126,8 @@ def _load_from_huggingface(config: DatasetConfig) -> Dict[str, List[Any]]:
                     runtime_checks=runtime_checks if isinstance(runtime_checks, dict) else {},
                     reference_solution=row.get("reference_solution"),
                     metadata=_row_metadata(row),
+                    artifact_kind=row.get("artifact_kind") or "php_snippet",
+                    reference_files=_parse_optional_dict(row.get("reference_files")),
                 )
             )
         else:
@@ -171,6 +178,12 @@ def _row_metadata(row: Dict[str, Any]) -> Dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def _parse_optional_dict(value: Any) -> Optional[Dict[str, Any]]:
+    """Parse an optional JSON-encoded dict column; empty means None."""
+    parsed = _parse_json_field(value) if value else None
+    return parsed if isinstance(parsed, dict) and parsed else None
+
+
 def _load_from_local_files(config: DatasetConfig) -> Dict[str, List[Any]]:
     suite = config.name.split("/")[-1]
     suite_dir = DATASET_SUITES_DIR / suite
@@ -216,6 +229,8 @@ def _parse_execution_suite(path: Path) -> List[ExecutionTest]:
                 runtime_checks=test.get("runtime_checks", {}),
                 reference_solution=test.get("reference_solution"),
                 metadata=_merge_metadata(test.get("metadata", {}), metadata),
+                artifact_kind=test.get("artifact_kind", "php_snippet"),
+                reference_files=test.get("reference_files"),
             )
         )
     return tests

--- a/python/wp_bench/environment.py
+++ b/python/wp_bench/environment.py
@@ -84,18 +84,39 @@ class WordPressEnvironment:
             self._exec(install_cmd)
 
     def execute_code(self, code: str, verification_spec: Dict[str, Any]) -> ExecutionResult:
-        """Run candidate code through the runtime verifier.
+        """Run a candidate PHP snippet through the runtime verifier.
 
-        A runtime timeout is a per-test failure, not a harness crash: it
-        returns a structured ``ExecutionResult`` with ``timed_out=True`` and
-        a synthetic zero-score runtime payload, so the benchmark records the
-        timeout and continues with the next test.
+        Compatibility wrapper over execute_artifact() for snippet payloads.
         """
         payload = {
             "payload_version": "1.0",
             "code": code,
             **verification_spec,
         }
+        return self._run_verifier(payload)
+
+    def execute_artifact(self, artifact: Any, verification_spec: Dict[str, Any]) -> ExecutionResult:
+        """Run a candidate artifact (snippet or plugin files) through the verifier.
+
+        Args:
+            artifact: An Artifact with kind, code, and optional files map.
+            verification_spec: static_checks/runtime_checks for the test.
+        """
+        payload = {
+            "payload_version": "1.0",
+            **artifact.payload_fields(),
+            **verification_spec,
+        }
+        return self._run_verifier(payload)
+
+    def _run_verifier(self, payload: Dict[str, Any]) -> ExecutionResult:
+        """Send a payload to the runtime verifier and parse the result.
+
+        A runtime timeout is a per-test failure, not a harness crash: it
+        returns a structured ``ExecutionResult`` with ``timed_out=True`` and
+        a synthetic zero-score runtime payload, so the benchmark records the
+        timeout and continues with the next test.
+        """
         verifier_path = self._runtime_verifier_path()
         cmd = [
             "wp",

--- a/runtime/src/class-artifact-installer.php
+++ b/runtime/src/class-artifact-installer.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Candidate plugin artifact installer.
+ *
+ * @package WPBench\Runtime
+ */
+
+declare(strict_types=1);
+
+namespace WPBench\Runtime;
+
+/**
+ * Writes candidate plugin files into wp-content/plugins, loads them for
+ * verification, and removes them afterwards.
+ *
+ * Path safety: file paths are validated against traversal and absolute
+ * paths before any write, and all writes are confined to a dedicated
+ * wp-bench-candidate directory that is deleted on cleanup.
+ */
+class Artifact_Installer {
+
+	private const PLUGIN_DIR_PREFIX = 'wp-bench-candidate';
+
+	/**
+	 * Directory created for the current candidate, if any.
+	 */
+	private ?string $plugin_dir = null;
+
+	/**
+	 * Install candidate plugin files and include the main plugin file.
+	 *
+	 * @param array<string, string> $files Relative path => file contents.
+	 * @return array{success: bool, error?: string, plugin_dir?: string}
+	 */
+	public function install( array $files ): array {
+		$base = trailingslashit( WP_PLUGIN_DIR ) . self::PLUGIN_DIR_PREFIX . '-' . wp_generate_password( 8, false );
+
+		foreach ( $files as $relative_path => $contents ) {
+			if ( ! is_string( $relative_path ) || ! is_string( $contents ) ) {
+				return [
+					'success' => false,
+					'error'   => 'Artifact file entries must map string paths to string contents.',
+				];
+			}
+			$validated = $this->validate_relative_path( $relative_path );
+			if ( null === $validated ) {
+				return [
+					'success' => false,
+					'error'   => "Unsafe artifact file path: {$relative_path}",
+				];
+			}
+		}
+
+		if ( ! wp_mkdir_p( $base ) ) {
+			return [
+				'success' => false,
+				'error'   => 'Could not create candidate plugin directory.',
+			];
+		}
+		$this->plugin_dir = $base;
+
+		foreach ( $files as $relative_path => $contents ) {
+			$validated = $this->validate_relative_path( $relative_path );
+			$target    = $base . '/' . $validated;
+			$dir       = dirname( $target );
+			if ( ! wp_mkdir_p( $dir ) ) {
+				return [
+					'success' => false,
+					'error'   => "Could not create directory for: {$relative_path}",
+				];
+			}
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Runtime container filesystem.
+			if ( false === file_put_contents( $target, $contents ) ) {
+				return [
+					'success' => false,
+					'error'   => "Could not write artifact file: {$relative_path}",
+				];
+			}
+		}
+
+		$main_file = $this->find_main_plugin_file( $files );
+		if ( null === $main_file ) {
+			return [
+				'success' => false,
+				'error'   => 'No top-level plugin file with a Plugin Name header found.',
+			];
+		}
+
+		try {
+			include_once $base . '/' . $main_file;
+		} catch ( \Throwable $e ) {
+			return [
+				'success' => false,
+				'error'   => 'Loading candidate plugin failed: ' . $e->getMessage(),
+			];
+		}
+
+		return [
+			'success'    => true,
+			'plugin_dir' => $base,
+		];
+	}
+
+	/**
+	 * Remove the candidate plugin directory.
+	 */
+	public function cleanup(): void {
+		if ( null === $this->plugin_dir || ! is_dir( $this->plugin_dir ) ) {
+			return;
+		}
+		$this->delete_dir( $this->plugin_dir );
+		$this->plugin_dir = null;
+	}
+
+	/**
+	 * Validate a relative artifact path; null when unsafe.
+	 */
+	private function validate_relative_path( string $path ): ?string {
+		$normalized = str_replace( '\\', '/', trim( $path ) );
+		if ( '' === $normalized || str_starts_with( $normalized, '/' ) || 1 === preg_match( '/^[A-Za-z]:/', $normalized ) ) {
+			return null;
+		}
+		foreach ( explode( '/', $normalized ) as $segment ) {
+			if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+				return null;
+			}
+			if ( 1 !== preg_match( '/^[A-Za-z0-9._-]+$/', $segment ) ) {
+				return null;
+			}
+		}
+		return $normalized;
+	}
+
+	/**
+	 * Locate the top-level PHP file carrying the plugin header.
+	 *
+	 * @param array<string, string> $files Relative path => contents.
+	 */
+	private function find_main_plugin_file( array $files ): ?string {
+		foreach ( $files as $path => $contents ) {
+			if ( str_contains( $path, '/' ) || ! str_ends_with( $path, '.php' ) ) {
+				continue;
+			}
+			if ( 1 === preg_match( '/Plugin\s+Name\s*:/i', $contents ) ) {
+				return $path;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Recursively delete a directory.
+	 */
+	private function delete_dir( string $dir ): void {
+		$items = scandir( $dir );
+		if ( false === $items ) {
+			return;
+		}
+		foreach ( $items as $item ) {
+			if ( '.' === $item || '..' === $item ) {
+				continue;
+			}
+			$path = $dir . '/' . $item;
+			if ( is_dir( $path ) ) {
+				$this->delete_dir( $path );
+			} else {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Runtime container filesystem.
+				unlink( $path );
+			}
+		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rmdir_rmdir -- Runtime container filesystem.
+		rmdir( $dir );
+	}
+}

--- a/runtime/src/class-verifier.php
+++ b/runtime/src/class-verifier.php
@@ -17,27 +17,110 @@ class Verifier {
 	}
 
 	/**
-	 * Verify candidate code against static and runtime checks.
+	 * Verify a candidate artifact against static and runtime checks.
+	 *
+	 * Supported artifact kinds:
+	 * - php_snippet (default): `code` string executed via the sandbox.
+	 * - wp_plugin_files: `files` map installed as a plugin before the
+	 *   assertions run; static analysis covers the concatenated files.
 	 *
 	 * @param array<string, mixed> $payload Verification payload.
 	 * @return array<string, mixed>
 	 */
 	public function verify_payload( array $payload ): array {
+		$kind_value = $payload['artifact_kind'] ?? 'php_snippet';
+		$kind       = is_string( $kind_value ) ? $kind_value : 'php_snippet';
+
+		$static_checks_value  = $payload['static_checks'] ?? [];
+		$runtime_checks_value = $payload['runtime_checks'] ?? [];
+		$static_checks        = is_array( $static_checks_value ) ? $static_checks_value : [];
+		$runtime_checks       = is_array( $runtime_checks_value ) ? $runtime_checks_value : [];
+
+		if ( 'wp_plugin_files' === $kind ) {
+			return $this->verify_plugin_files( $payload, $static_checks, $runtime_checks );
+		}
+
 		$code_value = $payload['code'] ?? '';
 		$code       = is_string( $code_value ) ? $code_value : '';
 
-		$static_checks  = $payload['static_checks'] ?? [];
-		$runtime_checks = $payload['runtime_checks'] ?? [];
+		$static_result  = $this->static_analysis->check( $code, $static_checks );
+		$runtime_result = $this->sandbox->execute_and_verify( $code, $runtime_checks );
 
-		$static_result  = $this->static_analysis->check( $code, is_array( $static_checks ) ? $static_checks : [] );
-		$runtime_result = $this->sandbox->execute_and_verify( $code, is_array( $runtime_checks ) ? $runtime_checks : [] );
+		return $this->build_result( $static_result, $runtime_result, $kind );
+	}
 
+	/**
+	 * Verify a plugin-files artifact: install, assert, clean up.
+	 *
+	 * @param array<string, mixed> $payload        Full payload.
+	 * @param array<string, mixed> $static_checks  Static check config.
+	 * @param array<string, mixed> $runtime_checks Runtime check config.
+	 * @return array<string, mixed>
+	 */
+	private function verify_plugin_files( array $payload, array $static_checks, array $runtime_checks ): array {
+		$files_value = $payload['files'] ?? [];
+		$files       = is_array( $files_value ) ? $files_value : [];
+
+		// Static analysis runs over all files so patterns can match any of them.
+		$combined = implode( "\n\n", array_map( 'strval', array_values( $files ) ) );
+
+		$installer      = new Artifact_Installer();
+		$install_result = $installer->install( $files );
+
+		if ( true !== $install_result['success'] ) {
+			$installer->cleanup();
+			$error = isset( $install_result['error'] ) && is_string( $install_result['error'] )
+				? $install_result['error']
+				: 'Plugin artifact installation failed.';
+			return [
+				'success' => false,
+				'static'  => $this->static_analysis->check( $combined, $static_checks ),
+				'runtime' => [
+					'score'   => 0.0,
+					'details' => [
+						'assertions'    => [
+							[
+								'type'        => 'artifact_install_error',
+								'description' => $error,
+								'passed'      => false,
+							],
+						],
+						'total_weight'  => 0,
+						'passed_weight' => 0,
+					],
+				],
+				'version' => '1.0.0',
+			];
+		}
+
+		try {
+			$static_result = $this->static_analysis->check( $combined, $static_checks );
+			// The plugin's main file is already loaded; run assertions
+			// without additional candidate code.
+			$runtime_result = $this->sandbox->execute_and_verify( '', $runtime_checks );
+		} finally {
+			$installer->cleanup();
+		}
+
+		return $this->build_result( $static_result, $runtime_result, 'wp_plugin_files' );
+	}
+
+	/**
+	 * Assemble the standard verifier response.
+	 *
+	 * @param array{score: float, details: array<string, mixed>} $static_result  Static outcome.
+	 * @param array{score: float, details: array<string, mixed>} $runtime_result Runtime outcome.
+	 * @param string                                             $kind           Artifact kind.
+	 * @return array<string, mixed>
+	 */
+	private function build_result( array $static_result, array $runtime_result, string $kind ): array {
 		return [
-			'success'    => $runtime_result['score'] >= 0.999 && $static_result['score'] >= 0.999,
-			'static'     => $static_result,
-			'runtime'    => $runtime_result,
-			'assertions' => $runtime_result['details']['assertions'] ?? [],
-			'version'    => '1.0.0',
+			'success'       => $runtime_result['score'] >= 0.999 && $static_result['score'] >= 0.999,
+			'artifact_kind' => $kind,
+			'static'        => $static_result,
+			'runtime'       => $runtime_result,
+			'assertions'    => $runtime_result['details']['assertions'] ?? [],
+			'version'       => '1.0.0',
 		];
 	}
 }

--- a/runtime/verify-runtime.php
+++ b/runtime/verify-runtime.php
@@ -11,6 +11,7 @@ use WPBench\Runtime\Verifier;
 
 require_once __DIR__ . '/src/class-sandbox.php';
 require_once __DIR__ . '/src/class-static-analysis.php';
+require_once __DIR__ . '/src/class-artifact-installer.php';
 require_once __DIR__ . '/src/class-verifier.php';
 
 $payload_json = file_get_contents( 'php://stdin' );

--- a/runtime/wp-bench-runtime.php
+++ b/runtime/wp-bench-runtime.php
@@ -20,5 +20,6 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 } else {
 	require_once __DIR__ . '/src/class-sandbox.php';
 	require_once __DIR__ . '/src/class-static-analysis.php';
+	require_once __DIR__ . '/src/class-artifact-installer.php';
 	require_once __DIR__ . '/src/class-verifier.php';
 }


### PR DESCRIPTION
## Why this matters

WP-Bench wants to answer 'which model is best at WordPress work' — but real WordPress work isn't isolated named-function snippets fed to `eval`. It's plugins with headers and file layout, activation hooks, includes, and eventually blocks and themes. A benchmark that only tests snippet-writing measures a narrow (and increasingly unrepresentative) slice of what people actually ask models to build, and models that are strong at structuring real projects get no credit for it. This adds the first realistic artifact mode: multi-file plugin generation, installed and verified in a live WordPress. It also establishes the parsing/validation/install pipeline that block, theme, and patch tracks can reuse.

Since candidate artifacts are now written to the runtime filesystem, this is also a security boundary: everything is validated twice (harness and runtime), confined to a dedicated directory, size-capped, and cleaned up.

## Changes

**Harness**
- New artifact layer: `php_snippet` (default, unchanged behavior) and `wp_plugin_files`, where the model must return a JSON `files` map. Validation rejects absolute paths, `..`/backslash traversal, hostile characters, oversized files (256KB), oversized artifacts (1MB / 20 files), and artifacts missing a top-level `Plugin Name:` header.
- Tests declare `artifact_kind` (plus `reference_files` for reference-solution runs); dataset loaders and the Parquet export carry both, and prompts render kind-specific output instructions.
- **A malformed completion is a scored failure, not a crash**: unparseable/invalid artifacts record `execution_pass: false` with the artifact error in the grader payload, and the run continues — a model that can't produce a valid plugin has failed the task.

**Runtime**
- New `Artifact_Installer` writes candidate files into an isolated `wp-content/plugins/wp-bench-candidate-*` directory (independently re-validating every path server-side — defense in depth against a compromised or buggy harness), loads the main plugin file, and deletes the directory after verification.
- `Verifier` routes on `artifact_kind`: plugin files are installed before assertions run; static analysis covers all files concatenated; install failures come back as structured `artifact_install_error` results.
- Per-test environment resets (from earlier in this series) guarantee candidate plugin state can't leak between tests.

## Verification

- `pytest python`: **122 passed** (17 new: parsing incl. fenced JSON, traversal/absolute/backslash rejection, size/count caps, main-file requirement, unknown-kind rejection, end-to-end runner integration, parse-failure continuation across tests, reference-files execution, kind-specific prompts)
- `php -l` on all touched runtime files: clean
- `ruff check python datasets`: clean
- `mypy python`: 2 pre-existing trunk errors only
- Live wp-env install/verify round-trip not run here (no local runtime up) — flagged for a runtime smoke test before this ships in an official run.

## Notes

- Stacked on #34 (stdin transport, which this depends on for payload size).
- Scope is deliberately `wp_plugin_files` only; `block_plugin`, `wp_theme_files`, `js_module`, and `patch` reuse this pipeline in future PRs.