### PR TITLE
fix: build runtime grader image on the Alpine wp-cli base

### DIFF
--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -3,12 +3,13 @@ FROM wordpress:cli-php8.2
 ENV WORDPRESS_VERSION=7.0 \
     WP_CLI_ALLOW_ROOT=1
 
-RUN apt-get update && apt-get install -y default-mysql-client && rm -rf /var/lib/apt/lists/*
+USER root
+RUN apk add --no-cache mysql-client
 
 WORKDIR /var/www/html
 
 RUN rm -rf ./* && \
-    wp core download --version=${WORDPRESS_VERSION} --force
+    php -d memory_limit=512M "$(command -v wp)" core download --version=${WORDPRESS_VERSION} --force
 
 COPY wp-bench-runtime.php /var/www/html/wp-content/plugins/wp-bench-runtime/wp-bench-runtime.php
 COPY verify-runtime.php /var/www/html/wp-content/plugins/wp-bench-runtime/verify-runtime.php


### PR DESCRIPTION
## What

The runtime `Dockerfile` never built via `docker build ./runtime`. #37 adds a Docker-build CI job that surfaces it for the first time — this fixes it so that job (and the grader image) goes green.

Two independent breakages, both pre-existing (the Dockerfile is unchanged since the initial commit):

1. **`apt-get: not found`** — the base `wordpress:cli-php8.2` is **Alpine** (uses `apk`) and runs as **non-root**. The `apt-get install default-mysql-client` line is Debian-shaped. → `USER root` + `apk add --no-cache mysql-client`. The `mysql` client is genuinely needed (the entrypoint's DB-wait loop uses it); `bash` is already present on the base.
2. **`wp core download` OOMs at PHP's 128M default** during tarball extraction. The `wp` wrapper is `#!/usr/bin/env php`, so `WP_CLI_PHP_ARGS` isn't consulted — invoke php directly: `php -d memory_limit=512M "$(command -v wp)" core download ...`.

## Verification

`docker build ./runtime` builds an image end-to-end (308MB), `Success: WordPress downloaded`. Diff is Dockerfile-only (+3/-2).

## Notes for @JasonTheAdams

Both values are adjustable and I deferred to what works — you own this image:
- package name `mysql-client` (Alpine has `mariadb-client` as the non-deprecated equivalent; `mysql` there prints a deprecation notice but works)
- `memory_limit=512M` (just needs to clear 128M for extraction)

If the intent was actually a **Debian** base (so the original `apt-get`/`default-mysql-client` was correct), changing `FROM` instead would be the other direction — your call. Also curious how `ghcr.io/wordpress/wp-bench-grader:latest` is currently built, since it isn't from a plain `docker build` of this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)