### PR TITLE
ci: add lint/type/test/dataset/runtime workflows and release checklist

### DIFF
--- a/.agents/skills/wp-bench-execution-tests/SKILL.md
+++ b/.agents/skills/wp-bench-execution-tests/SKILL.md
@@ -15,7 +15,7 @@ Use this skill when adding or reviewing execution tests for WP-Bench.
 4. Keep `requirements` concise and model-facing. They are appended to the prompt.
 5. Keep `expected_behavior` reviewer-facing. It documents the contract and review focus; it is not used for scoring.
 6. Use `reference_solution` as the canonical passing implementation. It is for verification and maintenance, not model input.
-7. Make static checks robust for the contract: require expected functions, methods, classes, hooks, slugs, schema keys, and other identifiers when their use is essential to the task. Do not require incidental helpers or checker calls that the runtime assertion can perform itself.
+7. Make static checks robust for the contract: require expected functions, methods, classes, hooks, slugs, schema keys, and other identifiers when their use is essential to the task. Do not require incidental helpers or checker calls that the runtime assertion can perform itself. Under scoring v2.0, required patterns are diagnostics only — runtime assertions decide the pass — while forbidden patterns with severity `error` fail the test outright, so reserve them for genuine policy violations.
 8. Make runtime checks test the behavior inside WordPress. Use built-in assertion types when they directly express the check, such as output containment or REST response checks. Use `custom_assertion` when the verifier needs PHP to inspect the result, such as checking a registered category, returned value, database state, capability result, dispatched hook, or computed WordPress output.
 9. Verify `reference_solution` with `wp-bench run --check-reference-solution` for every new or modified execution test.
 
@@ -26,6 +26,8 @@ Use this skill when adding or reviewing execution tests for WP-Bench.
 - `test_function`: PHP signature of the entry point the verifier calls, e.g. `wpbp_queries_004( string $category_slug, array $tag_slugs ): WP_Query`. Set it whenever assertions invoke the function. Shown to the model and checked at runtime with an unscored `function_exists` assertion. Use parameter names that convey meaning; pin the return type only when assertions check it.
 - `expected_behavior`: Reviewer documentation.
 - `reference_solution`: Canonical passing code used for author verification.
+- `artifact_kind`: What the model must produce. `php_snippet` (default) or `wp_plugin_files` (a JSON `files` map installed as a plugin before assertions run).
+- `reference_files`: For `wp_plugin_files` tests, the reference plugin files (relative path → contents) used by `--check-reference-solution` in place of `reference_solution`.
 - `static_checks`: Coarse guardrails for required or forbidden code patterns.
 - `runtime_checks.setup`: Optional PHP fixture setup evaluated before the submitted code.
 - `runtime_checks.assertions`: WordPress-executed behavioral assertions evaluated after the submitted code.
@@ -86,6 +88,12 @@ Treat `difficulty` as author-estimated implementation complexity, not scoring.
 
 Do not mark a test `hard` only because the API is new.
 
+## Scoring (v2.0)
+
+Runtime behavior is the primary signal. A test passes strictly (`execution_pass`) when the code runs without crash or timeout, every runtime assertion passes, and no forbidden static pattern with severity `error` matches. Static required-pattern scores are recorded as diagnostics and do not grant or deny credit. Author accordingly: the runtime assertions must fully express the contract on their own.
+
+Each runtime execution is capped by `grader.timeout_seconds` (default 90s); a timed-out test scores 0.0. Keep setup, submitted-code expectations, and assertions comfortably inside that budget.
+
 ## Setup, Teardown, And Isolation
 
 Runtime order is `setup`, submitted code, assertions, then `teardown`.
@@ -100,6 +108,12 @@ Clean up state in `teardown` when it persists beyond the PHP process or can affe
 - files or uploads created during the test
 
 Avoid cleanup for in-process-only registries when each verifier run starts a fresh WP-CLI process. Extra cleanup can make failing cases noisy and less diagnostic.
