### PR TITLE
refactor: migrate config to Pydantic v2 field_validator

### DIFF
--- a/python/tests/test_config_validation.py
+++ b/python/tests/test_config_validation.py
@@ -1,0 +1,63 @@
+"""Tests for config field validation (Pydantic v2 style)."""
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from pydantic import ValidationError
+
+from wp_bench.config import GraderConfig, HarnessConfig, ModelConfig, RunConfig
+
+
+def test_model_config_rejects_temperature_below_zero() -> None:
+    with pytest.raises(ValidationError, match="between 0 and 2"):
+        ModelConfig(temperature=-0.1)
+
+
+def test_model_config_rejects_temperature_above_two() -> None:
+    with pytest.raises(ValidationError, match="between 0 and 2"):
+        ModelConfig(temperature=2.1)
+
+
+def test_model_config_accepts_temperature_bounds() -> None:
+    assert ModelConfig(temperature=0.0).temperature == 0.0
+    assert ModelConfig(temperature=2.0).temperature == 2.0
+
+
+def test_model_config_rejects_invalid_top_p() -> None:
+    with pytest.raises(ValidationError, match="between 0 and 1"):
+        ModelConfig(top_p=1.5)
+    with pytest.raises(ValidationError, match="between 0 and 1"):
+        ModelConfig(top_p=-0.1)
+
+
+def test_model_config_accepts_valid_top_p() -> None:
+    assert ModelConfig(top_p=0.9).top_p == 0.9
+    assert ModelConfig(top_p=None).top_p is None
+
+
+def test_run_config_rejects_zero_concurrency() -> None:
+    with pytest.raises(ValidationError):
+        RunConfig(concurrency=0)
+
+
+def test_run_config_rejects_zero_limit() -> None:
+    with pytest.raises(ValidationError):
+        RunConfig(limit=0)
+
+
+def test_grader_config_rejects_nonpositive_timeouts() -> None:
+    with pytest.raises(ValidationError):
+        GraderConfig(timeout_seconds=0)
+    with pytest.raises(ValidationError):
+        GraderConfig(setup_timeout_seconds=-1)
+
+
+def test_config_construction_emits_no_deprecation_warnings() -> None:
+    """The config layer is fully on Pydantic v2 idioms."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        HarnessConfig()
+        ModelConfig(temperature=1.0, top_p=0.5)
+        RunConfig(limit=5)
+        GraderConfig(kind="cli")

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator, validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 ArtifactKind = Literal[
     "php_snippet",
@@ -43,7 +43,7 @@ class ModelConfig(StrictModel):
     temperature: float = 0.0
     max_tokens: Optional[int] = None
     top_p: Optional[float] = None
-    request_timeout: float = 300.0
+    request_timeout: float = Field(default=300.0, gt=0)
     #: Additional attempts after the first call fails with a transient
     #: provider error (rate limit, timeout, connection, 5xx).
     max_retries: int = 3
@@ -52,10 +52,18 @@ class ModelConfig(StrictModel):
     retry_on_rate_limit: bool = True
     retry_on_timeout: bool = True
 
-    @validator("temperature")
+    @field_validator("temperature")
+    @classmethod
     def _clamp_temperature(cls, value: float) -> float:
         if value < 0 or value > 2:
             raise ValueError("temperature must be between 0 and 2")
+        return value
+
+    @field_validator("top_p")
+    @classmethod
+    def _validate_top_p(cls, value: Optional[float]) -> Optional[float]:
+        if value is not None and not 0 <= value <= 1:
+            raise ValueError("top_p must be between 0 and 1")
         return value
 
     @model_validator(mode="after")
@@ -76,8 +84,8 @@ class GraderConfig(StrictModel):
     image: str = "ghcr.io/wordpress/wp-bench-grader:latest"
     container_name: str = "wp-bench-grader"
     base_url: str = "http://localhost:8888"
-    timeout_seconds: int = 90
-    setup_timeout_seconds: int = 600
+    timeout_seconds: int = Field(default=90, gt=0)
+    setup_timeout_seconds: int = Field(default=600, gt=0)
     wp_env_dir: Optional[Path] = None
 
     @model_validator(mode="before")
@@ -102,12 +110,12 @@ ExecutionIsolation = Literal["reset_per_test", "none"]
 class RunConfig(StrictModel):
     suite: str = "wp-core-v1"
     test_type: Optional[Literal["knowledge", "execution"]] = None
-    limit: Optional[int] = None
+    limit: Optional[int] = Field(default=None, gt=0)
     test_ids: List[str] = Field(default_factory=list)
     #: Reserved for deterministic subset selection; wired by seeded
     #: stratified test limiting. Not yet consumed elsewhere.
     seed: int = 1337
-    concurrency: int = 5
+    concurrency: int = Field(default=5, gt=0)
     execution_isolation: ExecutionIsolation = "reset_per_test"
     execution_concurrency: int = 1
     dry_run: bool = False


### PR DESCRIPTION
## Why this matters

The config layer is the first thing every contributor and every run touches, and right now it greets them with a deprecation warning on literally every invocation — the project pins `pydantic>=2.8` but still uses the v1 `@validator` API, which Pydantic removes entirely in v3. Beyond the noise (which trains people to ignore warnings, exactly what a benchmark repo can't afford), it's a time bomb: the first dependency bump to Pydantic v3 would break config loading outright. This clears the debt and uses the opportunity to tighten validation where invalid values previously slipped through to fail confusingly mid-run.

## Changes

- `@validator('temperature')` → `@field_validator` + `@classmethod` (v2 idiom).
- New `top_p` validator (must be 0–1 or unset) — previously any float was accepted and failed provider-side with a cryptic API error.
- Declarative `Field` constraints on numerics that must be positive: `request_timeout`, `timeout_seconds`, `setup_timeout_seconds`, `concurrency`, and `limit` — a `limit: 0` or zero timeout now fails at config load with a clear message instead of producing a silently empty or hanging run.
- **Regression guard**: a test constructs every config model under `warnings.simplefilter('error', DeprecationWarning)`, so any future deprecated-API usage in the config layer fails CI rather than accumulating.

## Verification

- `pytest python`: **131 passed** (9 new validation tests) — and the `PydanticDeprecatedSince20` warning that appeared in every previous test run is gone
- `ruff check python`: clean
- `mypy python`: 2 pre-existing trunk errors only
- No v1 `validator` imports remain anywhere in the package

## Notes

- Stacked on #35.
- Constraint tightening is intentionally conservative — only bounds that were already documented or obviously nonsensical to violate.