### PR TITLE
feat: add run.continue_on_error to record per-test failures and keep going

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ run:
   concurrency: 4             # model-call concurrency (knowledge tests)
   execution_isolation: reset_per_test  # reset WordPress before each execution test
   execution_concurrency: 1   # must stay 1 under reset_per_test isolation
+  continue_on_error: false   # record per-test errors and keep going (diagnostic
+                             # only; errored tests are excluded from aggregates)
 
 output:
   path: output/results.json

--- a/python/tests/test_continue_on_error.py
+++ b/python/tests/test_continue_on_error.py
@@ -1,0 +1,319 @@
+"""Tests for run.continue_on_error: record per-test errors, keep going."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wp_bench.config import (
+    DatasetConfig,
+    GraderConfig,
+    HarnessConfig,
+    ModelConfig,
+    OutputConfig,
+    RunConfig,
+)
+from wp_bench.core import BenchmarkRunner
+from wp_bench.datasets import ExecutionTest, KnowledgeTest
+from wp_bench.environment import ExecutionResult
+
+from conftest import fake_generation
+
+
+def _execution_test(test_id: str) -> ExecutionTest:
+    return ExecutionTest(
+        id=test_id,
+        suite="wp-core-v1",
+        prompt="Prompt",
+        expected_behavior="expected",
+        test_type="execution",
+        category="general",
+        difficulty="basic",
+        requirements=["Requirement"],
+        test_function=None,
+        static_checks={},
+        runtime_checks={"assertions": [{"type": "custom_assertion", "code": "return true;", "weight": 1}]},
+        reference_solution="function ref() { return true; }",
+        metadata={},
+    )
+
+
+def _knowledge_test(test_id: str) -> KnowledgeTest:
+    return KnowledgeTest(
+        id=test_id,
+        suite="wp-core-v1",
+        prompt="Which hook?",
+        test_type="knowledge",
+        category="hooks",
+        difficulty="basic",
+        choices=[
+            {"key": "A", "text": "init"},
+            {"key": "B", "text": "wp_loaded"},
+        ],
+        correct_answer="A",
+        metadata={},
+    )
+
+
+def _passing_result() -> ExecutionResult:
+    raw = {
+        "success": True,
+        "static": {"score": 1.0, "details": {"total_weight": 1}},
+        "runtime": {"score": 1.0, "details": {"total_weight": 1}},
+    }
+    return ExecutionResult(success=True, raw=raw, stdout="", stderr="")
+
+
+def _config(tmp_path: Path, **run_overrides: Any) -> HarnessConfig:
+    return HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        model=ModelConfig(name="test-model"),
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(**run_overrides),
+        output=OutputConfig(path=tmp_path / "results.json", jsonl_path=None),
+    )
+
+
+class QuietEnvironment:
+    """Environment stub that always passes."""
+
+    def setup(self) -> None:
+        pass
+
+    def reset(self) -> None:
+        pass
+
+    def execute_artifact(self, artifact: object, verification_spec: dict) -> ExecutionResult:
+        return _passing_result()
+
+
+def _model_failing_on(bad_prompts_substring: str, good_text: str = "```php\ncode\n```"):
+    """generate_with_metadata stub erroring when the prompt names a test."""
+
+    def generate(prompt: str):
+        if bad_prompts_substring in prompt:
+            raise RuntimeError("provider exploded")
+        return fake_generation(good_text)
+
+    return generate
+
+
+def _runner_with_tests(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    execution: list[ExecutionTest] | None = None,
+    knowledge: list[KnowledgeTest] | None = None,
+    **run_overrides: Any,
+) -> BenchmarkRunner:
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": execution or [], "knowledge": knowledge or []},
+    )
+    runner = BenchmarkRunner(_config(tmp_path, **run_overrides))
+    runner.environment = QuietEnvironment()  # type: ignore[assignment]
+    return runner
+
+
+def test_default_off_error_still_aborts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Without the flag, the first per-test error aborts the run (legacy)."""
+    tests = [_execution_test("e-one"), _execution_test("e-two")]
+    # Distinct prompts so the stub can target one test.
+    tests[1].prompt = "BAD Prompt"
+    runner = _runner_with_tests(
+        monkeypatch, tmp_path, execution=tests, test_type="execution"
+    )
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", _model_failing_on("BAD")
+    )
+
+    with pytest.raises(SystemExit):
+        runner.run()
+
+
+def test_execution_error_is_recorded_and_run_continues(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An errored execution test becomes a canonical record with error set."""
+    tests = [_execution_test("e-one"), _execution_test("e-two"), _execution_test("e-three")]
+    tests[1].prompt = "BAD Prompt"
+    runner = _runner_with_tests(
+        monkeypatch, tmp_path, execution=tests,
+        test_type="execution", continue_on_error=True,
+    )
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", _model_failing_on("BAD")
+    )
+
+    payload = runner.run()
+
+    records = {record["test_id"]: record for record in payload["results"]}
+    assert len(records) == 3
+    errored = records["e-two"]
+    assert errored["error"] == {"type": "RuntimeError", "message": "provider exploded"}
+    assert errored["scores"]["execution_pass"] is None
+    assert records["e-one"]["error"] is None
+    # Errored record keeps the exact canonical key structure.
+    assert set(errored.keys()) == set(records["e-one"].keys())
+
+
+def test_errored_tests_excluded_from_aggregates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An ungraded test has no score: pass rate covers graded tests only."""
+    tests = [_execution_test("e-one"), _execution_test("e-two"), _execution_test("e-three")]
+    tests[1].prompt = "BAD Prompt"
+    runner = _runner_with_tests(
+        monkeypatch, tmp_path, execution=tests,
+        test_type="execution", continue_on_error=True,
+    )
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", _model_failing_on("BAD")
+    )
+
+    payload = runner.run()
+
+    scores = payload["metadata"]["scores"]
+    # Two graded tests passed; the errored one neither passes nor fails.
+    assert scores["execution_pass_rate"] == 1.0
+
+
+def test_metadata_records_errored_test_ids(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Result metadata makes skipped-by-error tests auditable."""
+    tests = [_execution_test("e-one"), _execution_test("e-two")]
+    tests[0].prompt = "BAD Prompt"
+    runner = _runner_with_tests(
+        monkeypatch, tmp_path, execution=tests,
+        test_type="execution", continue_on_error=True,
+    )
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", _model_failing_on("BAD")
+    )
+
+    payload = runner.run()
+
+    assert payload["metadata"]["continue_on_error"] is True
+    assert payload["metadata"]["errored_test_ids"] == ["e-one"]
+
+
+def test_knowledge_error_is_recorded_and_run_continues(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Knowledge tests get the same record-and-continue treatment."""
+    tests = [_knowledge_test("k-one"), _knowledge_test("k-two")]
+    tests[0].prompt = "BAD Which hook?"
+    runner = _runner_with_tests(
+        monkeypatch, tmp_path, knowledge=tests,
+        test_type="knowledge", continue_on_error=True,
+    )
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", _model_failing_on("BAD", good_text="A")
+    )
+
+    payload = runner.run()
+
+    records = {record["test_id"]: record for record in payload["results"]}
+    assert records["k-one"]["error"]["type"] == "RuntimeError"
+    assert records["k-two"]["error"] is None
+    # The errored test does not drag the knowledge score down.
+    assert payload["metadata"]["scores"]["knowledge"] == 1.0
+    assert payload["metadata"]["errored_test_ids"] == ["k-one"]
+
+
+def test_concurrent_execution_path_continues_on_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The legacy concurrent path (isolation none) honors the flag too."""
+    tests = [_execution_test("e-one"), _execution_test("e-two"), _execution_test("e-three")]
+    tests[2].prompt = "BAD Prompt"
+    runner = _runner_with_tests(
+        monkeypatch, tmp_path, execution=tests,
+        test_type="execution", continue_on_error=True,
+        execution_isolation="none", execution_concurrency=2,
+    )
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", _model_failing_on("BAD")
+    )
+
+    payload = runner.run()
+
+    records = {record["test_id"]: record for record in payload["results"]}
+    assert len(records) == 3
+    assert records["e-three"]["error"] is not None
+
+
+def test_systemic_failure_still_aborts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """continue_on_error must not burn the suite when every test errors."""
+    tests = [_execution_test(f"e-{index}") for index in range(8)]
+    runner = _runner_with_tests(
+        monkeypatch, tmp_path, execution=tests,
+        test_type="execution", continue_on_error=True,
+    )
+
+    def always_fail(prompt: str):
+        raise RuntimeError("bad credentials")
+
+    monkeypatch.setattr(runner.model, "generate_with_metadata", always_fail)
+
+    with pytest.raises(SystemExit):
+        runner.run()
+
+    # Aborted at the systemic threshold, not after burning all 8 tests.
+    assert len(runner.records) < len(tests)
+
+
+def test_all_error_run_aborts_even_below_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A small run whose every test errors must not write a null-score file."""
+    tests = [_execution_test("e-one"), _execution_test("e-two")]
+    runner = _runner_with_tests(
+        monkeypatch, tmp_path, execution=tests,
+        test_type="execution", continue_on_error=True,
+    )
+
+    def always_fail(prompt: str):
+        raise RuntimeError("bad credentials")
+
+    monkeypatch.setattr(runner.model, "generate_with_metadata", always_fail)
+
+    with pytest.raises(SystemExit):
+        runner.run()
+
+
+def test_success_after_errors_disarms_systemic_abort(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """One graded test proves the setup works; later errors are per-test."""
+    tests = [_execution_test(f"e-{index}") for index in range(8)]
+    tests[0].prompt = "GOOD Prompt"
+    for test in tests[1:]:
+        test.prompt = "BAD Prompt"
+    runner = _runner_with_tests(
+        monkeypatch, tmp_path, execution=tests,
+        test_type="execution", continue_on_error=True,
+    )
+    monkeypatch.setattr(
+        runner.model, "generate_with_metadata", _model_failing_on("BAD")
+    )
+
+    payload = runner.run()
+
+    assert len(payload["results"]) == 8
+    assert len(payload["metadata"]["errored_test_ids"]) == 7

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -120,6 +120,11 @@ class RunConfig(StrictModel):
     execution_concurrency: int = 1
     dry_run: bool = False
     check_reference_solution: bool = False
+    #: Record per-test errors (provider failures, harness exceptions) and
+    #: continue instead of aborting the run. Errored tests are excluded from
+    #: score aggregates and listed in result metadata. Diagnostic runs only:
+    #: official leaderboard runs must grade every selected test.
+    continue_on_error: bool = False
     #: Skip runtime assertions (diagnostic runs only). Official leaderboard
     #: runs must not skip grading dimensions.
     skip_runtime: bool = False

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -29,11 +29,14 @@ from .output import (
     print_model_header,
     print_reference_solution_failures,
     print_results_path,
+    print_systemic_abort,
     print_test_error,
+    print_test_warning,
 )
 from .artifacts import Artifact, ArtifactError, parse_artifact, render_artifact_instructions
 from .records import (
     RESULT_SCHEMA_VERSION,
+    build_error_record,
     build_execution_record,
     build_knowledge_record,
     execution_record_passed,
@@ -147,6 +150,55 @@ def _model_call_info(generation: Any) -> Dict[str, Any]:
     }
 
 
+class _ContinueOnErrorPolicy:
+    """Decides whether a per-test error aborts the run.
+
+    With ``run.continue_on_error`` disabled (the default), the first error
+    aborts — legacy behavior, required for official runs. When enabled,
+    per-test errors are recorded and the run continues, with one guardrail:
+    if the first ``SYSTEMIC_THRESHOLD`` processed tests all error with no
+    success in between, the failure is systemic (bad credentials, dead
+    runtime) rather than per-test, and burning through the remaining suite
+    would waste hours and API spend for an unusable result. Fail loudly
+    instead.
+    """
+
+    SYSTEMIC_THRESHOLD = 5
+
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
+        self.errors = 0
+        self.successes = 0
+        self.last_error: TestError | None = None
+
+    def record_success(self) -> None:
+        self.successes += 1
+
+    def should_abort(self, error: TestError) -> bool:
+        """Record an error and decide whether it aborts the run."""
+        if not self.enabled:
+            return True
+        self.errors += 1
+        self.last_error = error
+        if self.successes == 0 and self.errors >= self.SYSTEMIC_THRESHOLD:
+            print_systemic_abort(self.errors)
+            return True
+        return False
+
+    def finish(self) -> None:
+        """Abort a completed loop that graded nothing.
+
+        Small runs (``--limit`` below the threshold) can finish before the
+        systemic check trips. A run whose every test errored has produced no
+        score at all — writing a null-score results file would be silently
+        useless, so fail loudly with the last error instead.
+        """
+        if self.enabled and self.errors and not self.successes:
+            print_systemic_abort(self.errors)
+            assert self.last_error is not None
+            raise self.last_error
+
+
 def _run_isolated_execution_loop(
     *,
     tests_to_run: List[Any],
@@ -154,6 +206,7 @@ def _run_isolated_execution_loop(
     environment: WordPressEnvironment,
     process_test: Any,
     on_result: Any,
+    on_error: Any,
     progress_label: str,
 ) -> None:
     """Run execution-style tests honoring the configured isolation strategy.
@@ -166,35 +219,92 @@ def _run_isolated_execution_loop(
     ``none``: legacy concurrent behavior against a shared environment,
     bounded by ``run.execution_concurrency``. Not valid for official runs.
 
+    Per-test errors abort the run unless ``run.continue_on_error`` is set,
+    in which case they are warned about, recorded via ``on_error``, and the
+    run continues (see _ContinueOnErrorPolicy for the systemic-failure
+    guardrail).
+
     Args:
         tests_to_run: Tests to execute, already limited/filtered.
         config: Harness configuration (isolation strategy, concurrency).
         environment: WordPress environment shared by this run.
         process_test: Callable taking a test and returning a record dict.
         on_result: Callable invoked with each record (aggregation/appending).
+        on_error: Callable (test, TestError) -> error record.
         progress_label: Label for the progress bar.
     """
     isolation = config.run.execution_isolation
+    policy = _ContinueOnErrorPolicy(config.run.continue_on_error)
     with create_progress() as progress:
         task = progress.add_task(progress_label, total=len(tests_to_run))
         if isolation == "reset_per_test":
             for test in tests_to_run:
                 environment.reset()
-                result = process_test(test)
+                try:
+                    result = process_test(test)
+                except TestError as error:
+                    if policy.should_abort(error):
+                        raise
+                    print_test_warning(error)
+                    result = on_error(test, error)
+                else:
+                    policy.record_success()
                 on_result(result)
                 progress.update(task, advance=1)
+            policy.finish()
             return
         with ThreadPoolExecutor(max_workers=config.run.execution_concurrency) as executor:
             futures = {executor.submit(process_test, test): test for test in tests_to_run}
             for future in as_completed(futures):
                 try:
                     result = future.result()
-                    on_result(result)
-                    progress.update(task, advance=1)
-                except TestError:
-                    for f in futures:
-                        f.cancel()
-                    raise
+                except TestError as error:
+                    if policy.should_abort(error):
+                        for f in futures:
+                            f.cancel()
+                        raise
+                    print_test_warning(error)
+                    result = on_error(futures[future], error)
+                else:
+                    policy.record_success()
+                on_result(result)
+                progress.update(task, advance=1)
+    policy.finish()
+
+
+def _run_knowledge_loop(
+    *,
+    tests_to_run: List[Any],
+    config: HarnessConfig,
+    process_test: Any,
+    on_result: Any,
+    on_error: Any,
+) -> None:
+    """Run knowledge tests concurrently, honoring run.continue_on_error.
+
+    Shared by the single- and multi-model runners. Per-test errors abort
+    unless ``run.continue_on_error`` is set (see _ContinueOnErrorPolicy).
+    """
+    policy = _ContinueOnErrorPolicy(config.run.continue_on_error)
+    with create_progress() as progress:
+        task = progress.add_task("Knowledge", total=len(tests_to_run))
+        with ThreadPoolExecutor(max_workers=config.run.concurrency) as executor:
+            futures = {executor.submit(process_test, test): test for test in tests_to_run}
+            for future in as_completed(futures):
+                try:
+                    result = future.result()
+                except TestError as error:
+                    if policy.should_abort(error):
+                        for f in futures:
+                            f.cancel()
+                        raise
+                    print_test_warning(error)
+                    result = on_error(futures[future], error)
+                else:
+                    policy.record_success()
+                on_result(result)
+                progress.update(task, advance=1)
+    policy.finish()
 
 
 class BenchmarkRunner:
@@ -275,6 +385,12 @@ class BenchmarkRunner:
                 "selected_test_ids": sorted(
                     {record["test_id"] for record in self.records}
                 ),
+                "continue_on_error": self.config.run.continue_on_error,
+                "errored_test_ids": sorted(
+                    record["test_id"]
+                    for record in self.records
+                    if record.get("error") is not None
+                ),
                 "usage": self.usage_aggregator.summary(),
                 "scores": {
                     "knowledge": summary.knowledge,
@@ -327,7 +443,6 @@ class BenchmarkRunner:
             TestError: If any test fails, stops execution and raises with details.
         """
         tests_to_run = _limit_tests(tests, self.config)
-        concurrency = self.config.run.concurrency
 
         def process_test(test: KnowledgeTest) -> Dict[str, Any]:
             try:
@@ -349,22 +464,30 @@ class BenchmarkRunner:
             except Exception as e:
                 raise TestError(test.id, "knowledge", e) from e
 
-        with create_progress() as progress:
-            task = progress.add_task("Knowledge", total=len(tests_to_run))
-            with ThreadPoolExecutor(max_workers=concurrency) as executor:
-                futures = {executor.submit(process_test, test): test for test in tests_to_run}
-                for future in as_completed(futures):
-                    try:
-                        result = future.result()
-                        with self._lock:
-                            self.aggregator.add_knowledge(result["scores"]["knowledge"])
-                            self.usage_aggregator.add(result.get("usage"))
-                            self.records.append(result)
-                        progress.update(task, advance=1)
-                    except TestError:
-                        for f in futures:
-                            f.cancel()
-                        raise
+        def on_result(result: Dict[str, Any]) -> None:
+            with self._lock:
+                if result.get("error") is None:
+                    self.aggregator.add_knowledge(result["scores"]["knowledge"])
+                self.usage_aggregator.add(result.get("usage"))
+                self.records.append(result)
+
+        def on_error(test: KnowledgeTest, error: TestError) -> Dict[str, Any]:
+            return build_error_record(
+                test=test,
+                test_type="knowledge",
+                mode="model",
+                model_config=self.config.model,
+                error_type=type(error.original_error).__name__,
+                error_message=str(error.original_error),
+            )
+
+        _run_knowledge_loop(
+            tests_to_run=tests_to_run,
+            config=self.config,
+            process_test=process_test,
+            on_result=on_result,
+            on_error=on_error,
+        )
 
     def _run_execution_tests(self, tests: List[ExecutionTest]) -> None:
         """Run code generation execution tests in parallel.
@@ -426,9 +549,20 @@ class BenchmarkRunner:
 
         def on_result(result: Dict[str, Any]) -> None:
             with self._lock:
-                self.aggregator.add_execution(result["scores"])
+                if result.get("error") is None:
+                    self.aggregator.add_execution(result["scores"])
                 self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
+
+        def on_error(test: ExecutionTest, error: TestError) -> Dict[str, Any]:
+            return build_error_record(
+                test=test,
+                test_type="execution",
+                mode="model",
+                model_config=self.config.model,
+                error_type=type(error.original_error).__name__,
+                error_message=str(error.original_error),
+            )
 
         _run_isolated_execution_loop(
             tests_to_run=tests_to_run,
@@ -436,6 +570,7 @@ class BenchmarkRunner:
             environment=self.environment,
             process_test=process_test,
             on_result=on_result,
+            on_error=on_error,
             progress_label="Execution",
         )
 
@@ -477,9 +612,20 @@ class BenchmarkRunner:
 
         def on_result(result: Dict[str, Any]) -> None:
             with self._lock:
-                self.aggregator.add_execution(result["scores"])
+                if result.get("error") is None:
+                    self.aggregator.add_execution(result["scores"])
                 self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
+
+        def on_error(test: ExecutionTest, error: TestError) -> Dict[str, Any]:
+            return build_error_record(
+                test=test,
+                test_type="execution",
+                mode="reference_solution",
+                model_config=None,
+                error_type=type(error.original_error).__name__,
+                error_message=str(error.original_error),
+            )
 
         _run_isolated_execution_loop(
             tests_to_run=tests_to_run,
@@ -487,6 +633,7 @@ class BenchmarkRunner:
             environment=self.environment,
             process_test=process_test,
             on_result=on_result,
+            on_error=on_error,
             progress_label="Reference solutions",
         )
 
@@ -745,6 +892,7 @@ class MultiModelRunner:
                 "grader": self.config.grader.model_dump(mode="json"),
                 "dataset": self.config.dataset.model_dump(mode="json"),
                 "runtime_isolation": self.config.run.execution_isolation,
+                "continue_on_error": self.config.run.continue_on_error,
             },
             "models": {
                 name: {
@@ -809,6 +957,11 @@ class SingleModelRunner:
             "model_config": self.model_config.model_dump(mode="json"),
             "scoring_version": SCORING_VERSION,
             "usage": self.usage_aggregator.summary(),
+            "errored_test_ids": sorted(
+                record["test_id"]
+                for record in self.records
+                if record.get("error") is not None
+            ),
             "scores": {
                 "knowledge": summary.knowledge,
                 "execution_pass_rate": summary.execution_pass_rate,
@@ -823,7 +976,6 @@ class SingleModelRunner:
     def _run_knowledge_tests(self, tests: List[KnowledgeTest]) -> None:
         """Run knowledge tests in parallel. See BenchmarkRunner._run_knowledge_tests."""
         tests_to_run = _limit_tests(tests, self.config)
-        concurrency = self.config.run.concurrency
 
         def process_test(test: KnowledgeTest) -> Dict[str, Any]:
             try:
@@ -845,22 +997,30 @@ class SingleModelRunner:
             except Exception as e:
                 raise TestError(test.id, "knowledge", e) from e
 
-        with create_progress() as progress:
-            task = progress.add_task("Knowledge", total=len(tests_to_run))
-            with ThreadPoolExecutor(max_workers=concurrency) as executor:
-                futures = {executor.submit(process_test, test): test for test in tests_to_run}
-                for future in as_completed(futures):
-                    try:
-                        result = future.result()
-                        with self._lock:
-                            self.aggregator.add_knowledge(result["scores"]["knowledge"])
-                            self.usage_aggregator.add(result.get("usage"))
-                            self.records.append(result)
-                        progress.update(task, advance=1)
-                    except TestError:
-                        for f in futures:
-                            f.cancel()
-                        raise
+        def on_result(result: Dict[str, Any]) -> None:
+            with self._lock:
+                if result.get("error") is None:
+                    self.aggregator.add_knowledge(result["scores"]["knowledge"])
+                self.usage_aggregator.add(result.get("usage"))
+                self.records.append(result)
+
+        def on_error(test: KnowledgeTest, error: TestError) -> Dict[str, Any]:
+            return build_error_record(
+                test=test,
+                test_type="knowledge",
+                mode="model",
+                model_config=self.model_config,
+                error_type=type(error.original_error).__name__,
+                error_message=str(error.original_error),
+            )
+
+        _run_knowledge_loop(
+            tests_to_run=tests_to_run,
+            config=self.config,
+            process_test=process_test,
+            on_result=on_result,
+            on_error=on_error,
+        )
 
     def _run_execution_tests(self, tests: List[ExecutionTest]) -> None:
         """Run execution tests with isolation. See BenchmarkRunner._run_execution_tests."""
@@ -911,9 +1071,20 @@ class SingleModelRunner:
 
         def on_result(result: Dict[str, Any]) -> None:
             with self._lock:
-                self.aggregator.add_execution(result["scores"])
+                if result.get("error") is None:
+                    self.aggregator.add_execution(result["scores"])
                 self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
+
+        def on_error(test: ExecutionTest, error: TestError) -> Dict[str, Any]:
+            return build_error_record(
+                test=test,
+                test_type="execution",
+                mode="model",
+                model_config=self.model_config,
+                error_type=type(error.original_error).__name__,
+                error_message=str(error.original_error),
+            )
 
         _run_isolated_execution_loop(
             tests_to_run=tests_to_run,
@@ -921,5 +1092,6 @@ class SingleModelRunner:
             environment=self.environment,
             process_test=process_test,
             on_result=on_result,
+            on_error=on_error,
             progress_label="Execution",
         )

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -7,7 +7,7 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import orjson
 
@@ -39,6 +39,7 @@ from .records import (
     build_error_record,
     build_execution_record,
     build_knowledge_record,
+    errored_test_ids,
     execution_record_passed,
     sort_records,
 )
@@ -150,6 +151,28 @@ def _model_call_info(generation: Any) -> Dict[str, Any]:
     }
 
 
+def _error_record(
+    test: Any,
+    error: TestError,
+    *,
+    mode: str,
+    model_config: Optional[ModelConfig],
+) -> Dict[str, Any]:
+    """Canonical record for a test the runner caught erroring.
+
+    Unwraps the TestError (type/message/test-type) so each ``on_error``
+    call site is a one-liner rather than repeating the extraction.
+    """
+    return build_error_record(
+        test=test,
+        test_type=error.test_type,
+        mode=mode,
+        model_config=model_config,
+        error_type=type(error.original_error).__name__,
+        error_message=str(error.original_error),
+    )
+
+
 class _ContinueOnErrorPolicy:
     """Decides whether a per-test error aborts the run.
 
@@ -161,6 +184,10 @@ class _ContinueOnErrorPolicy:
     runtime) rather than per-test, and burning through the remaining suite
     would waste hours and API spend for an unusable result. Fail loudly
     instead.
+
+    Scope is intentionally per-loop: a fresh policy is created for each
+    test-type loop, so "systemic" is judged within a loop. In a combined run
+    knowledge runs first and would abort before execution starts.
     """
 
     SYSTEMIC_THRESHOLD = 5
@@ -174,8 +201,8 @@ class _ContinueOnErrorPolicy:
     def record_success(self) -> None:
         self.successes += 1
 
-    def should_abort(self, error: TestError) -> bool:
-        """Record an error and decide whether it aborts the run."""
+    def register_error(self, error: TestError) -> bool:
+        """Record a per-test error and return whether it aborts the run."""
         if not self.enabled:
             return True
         self.errors += 1
@@ -233,33 +260,62 @@ def _run_isolated_execution_loop(
         on_error: Callable (test, TestError) -> error record.
         progress_label: Label for the progress bar.
     """
-    isolation = config.run.execution_isolation
     policy = _ContinueOnErrorPolicy(config.run.continue_on_error)
+    if config.run.execution_isolation != "reset_per_test":
+        _run_concurrent_loop(
+            tests_to_run=tests_to_run,
+            max_workers=config.run.execution_concurrency,
+            progress_label=progress_label,
+            process_test=process_test,
+            on_result=on_result,
+            on_error=on_error,
+            policy=policy,
+        )
+        return
     with create_progress() as progress:
         task = progress.add_task(progress_label, total=len(tests_to_run))
-        if isolation == "reset_per_test":
-            for test in tests_to_run:
-                environment.reset()
-                try:
-                    result = process_test(test)
-                except TestError as error:
-                    if policy.should_abort(error):
-                        raise
-                    print_test_warning(error)
-                    result = on_error(test, error)
-                else:
-                    policy.record_success()
-                on_result(result)
-                progress.update(task, advance=1)
-            policy.finish()
-            return
-        with ThreadPoolExecutor(max_workers=config.run.execution_concurrency) as executor:
+        for test in tests_to_run:
+            environment.reset()
+            try:
+                result = process_test(test)
+            except TestError as error:
+                if policy.register_error(error):
+                    raise
+                print_test_warning(error)
+                result = on_error(test, error)
+            else:
+                policy.record_success()
+            on_result(result)
+            progress.update(task, advance=1)
+    policy.finish()
+
+
+def _run_concurrent_loop(
+    *,
+    tests_to_run: List[Any],
+    max_workers: int,
+    progress_label: str,
+    process_test: Any,
+    on_result: Any,
+    on_error: Any,
+    policy: "_ContinueOnErrorPolicy",
+) -> None:
+    """Run tests concurrently, honoring the continue-on-error policy.
+
+    The shared concurrent core for the knowledge loop and the ``none``
+    isolation execution branch — the only differences are the worker count
+    and progress label. A per-test error aborts (cancelling pending futures)
+    unless the policy records it and lets the run continue.
+    """
+    with create_progress() as progress:
+        task = progress.add_task(progress_label, total=len(tests_to_run))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = {executor.submit(process_test, test): test for test in tests_to_run}
             for future in as_completed(futures):
                 try:
                     result = future.result()
                 except TestError as error:
-                    if policy.should_abort(error):
+                    if policy.register_error(error):
                         for f in futures:
                             f.cancel()
                         raise
@@ -285,26 +341,15 @@ def _run_knowledge_loop(
     Shared by the single- and multi-model runners. Per-test errors abort
     unless ``run.continue_on_error`` is set (see _ContinueOnErrorPolicy).
     """
-    policy = _ContinueOnErrorPolicy(config.run.continue_on_error)
-    with create_progress() as progress:
-        task = progress.add_task("Knowledge", total=len(tests_to_run))
-        with ThreadPoolExecutor(max_workers=config.run.concurrency) as executor:
-            futures = {executor.submit(process_test, test): test for test in tests_to_run}
-            for future in as_completed(futures):
-                try:
-                    result = future.result()
-                except TestError as error:
-                    if policy.should_abort(error):
-                        for f in futures:
-                            f.cancel()
-                        raise
-                    print_test_warning(error)
-                    result = on_error(futures[future], error)
-                else:
-                    policy.record_success()
-                on_result(result)
-                progress.update(task, advance=1)
-    policy.finish()
+    _run_concurrent_loop(
+        tests_to_run=tests_to_run,
+        max_workers=config.run.concurrency,
+        progress_label="Knowledge",
+        process_test=process_test,
+        on_result=on_result,
+        on_error=on_error,
+        policy=_ContinueOnErrorPolicy(config.run.continue_on_error),
+    )
 
 
 class BenchmarkRunner:
@@ -386,11 +431,7 @@ class BenchmarkRunner:
                     {record["test_id"] for record in self.records}
                 ),
                 "continue_on_error": self.config.run.continue_on_error,
-                "errored_test_ids": sorted(
-                    record["test_id"]
-                    for record in self.records
-                    if record.get("error") is not None
-                ),
+                "errored_test_ids": errored_test_ids(self.records),
                 "usage": self.usage_aggregator.summary(),
                 "scores": {
                     "knowledge": summary.knowledge,
@@ -472,14 +513,7 @@ class BenchmarkRunner:
                 self.records.append(result)
 
         def on_error(test: KnowledgeTest, error: TestError) -> Dict[str, Any]:
-            return build_error_record(
-                test=test,
-                test_type="knowledge",
-                mode="model",
-                model_config=self.config.model,
-                error_type=type(error.original_error).__name__,
-                error_message=str(error.original_error),
-            )
+            return _error_record(test, error, mode="model", model_config=self.config.model)
 
         _run_knowledge_loop(
             tests_to_run=tests_to_run,
@@ -555,14 +589,7 @@ class BenchmarkRunner:
                 self.records.append(result)
 
         def on_error(test: ExecutionTest, error: TestError) -> Dict[str, Any]:
-            return build_error_record(
-                test=test,
-                test_type="execution",
-                mode="model",
-                model_config=self.config.model,
-                error_type=type(error.original_error).__name__,
-                error_message=str(error.original_error),
-            )
+            return _error_record(test, error, mode="model", model_config=self.config.model)
 
         _run_isolated_execution_loop(
             tests_to_run=tests_to_run,
@@ -618,14 +645,7 @@ class BenchmarkRunner:
                 self.records.append(result)
 
         def on_error(test: ExecutionTest, error: TestError) -> Dict[str, Any]:
-            return build_error_record(
-                test=test,
-                test_type="execution",
-                mode="reference_solution",
-                model_config=None,
-                error_type=type(error.original_error).__name__,
-                error_message=str(error.original_error),
-            )
+            return _error_record(test, error, mode="reference_solution", model_config=None)
 
         _run_isolated_execution_loop(
             tests_to_run=tests_to_run,
@@ -957,11 +977,7 @@ class SingleModelRunner:
             "model_config": self.model_config.model_dump(mode="json"),
             "scoring_version": SCORING_VERSION,
             "usage": self.usage_aggregator.summary(),
-            "errored_test_ids": sorted(
-                record["test_id"]
-                for record in self.records
-                if record.get("error") is not None
-            ),
+            "errored_test_ids": errored_test_ids(self.records),
             "scores": {
                 "knowledge": summary.knowledge,
                 "execution_pass_rate": summary.execution_pass_rate,
@@ -1005,14 +1021,7 @@ class SingleModelRunner:
                 self.records.append(result)
 
         def on_error(test: KnowledgeTest, error: TestError) -> Dict[str, Any]:
-            return build_error_record(
-                test=test,
-                test_type="knowledge",
-                mode="model",
-                model_config=self.model_config,
-                error_type=type(error.original_error).__name__,
-                error_message=str(error.original_error),
-            )
+            return _error_record(test, error, mode="model", model_config=self.model_config)
 
         _run_knowledge_loop(
             tests_to_run=tests_to_run,
@@ -1077,14 +1086,7 @@ class SingleModelRunner:
                 self.records.append(result)
 
         def on_error(test: ExecutionTest, error: TestError) -> Dict[str, Any]:
-            return build_error_record(
-                test=test,
-                test_type="execution",
-                mode="model",
-                model_config=self.model_config,
-                error_type=type(error.original_error).__name__,
-                error_message=str(error.original_error),
-            )
+            return _error_record(test, error, mode="model", model_config=self.model_config)
 
         _run_isolated_execution_loop(
             tests_to_run=tests_to_run,

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -49,6 +49,24 @@ def print_test_error(error: TestError) -> None:
     console.print(panel)
 
 
+def print_test_warning(error: TestError) -> None:
+    """Display a one-line warning for a test recorded as errored, not aborting."""
+    console.print(
+        f"[yellow]⚠ Test errored[/yellow] [cyan]{error.test_id}[/cyan] "
+        f"([magenta]{error.test_type}[/magenta]): "
+        f"[red]{type(error.original_error).__name__}[/red] {error.original_error}"
+    )
+
+
+def print_systemic_abort(error_count: int) -> None:
+    """Explain why continue_on_error still aborted: every test errored."""
+    console.print(
+        f"[red]✖ Aborting despite run.continue_on_error: {error_count} "
+        f"test(s) errored with zero successes — this looks systemic "
+        f"(bad credentials, unreachable runtime), not per-test.[/red]"
+    )
+
+
 def print_abort_message() -> None:
     """Display a message when the benchmark is aborted by the user."""
     panel = Panel(

--- a/python/wp_bench/records.py
+++ b/python/wp_bench/records.py
@@ -39,6 +39,50 @@ def _empty_usage() -> Dict[str, Any]:
     }
 
 
+def _null_scores() -> Dict[str, Any]:
+    """The full score key set, all null — a record that carries no score."""
+    return {
+        "knowledge": None,
+        "correctness": None,
+        "execution_pass": None,
+        "runtime": None,
+        "static": None,
+        "static_policy_pass": None,
+    }
+
+
+def _base_record(
+    *,
+    test: Any,
+    test_type: str,
+    mode: str,
+    model_config: Optional[ModelConfig],
+) -> Dict[str, Any]:
+    """The canonical per-test record skeleton shared by every builder.
+
+    Every field defaults to its null/empty form; each builder overrides only
+    the ones its record populates. Centralizing the key structure here keeps
+    the builders from drifting (the key set is asserted identical in tests).
+    """
+    return {
+        "test_id": test.id,
+        "suite": test.suite,
+        "type": test_type,
+        "category": test.category,
+        "difficulty": test.difficulty,
+        "metadata": getattr(test, "metadata", None) or {},
+        "mode": mode,
+        "prompt_hash": None,
+        "model": _model_info(model_config),
+        "output": {"raw_completion": None, "code": None, "answer": None},
+        "scores": _null_scores(),
+        "grader": None,
+        "usage": _empty_usage(),
+        "model_call": None,
+        "error": None,
+    }
+
+
 def build_knowledge_record(
     *,
     test: Any,
@@ -52,34 +96,13 @@ def build_knowledge_record(
     model_call: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build the canonical record for a knowledge test result."""
-    return {
-        "test_id": test.id,
-        "suite": test.suite,
-        "type": "knowledge",
-        "category": test.category,
-        "difficulty": test.difficulty,
-        "metadata": getattr(test, "metadata", None) or {},
-        "mode": mode,
-        "prompt_hash": prompt_hash,
-        "model": _model_info(model_config),
-        "output": {
-            "raw_completion": raw_completion,
-            "code": None,
-            "answer": answer,
-        },
-        "scores": {
-            "knowledge": knowledge_score,
-            "correctness": None,
-            "execution_pass": None,
-            "runtime": None,
-            "static": None,
-            "static_policy_pass": None,
-        },
-        "grader": None,
-        "usage": usage if usage is not None else _empty_usage(),
-        "model_call": model_call,
-        "error": None,
-    }
+    record = _base_record(test=test, test_type="knowledge", mode=mode, model_config=model_config)
+    record["prompt_hash"] = prompt_hash
+    record["output"] = {"raw_completion": raw_completion, "code": None, "answer": answer}
+    record["scores"]["knowledge"] = knowledge_score
+    record["usage"] = usage if usage is not None else _empty_usage()
+    record["model_call"] = model_call
+    return record
 
 
 def build_execution_record(
@@ -103,33 +126,20 @@ def build_execution_record(
             and static_policy_pass.
     """
     raw = env_result.raw or {}
-    return {
-        "test_id": test.id,
-        "suite": test.suite,
-        "type": "execution",
-        "category": test.category,
-        "difficulty": test.difficulty,
-        "metadata": getattr(test, "metadata", None) or {},
-        "mode": mode,
-        "prompt_hash": prompt_hash,
-        "model": _model_info(model_config),
-        "output": {
-            "raw_completion": raw_completion,
-            "code": code,
-            "answer": None,
-        },
-        "scores": scores,
-        "grader": {
-            "success": env_result.success,
-            "raw": raw,
-            "stdout": env_result.stdout,
-            "stderr": env_result.stderr,
-            "timeout": bool(raw.get("timeout", False)) or getattr(env_result, "timed_out", False),
-        },
-        "usage": usage if usage is not None else _empty_usage(),
-        "model_call": model_call,
-        "error": None,
+    record = _base_record(test=test, test_type="execution", mode=mode, model_config=model_config)
+    record["prompt_hash"] = prompt_hash
+    record["output"] = {"raw_completion": raw_completion, "code": code, "answer": None}
+    record["scores"] = scores
+    record["grader"] = {
+        "success": env_result.success,
+        "raw": raw,
+        "stdout": env_result.stdout,
+        "stderr": env_result.stderr,
+        "timeout": bool(raw.get("timeout", False)) or getattr(env_result, "timed_out", False),
     }
+    record["usage"] = usage if usage is not None else _empty_usage()
+    record["model_call"] = model_call
+    return record
 
 
 def build_error_record(
@@ -148,37 +158,9 @@ def build_error_record(
     pass or fail), and keeps the exact canonical key structure so consumers
     never need a separate parser for errored tests.
     """
-    return {
-        "test_id": test.id,
-        "suite": test.suite,
-        "type": test_type,
-        "category": test.category,
-        "difficulty": test.difficulty,
-        "metadata": getattr(test, "metadata", None) or {},
-        "mode": mode,
-        "prompt_hash": None,
-        "model": _model_info(model_config),
-        "output": {
-            "raw_completion": None,
-            "code": None,
-            "answer": None,
-        },
-        "scores": {
-            "knowledge": None,
-            "correctness": None,
-            "execution_pass": None,
-            "runtime": None,
-            "static": None,
-            "static_policy_pass": None,
-        },
-        "grader": None,
-        "usage": _empty_usage(),
-        "model_call": None,
-        "error": {
-            "type": error_type,
-            "message": error_message,
-        },
-    }
+    record = _base_record(test=test, test_type=test_type, mode=mode, model_config=model_config)
+    record["error"] = {"type": error_type, "message": error_message}
+    return record
 
 
 def execution_record_passed(record: Dict[str, Any]) -> bool:
@@ -193,3 +175,8 @@ def execution_record_passed(record: Dict[str, Any]) -> bool:
 def sort_records(records: list) -> list:
     """Order records deterministically for stable output diffs."""
     return sorted(records, key=lambda record: (record.get("type", ""), record.get("test_id", "")))
+
+
+def errored_test_ids(records: list) -> list:
+    """Sorted ids of records that errored (run.continue_on_error)."""
+    return sorted(record["test_id"] for record in records if record.get("error") is not None)

--- a/python/wp_bench/records.py
+++ b/python/wp_bench/records.py
@@ -132,6 +132,55 @@ def build_execution_record(
     }
 
 
+def build_error_record(
+    *,
+    test: Any,
+    test_type: str,
+    mode: str,
+    model_config: Optional[ModelConfig],
+    error_type: str,
+    error_message: str,
+) -> Dict[str, Any]:
+    """Build the canonical record for a test that errored before grading.
+
+    Used by ``run.continue_on_error``: the record fills the reserved
+    ``error`` field, carries null scores (an ungraded test has no score,
+    pass or fail), and keeps the exact canonical key structure so consumers
+    never need a separate parser for errored tests.
+    """
+    return {
+        "test_id": test.id,
+        "suite": test.suite,
+        "type": test_type,
+        "category": test.category,
+        "difficulty": test.difficulty,
+        "metadata": getattr(test, "metadata", None) or {},
+        "mode": mode,
+        "prompt_hash": None,
+        "model": _model_info(model_config),
+        "output": {
+            "raw_completion": None,
+            "code": None,
+            "answer": None,
+        },
+        "scores": {
+            "knowledge": None,
+            "correctness": None,
+            "execution_pass": None,
+            "runtime": None,
+            "static": None,
+            "static_policy_pass": None,
+        },
+        "grader": None,
+        "usage": _empty_usage(),
+        "model_call": None,
+        "error": {
+            "type": error_type,
+            "message": error_message,
+        },
+    }
+
+
 def execution_record_passed(record: Dict[str, Any]) -> bool:
     """Whether an execution record represents a strict pass.
 

--- a/wp-bench.example.yaml
+++ b/wp-bench.example.yaml
@@ -56,6 +56,13 @@ run:
   # dimension; skipping either invalidates a run for comparison purposes.
   # skip_runtime: false  # skip runtime assertions (static checks only)
   # skip_static: false   # skip static checks (runtime assertions only)
+  # Record per-test errors (provider blips, harness exceptions) and keep
+  # going instead of aborting the run. Errored tests carry an `error` object
+  # in results, are excluded from score aggregates, and are listed in
+  # metadata.errored_test_ids. A run where every test errors still aborts
+  # (that is systemic failure, not per-test). Diagnostic runs only: official
+  # leaderboard runs must grade every selected test.
+  # continue_on_error: false
 
 # Output paths
 output:


### PR DESCRIPTION
## What

New `run.continue_on_error` switch (default **false**): when enabled, an unrecoverable per-test error — a provider failure that survives the retry policy, or an unexpected harness exception — is warned about on one line, recorded as a canonical result record with the `error` field populated, and the run continues to the next test.

- **Errored records fill the schema's reserved seam**: `error: {type, message}` (reserved null since the unified schema landed), null scores, exact canonical key structure — no `RESULT_SCHEMA_VERSION` bump, no fourth parser needed.
- **Excluded from aggregates, by design**: an ungraded test neither passes nor fails, so infrastructure failures never masquerade as model failures in `execution_pass_rate`/`knowledge`. The trade-off (a diagnostic run's denominator shrinks) is disclosed in the results file via `metadata.continue_on_error` and `metadata.errored_test_ids` — an auditor can always see exactly which tests were skipped and why the run is not leaderboard material.
- **Systemic guardrail, two layers**: (1) if the first 5 processed tests all error with zero successes, abort immediately — bad credentials or a dead runtime should not burn 470 tests of wall-clock and spend; (2) a run that *completes* with errors and zero graded tests (e.g. `--limit 3`, all erroring) also aborts instead of writing a useless null-score results file. One graded success disarms both — after that, errors are per-test facts worth recording.
- Applies to knowledge, execution, and reference-solution paths (an errored reference test shows up in the failure table → exit 1, so authors see *all* broken tests in one pass instead of dying at the first).
- Incidental de-dup: the two identical knowledge futures loops (single/multi-model) collapse into a shared `_run_knowledge_loop()`, mirroring `_run_isolated_execution_loop`.

## Why

A full run is hours of compute and thousands of model calls. The retry layer (#32) absorbs transient blips, but a single error that survives it currently aborts the entire run and discards everything already graded. For long diagnostic runs the right cost of one bad test is one record — while official leaderboard runs keep the strict default: every selected test must grade, so the flag is off by default and documented as diagnostic-only (same contract as `skip_runtime`/`execution_isolation: none`).

This is deliberately the first slice of the "distinguish infrastructure failures from model failures" direction noted in #32 — resumable runs can build on the same error-record shape later.

## Verification

- [x] `ruff check python` — clean
- [x] `mypy python` — clean (0 errors)
- [x] `pytest python` — **142 passed** (9 new: default-off still aborts; error recorded + run continues on serial, concurrent, and knowledge paths; aggregates exclude errored tests; metadata audit fields; systemic abort after 5 straight errors; all-error run below the threshold aborts too; one success disarms the guardrail)
- [ ] PHP syntax / runtime smoke test — n/a (`runtime/` untouched)

## Score impact

- [x] This PR does **not** change how any test is scored. Default behavior is byte-identical (flag off → legacy abort). With the flag on, graded tests score exactly as before; errored tests carry null scores and are excluded from aggregates — and such runs are diagnostic-only by documentation, not leaderboard artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)