### PR TITLE
Update README with Python version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ WP-Bench measures AI model capabilities across two dimensions:
 
 The benchmark uses WordPress itself as the grader, running generated code in a sandboxed environment with static analysis and runtime assertions.
 
+## Requirements
+
+Requires Python version 3.10 or later
+
 ## Quick Start
 
 ### 1. Install


### PR DESCRIPTION
Add Python version requirement to README.

Setting up wp-bench on my new M5 MBP, and macOS Tahoe only ships with 3.9.6, so adding the Python version requirement.