### PR TITLE
feat: add --check-exploits adversarial assertion audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,23 @@ wp-bench run --test-type execution           # run only execution tests
 wp-bench run --test-type execution --test-id e-abilities-api-001
 wp-bench run --test-id e-abilities-api-001 --test-id e-rest-api-001
 wp-bench run --config wp-bench.yaml --dry-run # validate config without calling models
+wp-bench run --check-reference-solution --test-type execution  # verify reference solutions pass
+wp-bench run --check-exploits --test-type execution            # adversarial assertion audit (see below)
+```
+
+### Adversarial assertion audit
+
+`--check-reference-solution` proves a correct solution *passes*; `--check-exploits`
+proves that trivial cheats *fail*. For every execution test it runs a battery of
+zero-effort stubs (an empty function, `return 1`, `return true`, `return array()`, …)
+through the real WordPress verifier and flags any test whose assertions a cheat can
+satisfy. Such a test is under-specified — its assertions check a predictable output
+(one fixture's answer) rather than the WordPress behavior the task describes, so a
+model could score on it without doing the work. Exits non-zero if any test is
+exploitable; results (with the passing cheat per test) are written to the output file.
+
+```bash
+wp-bench run --check-exploits --test-type execution
 ```
 
 ## Repository Structure

--- a/python/tests/test_exploit_audit.py
+++ b/python/tests/test_exploit_audit.py
@@ -1,0 +1,201 @@
+"""Tests for the adversarial assertion audit (--check-exploits)."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wp_bench.config import (
+    DatasetConfig,
+    GraderConfig,
+    HarnessConfig,
+    ModelConfig,
+    OutputConfig,
+    RunConfig,
+)
+from wp_bench.core import BenchmarkRunner
+from wp_bench.datasets import ExecutionTest
+from wp_bench.environment import ExecutionResult
+from wp_bench.exploits import exploit_candidates, generic_exploit_candidates
+
+
+def _execution_test(test_id: str, test_function: str | None = "wpbp_x( int $n ): int") -> ExecutionTest:
+    return ExecutionTest(
+        id=test_id,
+        suite="wp-core-v1",
+        prompt="Prompt",
+        expected_behavior="expected",
+        test_type="execution",
+        category="general",
+        difficulty="basic",
+        requirements=[],
+        test_function=test_function,
+        static_checks={},
+        runtime_checks={"assertions": [{"type": "custom_assertion", "code": "return true;", "weight": 1}]},
+        reference_solution="function wpbp_x( int $n ): int { return $n; }",
+        metadata={},
+    )
+
+
+def _pass_raw() -> dict:
+    return {
+        "success": True,
+        "static": {"score": 1.0, "details": {"total_weight": 1}},
+        "runtime": {"score": 1.0, "details": {"total_weight": 1}},
+    }
+
+
+def _fail_raw() -> dict:
+    return {
+        "success": True,
+        "static": {"score": 0.0, "details": {"total_weight": 1}},
+        "runtime": {"score": 0.0, "details": {"total_weight": 1, "assertions": [{"passed": False}]}},
+    }
+
+
+class VulnerableEnv:
+    """Stub runtime where any code returning the constant 1 'passes'.
+
+    Models a single-fixture assertion whose expected answer is 1 — exactly
+    the class of under-specified test the audit exists to catch.
+    """
+
+    def setup(self) -> None:
+        pass
+
+    def reset(self) -> None:
+        pass
+
+    def execute_artifact(self, artifact: Any, verification_spec: dict) -> ExecutionResult:
+        passes = "return 1;" in artifact.code
+        raw = _pass_raw() if passes else _fail_raw()
+        return ExecutionResult(success=True, raw=raw, stdout="", stderr="")
+
+
+class RobustEnv:
+    """Stub runtime where no zero-effort cheat ever passes."""
+
+    def setup(self) -> None:
+        pass
+
+    def reset(self) -> None:
+        pass
+
+    def execute_artifact(self, artifact: Any, verification_spec: dict) -> ExecutionResult:
+        return ExecutionResult(success=True, raw=_fail_raw(), stdout="", stderr="")
+
+
+def _config(tmp_path: Path, **run_overrides: Any) -> HarnessConfig:
+    return HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        model=ModelConfig(name="test-model"),
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(test_type="execution", check_exploits=True, **run_overrides),
+        output=OutputConfig(path=tmp_path / "results.json", jsonl_path=None),
+    )
+
+
+def _runner(monkeypatch, tmp_path, tests, env) -> BenchmarkRunner:
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests",
+        lambda dataset: {"execution": tests, "knowledge": []},
+    )
+    runner = BenchmarkRunner(_config(tmp_path))
+    runner.environment = env  # type: ignore[assignment]
+    return runner
+
+
+# --- candidate generation ---------------------------------------------------
+
+
+def test_generic_candidates_synthesize_gateway_stubs() -> None:
+    test = _execution_test("e-one")
+    candidates = generic_exploit_candidates(test)
+    labels = [label for label, _ in candidates]
+    assert "empty-stub" in labels
+    assert "return-1" in labels
+    # Every candidate defines the test's gateway function by name.
+    assert all("function wpbp_x()" in code for _, code in candidates)
+
+
+def test_no_test_function_yields_no_generic_candidates() -> None:
+    test = _execution_test("e-one", test_function=None)
+    assert generic_exploit_candidates(test) == []
+
+
+def test_plugin_artifact_yields_no_generic_candidates() -> None:
+    test = _execution_test("e-one")
+    test.artifact_kind = "wp_plugin_files"
+    assert generic_exploit_candidates(test) == []
+
+
+def test_exploit_candidates_equal_generic_without_authored() -> None:
+    # Authored exploit_solutions are a follow-up schema field; until then the
+    # candidate set is exactly the generic battery.
+    test = _execution_test("e-one")
+    assert exploit_candidates(test) == generic_exploit_candidates(test)
+
+
+# --- audit behavior ---------------------------------------------------------
+
+
+def test_vulnerable_test_is_flagged_and_exits_nonzero(monkeypatch, tmp_path) -> None:
+    runner = _runner(monkeypatch, tmp_path, [_execution_test("e-vuln")], VulnerableEnv())
+
+    with pytest.raises(SystemExit) as exc:
+        runner.run()
+
+    assert exc.value.code == 1
+    record = runner.records[0]
+    assert record["exploitable"] is True
+    assert record["passing_exploit"] == "return-1"
+    assert "return 1;" in record["exploit_code"]
+
+
+def test_robust_test_is_not_flagged(monkeypatch, tmp_path) -> None:
+    runner = _runner(monkeypatch, tmp_path, [_execution_test("e-safe")], RobustEnv())
+
+    payload = runner.run()
+
+    record = payload["results"][0]
+    assert record["exploitable"] is False
+    assert record["candidates_tried"] > 0
+    assert payload["metadata"]["audit"]["exploitable"] == 0
+
+
+def test_audit_metadata_lists_exploitable_ids(monkeypatch, tmp_path) -> None:
+    tests = [_execution_test("e-vuln"), _execution_test("e-safe", test_function=None)]
+    runner = _runner(monkeypatch, tmp_path, tests, VulnerableEnv())
+
+    with pytest.raises(SystemExit):
+        runner.run()
+
+    audit = _read_audit_metadata(runner)
+    assert audit["exploitable_test_ids"] == ["e-vuln"]
+    # e-safe has no test_function → not covered by the generic battery.
+    assert audit["not_auditable"] == 1
+    assert audit["auditable"] == 1
+
+
+def _read_audit_metadata(runner: BenchmarkRunner) -> dict:
+    exploitable = [r for r in runner.records if r["exploitable"]]
+    auditable = [r for r in runner.records if r["auditable"]]
+    return {
+        "exploitable_test_ids": sorted(r["test_id"] for r in exploitable),
+        "auditable": len(auditable),
+        "not_auditable": len(runner.records) - len(auditable),
+    }
+
+
+# --- config guards ----------------------------------------------------------
+
+
+def test_check_exploits_rejects_reference_solution_combo() -> None:
+    with pytest.raises(ValueError, match="separate audit modes"):
+        RunConfig(check_exploits=True, check_reference_solution=True)
+
+
+def test_check_exploits_rejects_dry_run_combo() -> None:
+    with pytest.raises(ValueError, match="cannot be combined with run.dry_run"):
+        RunConfig(check_exploits=True, dry_run=True)

--- a/python/tests/test_exploit_audit.py
+++ b/python/tests/test_exploit_audit.py
@@ -180,7 +180,7 @@ def test_audit_metadata_lists_exploitable_ids(monkeypatch, tmp_path) -> None:
 
 def _read_audit_metadata(runner: BenchmarkRunner) -> dict:
     exploitable = [r for r in runner.records if r["exploitable"]]
-    auditable = [r for r in runner.records if r["auditable"]]
+    auditable = [r for r in runner.records if r["candidates_tried"] > 0]
     return {
         "exploitable_test_ids": sorted(r["test_id"] for r in exploitable),
         "auditable": len(auditable),

--- a/python/wp_bench/cli.py
+++ b/python/wp_bench/cli.py
@@ -107,6 +107,10 @@ def run(
         False,
         help="Run execution tests with their reference_solution instead of calling models",
     ),
+    check_exploits: bool = typer.Option(
+        False,
+        help="Adversarial assertion audit: flag execution tests a zero-effort cheat can pass",
+    ),
     test_id: Optional[List[str]] = typer.Option(
         None,
         "--test-id",
@@ -126,6 +130,8 @@ def run(
         harness_config.run.dry_run = True
     if check_reference_solution:
         harness_config.run.check_reference_solution = True
+    if check_exploits:
+        harness_config.run.check_exploits = True
     normalized_test_ids = _normalize_test_ids(test_id)
     if normalized_test_ids:
         harness_config.run.test_ids = normalized_test_ids
@@ -156,6 +162,16 @@ def run(
             console.print(f"[red]{exc}[/red]")
             raise typer.Exit(1) from exc
         console.print("[bold green]Reference solution check completed[/bold green]", result["metadata"]["scores"])
+        return
+
+    if harness_config.run.check_exploits:
+        exploit_runner = BenchmarkRunner(harness_config)
+        try:
+            result = exploit_runner.run()
+        except ValueError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1) from exc
+        console.print("[bold green]Exploit audit completed[/bold green]", result["metadata"]["audit"])
         return
 
     # Check if multi-model mode

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -125,6 +125,12 @@ class RunConfig(StrictModel):
     #: score aggregates and listed in result metadata. Diagnostic runs only:
     #: official leaderboard runs must grade every selected test.
     continue_on_error: bool = False
+    #: Adversarial assertion audit: run zero-effort cheats against each test
+    #: and flag any whose assertions a cheat can satisfy (they are
+    #: under-specified). The mirror of check_reference_solution — that proves
+    #: correct code passes; this proves wrong code fails. Diagnostic tooling,
+    #: not a scored run.
+    check_exploits: bool = False
     #: Skip runtime assertions (diagnostic runs only). Official leaderboard
     #: runs must not skip grading dimensions.
     skip_runtime: bool = False
@@ -160,6 +166,17 @@ class RunConfig(StrictModel):
                 "run.skip_runtime and run.skip_static cannot both be true: "
                 "execution tests would have no grading dimension left."
             )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_exclusive_modes(self) -> "RunConfig":
+        if self.check_exploits and self.check_reference_solution:
+            raise ValueError(
+                "run.check_exploits and run.check_reference_solution are "
+                "separate audit modes and cannot both be enabled."
+            )
+        if self.check_exploits and self.dry_run:
+            raise ValueError("run.check_exploits cannot be combined with run.dry_run.")
         return self
 
 

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -1,13 +1,12 @@
 """Main orchestration loop for WP-Bench."""
 from __future__ import annotations
 
-import re
 import threading
 import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import orjson
 
@@ -35,11 +34,12 @@ from .output import (
     print_test_warning,
 )
 from .artifacts import Artifact, ArtifactError, parse_artifact, render_artifact_instructions
-from .exploits import exploit_candidates
+from .exploits import exploit_candidates, gateway_name
 from .records import (
     RESULT_SCHEMA_VERSION,
     build_error_record,
     build_execution_record,
+    build_exploit_audit_record,
     build_knowledge_record,
     errored_test_ids,
     execution_record_passed,
@@ -95,13 +95,12 @@ def _build_verification_spec(test: Any, config: HarnessConfig) -> Dict[str, Any]
     else:
         runtime_checks = dict(test.runtime_checks)
         if test.test_function:
-            match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", test.test_function.strip())
-            if not match:
+            name = gateway_name(test)
+            if not name:
                 raise ValueError(
                     f"Cannot extract function name from test_function "
                     f"signature: {test.test_function!r}"
                 )
-            name = match.group(0)
             derived = {
                 "type": "function_exists",
                 "target": name,
@@ -395,7 +394,7 @@ class BenchmarkRunner:
         if reference_mode:
             if test_type == "knowledge":
                 raise ValueError("--check-reference-solution only supports execution tests")
-            self._ensure_reference_solution_ids_are_execution_tests(tests)
+            self._ensure_execution_only_ids("--check-reference-solution", tests)
             run_knowledge = False
             run_execution = True
         else:
@@ -457,23 +456,6 @@ class BenchmarkRunner:
                 print_reference_solution_failures(failures)
                 raise SystemExit(1)
         return payload
-
-    def _ensure_reference_solution_ids_are_execution_tests(
-        self,
-        tests: Dict[str, List[Any]],
-    ) -> None:
-        """Ensure reference-solution mode is scoped to execution tests."""
-        selected_ids = self.config.run.test_ids
-        if not selected_ids:
-            return
-
-        execution_ids = {test.id for test in tests["execution"]}
-        non_execution_ids = [test_id for test_id in selected_ids if test_id not in execution_ids]
-        if non_execution_ids:
-            raise ValueError(
-                "--check-reference-solution only supports execution test id(s): "
-                + ", ".join(non_execution_ids)
-            )
 
     def _run_knowledge_tests(self, tests: List[KnowledgeTest]) -> None:
         """Run knowledge tests in parallel.
@@ -685,7 +667,14 @@ class BenchmarkRunner:
             raise SystemExit(130) from None
 
         exploitable = [record for record in self.records if record["exploitable"]]
-        auditable = [record for record in self.records if record["auditable"]]
+        auditable = sum(1 for record in self.records if record["candidates_tried"] > 0)
+        audit = {
+            "total": len(self.records),
+            "auditable": auditable,
+            "not_auditable": len(self.records) - auditable,
+            "exploitable": len(exploitable),
+            "exploitable_test_ids": sorted(record["test_id"] for record in exploitable),
+        }
         payload = {
             "metadata": {
                 "suite": self.config.run.suite,
@@ -695,20 +684,12 @@ class BenchmarkRunner:
                 "grader": self.config.grader.model_dump(mode="json"),
                 "dataset": self.config.dataset.model_dump(mode="json"),
                 "runtime_isolation": self.config.run.execution_isolation,
-                "audit": {
-                    "total": len(self.records),
-                    "auditable": len(auditable),
-                    "not_auditable": len(self.records) - len(auditable),
-                    "exploitable": len(exploitable),
-                    "exploitable_test_ids": sorted(
-                        record["test_id"] for record in exploitable
-                    ),
-                },
+                "audit": audit,
             },
             "results": sort_records(self.records),
         }
         self._write_outputs(payload)
-        print_exploit_findings(self.records)
+        print_exploit_findings(audit, exploitable)
         if exploitable:
             raise SystemExit(1)
         return payload
@@ -725,41 +706,47 @@ class BenchmarkRunner:
             task = progress.add_task("Exploit audit", total=len(tests_to_run))
             for test in tests_to_run:
                 candidates = exploit_candidates(test)
-                record: Dict[str, Any] = {
-                    "test_id": test.id,
-                    "suite": test.suite,
-                    "type": "execution",
-                    "category": test.category,
-                    "difficulty": test.difficulty,
-                    "auditable": bool(candidates),
-                    "candidates_tried": len(candidates),
-                    "exploitable": False,
-                    "passing_exploit": None,
-                    "exploit_code": None,
-                }
                 try:
-                    for label, code in candidates:
-                        self.environment.reset()
-                        env_result = self.environment.execute_artifact(
-                            Artifact(kind="php_snippet", code=code),
-                            _build_verification_spec(test, self.config),
-                        )
-                        scores = self._score_execution(
-                            env_result.raw,
-                            test,
-                            skip_runtime=self.config.run.skip_runtime,
-                            skip_static=self.config.run.skip_static,
-                        )
-                        if scores.get("execution_pass"):
-                            record["exploitable"] = True
-                            record["passing_exploit"] = label
-                            record["exploit_code"] = code
-                            break
+                    hit = self._first_passing_exploit(test, candidates)
                 except Exception as e:
                     raise TestError(test.id, "execution", e) from e
+                record = build_exploit_audit_record(
+                    test=test,
+                    candidates_tried=len(candidates),
+                    passing_exploit=hit[0] if hit else None,
+                    exploit_code=hit[1] if hit else None,
+                )
                 with self._lock:
                     self.records.append(record)
                 progress.update(task, advance=1)
+
+    def _first_passing_exploit(
+        self,
+        test: ExecutionTest,
+        candidates: List[Tuple[str, str]],
+    ) -> Optional[Tuple[str, str]]:
+        """Return the first (label, code) cheat that satisfies the assertions.
+
+        The verification spec is identical across a test's candidates, so it
+        is built once here rather than per candidate. Returns None when no
+        cheat passes — the test's assertions rejected every zero-effort stub.
+        """
+        verification_spec = _build_verification_spec(test, self.config)
+        for label, code in candidates:
+            self.environment.reset()
+            env_result = self.environment.execute_artifact(
+                Artifact(kind="php_snippet", code=code),
+                verification_spec,
+            )
+            scores = self._score_execution(
+                env_result.raw,
+                test,
+                skip_runtime=self.config.run.skip_runtime,
+                skip_static=self.config.run.skip_static,
+            )
+            if scores.get("execution_pass"):
+                return (label, code)
+        return None
 
     def _ensure_execution_only_ids(self, mode_flag: str, tests: Dict[str, List[Any]]) -> None:
         """Ensure explicitly selected test ids are execution tests for audit modes."""

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -26,6 +26,7 @@ from .output import (
     create_progress,
     print_abort_message,
     print_comparison_table,
+    print_exploit_findings,
     print_model_header,
     print_reference_solution_failures,
     print_results_path,
@@ -34,6 +35,7 @@ from .output import (
     print_test_warning,
 )
 from .artifacts import Artifact, ArtifactError, parse_artifact, render_artifact_instructions
+from .exploits import exploit_candidates
 from .records import (
     RESULT_SCHEMA_VERSION,
     build_error_record,
@@ -387,6 +389,8 @@ class BenchmarkRunner:
         """
         tests = filter_tests_by_ids(load_tests(self.config.dataset), self.config.run.test_ids)
         test_type = self.config.run.test_type
+        if self.config.run.check_exploits:
+            return self._run_exploit_audit(tests)
         reference_mode = self.config.run.check_reference_solution
         if reference_mode:
             if test_type == "knowledge":
@@ -656,6 +660,119 @@ class BenchmarkRunner:
             on_error=on_error,
             progress_label="Reference solutions",
         )
+
+    def _run_exploit_audit(self, tests: Dict[str, List[Any]]) -> Dict[str, Any]:
+        """Adversarial assertion audit: prove zero-effort cheats fail.
+
+        For every execution test, run each exploit candidate (generic
+        battery + any authored exploit_solutions) through the real verifier
+        and check whether it earns ``execution_pass``. A test a cheat can
+        pass is under-specified — its assertions check a predictable output
+        rather than the WordPress behavior the task describes. Exits non-zero
+        when any test is exploitable, mirroring reference-solution mode.
+        """
+        if self.config.run.test_type == "knowledge":
+            raise ValueError("--check-exploits only supports execution tests")
+        self._ensure_execution_only_ids("--check-exploits", tests)
+        self.environment.setup()
+        try:
+            self._run_exploit_audit_tests(tests["execution"])
+        except TestError as e:
+            print_test_error(e)
+            raise SystemExit(1) from e
+        except KeyboardInterrupt:
+            print_abort_message()
+            raise SystemExit(130) from None
+
+        exploitable = [record for record in self.records if record["exploitable"]]
+        auditable = [record for record in self.records if record["auditable"]]
+        payload = {
+            "metadata": {
+                "suite": self.config.run.suite,
+                "mode": "exploit_audit",
+                "result_schema_version": RESULT_SCHEMA_VERSION,
+                "scoring_version": SCORING_VERSION,
+                "grader": self.config.grader.model_dump(mode="json"),
+                "dataset": self.config.dataset.model_dump(mode="json"),
+                "runtime_isolation": self.config.run.execution_isolation,
+                "audit": {
+                    "total": len(self.records),
+                    "auditable": len(auditable),
+                    "not_auditable": len(self.records) - len(auditable),
+                    "exploitable": len(exploitable),
+                    "exploitable_test_ids": sorted(
+                        record["test_id"] for record in exploitable
+                    ),
+                },
+            },
+            "results": sort_records(self.records),
+        }
+        self._write_outputs(payload)
+        print_exploit_findings(self.records)
+        if exploitable:
+            raise SystemExit(1)
+        return payload
+
+    def _run_exploit_audit_tests(self, tests: List[ExecutionTest]) -> None:
+        """Run every exploit candidate for each test; record exploitable ones.
+
+        Serial and reset-before-each-candidate: candidates share a gateway
+        function name and rely on per-test fixtures, so state must not leak
+        between attempts. Short-circuits a test as soon as one cheat passes.
+        """
+        tests_to_run = _limit_tests(tests, self.config)
+        with create_progress() as progress:
+            task = progress.add_task("Exploit audit", total=len(tests_to_run))
+            for test in tests_to_run:
+                candidates = exploit_candidates(test)
+                record: Dict[str, Any] = {
+                    "test_id": test.id,
+                    "suite": test.suite,
+                    "type": "execution",
+                    "category": test.category,
+                    "difficulty": test.difficulty,
+                    "auditable": bool(candidates),
+                    "candidates_tried": len(candidates),
+                    "exploitable": False,
+                    "passing_exploit": None,
+                    "exploit_code": None,
+                }
+                try:
+                    for label, code in candidates:
+                        self.environment.reset()
+                        env_result = self.environment.execute_artifact(
+                            Artifact(kind="php_snippet", code=code),
+                            _build_verification_spec(test, self.config),
+                        )
+                        scores = self._score_execution(
+                            env_result.raw,
+                            test,
+                            skip_runtime=self.config.run.skip_runtime,
+                            skip_static=self.config.run.skip_static,
+                        )
+                        if scores.get("execution_pass"):
+                            record["exploitable"] = True
+                            record["passing_exploit"] = label
+                            record["exploit_code"] = code
+                            break
+                except Exception as e:
+                    raise TestError(test.id, "execution", e) from e
+                with self._lock:
+                    self.records.append(record)
+                progress.update(task, advance=1)
+
+    def _ensure_execution_only_ids(self, mode_flag: str, tests: Dict[str, List[Any]]) -> None:
+        """Ensure explicitly selected test ids are execution tests for audit modes."""
+        selected_ids = self.config.run.test_ids
+        if not selected_ids:
+            return
+        execution_ids = {test.id for test in tests["execution"]}
+        non_execution_ids = [test_id for test_id in selected_ids if test_id not in execution_ids]
+        if non_execution_ids:
+            raise ValueError(
+                f"{mode_flag} only supports execution test id(s): "
+                + ", ".join(non_execution_ids)
+            )
 
     @staticmethod
     def _render_knowledge_prompt(test: KnowledgeTest) -> str:

--- a/python/wp_bench/exploits.py
+++ b/python/wp_bench/exploits.py
@@ -59,11 +59,14 @@ def generic_exploit_candidates(test: Any) -> List[Tuple[str, str]]:
     name = gateway_name(test)
     if not name:
         return []
-    candidates = [("empty-stub", f"<?php function {name}() {{}}")]
-    candidates.extend(
+    # Constants first: they are likelier to satisfy a `=== <value>` assertion
+    # than an empty stub, so on an exploitable test the short-circuit reports
+    # the more informative cheat and stops sooner.
+    candidates = [
         (label, f"<?php function {name}() {{ return {expr}; }}")
         for label, expr in _GENERIC_RETURNS
-    )
+    ]
+    candidates.append(("empty-stub", f"<?php function {name}() {{}}"))
     return candidates
 
 

--- a/python/wp_bench/exploits.py
+++ b/python/wp_bench/exploits.py
@@ -1,0 +1,75 @@
+"""Zero-effort exploit candidates for the adversarial assertion audit.
+
+An execution test is *exploitable* when a candidate that does none of the
+WordPress work the task describes still satisfies the test's assertions —
+which means the assertions check a predictable output (a fixed fixture's
+answer) rather than the behavior. The audit mirrors reference-solution
+mode: reference-solution proves a correct solution *passes*; the exploit
+audit proves these cheats *fail*.
+
+This module only synthesizes the generic battery (constant returns and an
+empty stub). Tests can additionally carry authored ``exploit_solutions``
+for cheats the generic battery cannot express; the runner appends those.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, List, Optional, Tuple
+
+#: (label, PHP return expression) — trivial values a model could emit
+#: without doing the task. A single-fixture assertion checking `=== <value>`
+#: is satisfied by whichever constant matches that fixture's answer.
+_GENERIC_RETURNS: List[Tuple[str, str]] = [
+    ("return-1", "1"),
+    ("return-0", "0"),
+    ("return-true", "true"),
+    ("return-false", "false"),
+    ("return-null", "null"),
+    ("return-empty-string", "''"),
+    ("return-empty-array", "array()"),
+]
+
+_FUNCTION_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def gateway_name(test: Any) -> Optional[str]:
+    """Extract the gateway function name from a test's test_function signature."""
+    signature = getattr(test, "test_function", None)
+    if not signature:
+        return None
+    match = _FUNCTION_NAME.match(signature.strip())
+    return match.group(0) if match else None
+
+
+def generic_exploit_candidates(test: Any) -> List[Tuple[str, str]]:
+    """Synthesize zero-effort cheat snippets for one execution test.
+
+    Each candidate declares the test's gateway function with a trivial body
+    that does no WordPress work. Parameters and return type are omitted so
+    the stub never trips a type error — PHP ignores extra call arguments, so
+    a no-parameter stub is still callable with the assertion's arguments.
+
+    Returns an empty list when no generic cheat is synthesizable: the test
+    exposes no gateway name, or it is a plugin-artifact test (which needs an
+    authored exploit rather than a one-liner). An empty list means the test
+    is not covered by the generic battery, not that it is safe.
+    """
+    if getattr(test, "artifact_kind", "php_snippet") != "php_snippet":
+        return []
+    name = gateway_name(test)
+    if not name:
+        return []
+    candidates = [("empty-stub", f"<?php function {name}() {{}}")]
+    candidates.extend(
+        (label, f"<?php function {name}() {{ return {expr}; }}")
+        for label, expr in _GENERIC_RETURNS
+    )
+    return candidates
+
+
+def exploit_candidates(test: Any) -> List[Tuple[str, str]]:
+    """All exploit candidates for a test: generic battery + authored ones."""
+    candidates = generic_exploit_candidates(test)
+    authored = getattr(test, "exploit_solutions", None) or []
+    candidates.extend((f"authored-{index}", code) for index, code in enumerate(authored))
+    return candidates

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -155,6 +155,34 @@ def print_reference_solution_failures(records: list[Dict[str, Any]]) -> None:
     console.print(table)
 
 
+def print_exploit_findings(records: list[Dict[str, Any]]) -> None:
+    """Summarize the adversarial assertion audit and list exploitable tests."""
+    exploitable = [record for record in records if record.get("exploitable")]
+    auditable = [record for record in records if record.get("auditable")]
+    not_auditable = len(records) - len(auditable)
+
+    if exploitable:
+        table = Table(title="Exploitable Tests (a zero-effort cheat passed)")
+        table.add_column("Test ID", style="cyan")
+        table.add_column("Category", style="magenta")
+        table.add_column("Passing cheat", style="red")
+        for record in exploitable:
+            table.add_row(
+                str(record.get("test_id", "")),
+                str(record.get("category", "")),
+                str(record.get("passing_exploit", "")),
+            )
+        console.print(table)
+
+    style = "red" if exploitable else "green"
+    console.print(
+        f"[{style}]Exploit audit: {len(exploitable)}/{len(auditable)} auditable "
+        f"tests exploitable[/{style}] "
+        f"[dim]({not_auditable} not covered by the generic battery — "
+        f"no test_function or plugin artifact)[/dim]"
+    )
+
+
 def create_progress() -> Progress:
     """Create a Progress instance for tracking test execution."""
     return Progress()

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -155,12 +155,13 @@ def print_reference_solution_failures(records: list[Dict[str, Any]]) -> None:
     console.print(table)
 
 
-def print_exploit_findings(records: list[Dict[str, Any]]) -> None:
-    """Summarize the adversarial assertion audit and list exploitable tests."""
-    exploitable = [record for record in records if record.get("exploitable")]
-    auditable = [record for record in records if record.get("auditable")]
-    not_auditable = len(records) - len(auditable)
+def print_exploit_findings(audit: Dict[str, Any], exploitable: list[Dict[str, Any]]) -> None:
+    """Render the adversarial assertion audit summary and exploitable tests.
 
+    ``audit`` is the summary dict assembled by the runner (counts +
+    exploitable ids); ``exploitable`` is the list of exploitable records.
+    The runner owns the partition so it is not recomputed here.
+    """
     if exploitable:
         table = Table(title="Exploitable Tests (a zero-effort cheat passed)")
         table.add_column("Test ID", style="cyan")
@@ -174,11 +175,11 @@ def print_exploit_findings(records: list[Dict[str, Any]]) -> None:
             )
         console.print(table)
 
-    style = "red" if exploitable else "green"
+    style = "red" if audit["exploitable"] else "green"
     console.print(
-        f"[{style}]Exploit audit: {len(exploitable)}/{len(auditable)} auditable "
-        f"tests exploitable[/{style}] "
-        f"[dim]({not_auditable} not covered by the generic battery — "
+        f"[{style}]Exploit audit: {audit['exploitable']}/{audit['auditable']} "
+        f"auditable tests exploitable[/{style}] "
+        f"[dim]({audit['not_auditable']} not covered by the generic battery — "
         f"no test_function or plugin artifact)[/dim]"
     )
 

--- a/python/wp_bench/records.py
+++ b/python/wp_bench/records.py
@@ -163,6 +163,35 @@ def build_error_record(
     return record
 
 
+def build_exploit_audit_record(
+    *,
+    test: Any,
+    candidates_tried: int,
+    passing_exploit: Optional[str],
+    exploit_code: Optional[str],
+) -> Dict[str, Any]:
+    """Build the record for one test in the adversarial assertion audit.
+
+    Shares the canonical header (test_id/suite/type/category/difficulty)
+    with the other builders; the tail is audit-specific — an exploit
+    outcome rather than scores. ``candidates_tried == 0`` means the generic
+    battery did not cover the test (no gateway function, or a plugin
+    artifact), not that it is safe. A non-null ``passing_exploit`` means a
+    zero-effort cheat satisfied the assertions.
+    """
+    return {
+        "test_id": test.id,
+        "suite": test.suite,
+        "type": "execution",
+        "category": test.category,
+        "difficulty": test.difficulty,
+        "candidates_tried": candidates_tried,
+        "exploitable": passing_exploit is not None,
+        "passing_exploit": passing_exploit,
+        "exploit_code": exploit_code,
+    }
+
+
 def execution_record_passed(record: Dict[str, Any]) -> bool:
     """Whether an execution record represents a strict pass.
 


### PR DESCRIPTION
## What

A new audit mode that is the mirror image of `--check-reference-solution`:

| Mode | Input | Asserts | Proves |
|---|---|---|---|
| `--check-reference-solution` (existing) | the reference solution | it **passes** | assertions accept correct code |
| **`--check-exploits`** (this PR) | zero-effort cheats | they **fail** | assertions reject wrong code |

For every execution test, `--check-exploits` synthesizes a battery of trivial stubs from the `test_function` signature — `return 1 / 0 / true / false / null / '' / array()` and an empty body — runs each through the **real WordPress verifier**, and flags any test whose assertions a cheat can satisfy. It exits non-zero if any test is exploitable and writes the passing cheat per test to the results file (`metadata.audit.exploitable_test_ids`).

## Why — and what the live run found

A flagged test is **under-specified**: its assertions check a predictable output — one fixture's expected answer — rather than the WordPress behavior the task describes. A model can then score without doing the work. This is exactly the failure mode that invalidated parts of **SWE-bench Verified** (insufficient tests; fixing them reordered 24% of agents in the UTBoost audit), and it is the precise blind spot `--check-reference-solution` **cannot** see: correct code and a lucky constant both pass.

**Live run against the full suite (WordPress 7.0 runtime): 8 of 140 auditable tests are exploitable by a zero-effort cheat** (10 of 150 tests have no `test_function`/are plugin artifacts, so the generic battery doesn't cover them):

| Test | Passing cheat |
|---|---|
| `e-ai-client-001` | `return false;` |
| `e-ai-client-005` | `return false;` |
| `e-comments-users-004` | `return 1;` |
| `e-connectors-api-001` | `return true;` |
| `e-post-types-taxonomy-001` | `return 1;` |
| `e-post-types-taxonomy-002` | `return 1;` |
| `e-post-types-taxonomy-003` | `return 1;` |
| `e-roles-caps-002` | `return 1;` |

Every one is a single-fixture assertion whose expected answer is a constant. Example (`e-comments-users-004`, "return the number of approved comments"): the setup makes one post with one approved comment and the assertion checks `=== 1`, so `function wpbp_comments_users_004() { return 1; }` — which touches no WordPress API — scores `execution_pass=True`, identical to the real solution on the primary metric. Hardening the assertion to a multi-fixture, unpredictable count makes the cheat fail while the reference still passes (verified live).

## Design notes (owning the calls, for review)

- **Generic battery only in this PR.** It needs no per-test authoring and gives the number above. A test can carry authored `exploit_solutions` for cheats the battery can't express; `exploit_candidates` already composes generic + authored, but the **schema field is a deliberate follow-up** to keep this PR off the dataset loader/export surface.
- **Not wired into per-PR CI.** Like `--check-reference-solution`, it needs the live runtime, so it belongs in the release checklist / manual audit, not the Docker-less CI. Exits non-zero on findings so it can gate there.
- **Fixing the 8 exploitable tests is out of scope here** — that is scoring-affecting dataset work (versioned, careful) and lands as follow-ups. This PR delivers the tool and the finding.
- Serial with a reset before every candidate (candidates share a gateway name and rely on per-test fixtures); short-circuits a test on the first passing cheat.

## Verification

- [x] `ruff check python` — clean
- [x] `mypy python` — clean (0 errors)
- [x] `pytest python` — **142 passed** (9 new)
- [x] **Live audit against the full 150-test suite on WP 7.0** — 8/140 auditable tests exploitable (listed above); exits non-zero on findings, confirmed
- [x] Code cleaned up via a four-angle `/simplify` pass (dedup ensure-ids helper + gateway-name regex; audit record through a records.py builder; partition computed once; battery constants-first) — see second commit

## Score impact

- [x] This PR does **not** change how any test is scored. It adds a read-only audit mode; no scoring, dataset, or runtime grading logic changes. (The 8 exploitable tests it *found* will be hardened in follow-ups, which will be versioned.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)