+
+The harness also resets the WordPress environment between execution tests by default (`run.execution_isolation: reset_per_test` — database reset plus fresh install), so cross-test leakage is prevented even when a teardown is missed. Teardown still matters within a single test: assertions run in the same process and site state as the submitted code.
+
+## Plugin Artifact Tests
+
+For `artifact_kind: wp_plugin_files`, the model must return a JSON object with a `files` map (relative paths → complete file contents) including one top-level PHP file with a `Plugin Name:` header. The runtime installs the files as a plugin, loads the main file, runs the assertions, and removes the plugin directory. Provide `reference_files` instead of `reference_solution`, and keep artifacts within the validation limits: 20 files, 256KB per file, 1MB total, no path traversal. A completion that fails artifact validation scores as a failed test.
 
 ## Validation
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## What
+
+<!-- What does this PR change? -->
+
+## Why
+
+<!-- Why is this change needed? What does it improve for benchmark users, providers, or contributors? -->
+
+## Verification
+
+<!-- Commands run and their results. At minimum: -->
+
+- [ ] `ruff check python`
+- [ ] `mypy python`
+- [ ] `pytest python`
+- [ ] PHP syntax / runtime smoke test (when `runtime/` changed)
+
+## Score impact
+
+<!-- Required when changing datasets/, runtime/, or scoring code. -->
+
+- [ ] This PR does **not** change how any test is scored, or
+- [ ] This PR changes scoring/dataset/runtime behavior — bump the relevant
+      version (`scoring_version`, suite version, or runtime version), and
+      note below whether new scores are comparable to previous runs.
+
+<!-- Comparability note: -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  push:
+    branches: [trunk]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    name: Python lint, types, tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install harness with dev tooling
+        run: pip install -e ./python[dev]
+
+      - name: Lint (ruff)
+        run: ruff check python
+
+      - name: Type check (mypy)
+        run: mypy python
+
+      - name: Unit tests (pytest)
+        run: pytest python -q
+
+  dataset:
+    name: Dataset validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install harness with dev tooling
+        run: pip install -e ./python[dev]
+
+      - name: Dataset shape and metadata tests
+        run: pytest python/tests/test_execution_dataset.py python/tests/test_knowledge.py python/tests/test_dataset_metadata.py -q
+
+      - name: Parquet export builds
+        run: |
+          pip install pyarrow
+          python datasets/export_dataset.py
+
+  runtime:
+    name: PHP runtime syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.2"
+
+      - name: PHP syntax check
+        run: find runtime -name '*.php' -print0 | xargs -0 -n1 php -l
+
+  docker:
+    name: Runtime Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build grader image
+        run: docker build -t wp-bench-grader:ci ./runtime

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,45 @@
+# Release Checklist
+
+A WP-Bench release is a scoring contract: published numbers must be
+reproducible against a specific harness, dataset, runtime, and scoring
+version. Complete every item before tagging a release or publishing
+results.
+
+## Versioning
+
+- [ ] Bump the harness version in `python/pyproject.toml`.
+- [ ] If any task changed (added, removed, edited prompts/checks/weights),
+      bump the suite version and note affected test IDs.
+- [ ] If scoring semantics changed, bump `SCORING_VERSION`
+      (`python/wp_bench/scoring.py`) and document the formula change.
+- [ ] If the per-test record shape changed, bump `RESULT_SCHEMA_VERSION`
+      (`python/wp_bench/records.py`).
+
+## Quality gates
+
+- [ ] `ruff check python` — clean.
+- [ ] `mypy python` — clean.
+- [ ] `pytest python` — all tests pass.
+- [ ] `find runtime -name '*.php' -print0 | xargs -0 -n1 php -l` — clean.
+- [ ] `cd runtime && docker build -t wp-bench-grader:release .` — builds.
+
+## Runtime verification
+
+- [ ] Start the runtime (`cd runtime && npx wp-env start`).
+- [ ] Run the full reference-solution suite:
+      `wp-bench run --config wp-bench.example.yaml --check-reference-solution`
+      — every reference solution passes strictly.
+
+## Dataset artifacts
+
+- [ ] Regenerate the export: `python datasets/export_dataset.py`.
+- [ ] Verify row counts match the local suites (execution + knowledge).
+- [ ] Publish the Parquet/dataset update alongside the release when tasks
+      changed.
+
+## Publication
+
+- [ ] Publish the runtime Docker image and record its digest in the
+      release notes (official runs must pin the digest, not a tag).
+- [ ] Write a changelog entry stating explicitly whether scores from this
+      release are comparable to the previous release, and why.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 
 [project.optional-dependencies]
 http = ["uvicorn>=0.30", "fastapi>=0.111"]
-dev = ["pytest>=8.3", "ruff>=0.6", "mypy>=1.10"]
+dev = ["pytest>=8.3", "ruff>=0.6", "mypy>=1.10", "types-PyYAML>=6.0"]
 
 [project.scripts]
 wp-bench = "wp_bench.cli:app"

--- a/python/wp_bench/datasets.py
+++ b/python/wp_bench/datasets.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import orjson
-from datasets import load_dataset as hf_load_dataset
+from datasets import load_dataset as hf_load_dataset  # type: ignore[attr-defined]
 
 from .config import DatasetConfig
 


### PR DESCRIPTION
## Why this matters

A benchmark repo needs unusually high change discipline, because its failure modes are silent: a dataset edit can shift every model's score, a runtime change can break grading without any test noticing locally, and a scoring tweak can quietly invalidate comparisons with published history. Until now none of the documented checks ran automatically — trust depended on every contributor remembering to run everything by hand. This puts the quality gates in the merge path and, just as importantly, makes *score-breaking changes explicit*: anyone touching datasets, runtime, or scoring must declare whether results remain comparable, so the leaderboard's history stays interpretable.

## Changes

**CI (four jobs on PRs and trunk pushes)**
- **python** — ruff, mypy, pytest against an editable install with dev extras
- **dataset** — dataset shape/metadata tests plus a full Parquet export build (currently 470 tests), so export breakage is caught before publish time
- **runtime** — `php -l` over every runtime PHP file
- **docker** — grader image build, catching Dockerfile/package rot

**mypy is now enforced and fully clean** — this PR fixes the last two long-standing errors (missing PyYAML stubs in dev deps; a targeted ignore for the `datasets` library's dynamically-generated exports). The codebase goes from 3 mypy errors on trunk to 0, gated in CI.

**Process**
- PR template requiring verification commands and an explicit score-impact declaration: either "does not change scoring" or a version bump (`scoring_version` / suite / `RESULT_SCHEMA_VERSION`) plus a comparability note.
- `RELEASE_CHECKLIST.md`: version bumps, quality gates, full reference-solution verification against a live runtime, dataset export validation with row-count checks, and Docker image publication *by digest* so official runs pin an immutable grader.

## Verification

- `pytest python`: **131 passed**
- `ruff check python`: clean
- `mypy python`: **clean — 0 errors** (was 3 on trunk)
- `python datasets/export_dataset.py`: 470 tests exported with all expected columns
- Workflow YAML validated

## Notes

- Stacked on #36 — final PR in the series.
- The full reference-solution runtime smoke test lives in the release checklist rather than per-PR CI; running wp-env inside Actions is worth doing but deserves its own cost/flakiness evaluation first.