### PR TITLE
fix: harden the 8 assertion sets flagged exploitable by --check-exploits

### DIFF
--- a/datasets/suites/wp-core-v1/execution/ai-client.json
+++ b/datasets/suites/wp-core-v1/execution/ai-client.json
@@ -1,6 +1,6 @@
 {
   "id": "wp-core-execution-v1-ai_client",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "metadata": {
     "name": "WordPress Core Execution Tests - AI Client",
     "description": "Code generation tasks for WordPress AI Client APIs",
@@ -13,7 +13,7 @@
       "category": "ai-client",
       "difficulty": "basic",
       "prompt": "Implement a function that temporarily disables WordPress AI support for its own check, returns the disabled support result, and leaves AI support enabled afterward.",
-      "expected_behavior": "`wpbp_ai_client_001()` uses the `wp_supports_ai` filter only around a call to `wp_supports_ai()`, returns `false` for that temporary check, and removes the filter before returning. The test focuses on the AI support gate and cleanup, not a hard-coded return value.",
+      "expected_behavior": "`wpbp_ai_client_001()` uses the `wp_supports_ai` filter only around a call to `wp_supports_ai()`, returns `false` for that temporary check, and removes the filter before returning. The runtime attaches a counting spy to the `wp_supports_ai` filter, so a hard-coded `return false` fails: the support state must actually be read through `wp_supports_ai()` during the call, and support must be enabled again afterward.",
       "requirements": [
         "Use wp_supports_ai() to read the support state",
         "Use the wp_supports_ai filter to force support off for the temporary check",
@@ -43,8 +43,8 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_001' ) ) { return false; } $result = wpbp_ai_client_001(); return false === $result && true === wp_supports_ai();",
-            "description": "The support check is disabled only temporarily",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_001' ) ) { return false; } $calls = 0; $spy = function ( $supported ) use ( &$calls ) { $calls++; return $supported; }; add_filter( 'wp_supports_ai', $spy, 1 ); $result = wpbp_ai_client_001(); remove_filter( 'wp_supports_ai', $spy, 1 ); return false === $result && $calls > 0 && true === wp_supports_ai();",
+            "description": "The support state is read through wp_supports_ai() during the call, returns false, and support is enabled again afterward",
             "weight": 1
           }
         ]
@@ -229,7 +229,7 @@
       "category": "ai-client",
       "difficulty": "intermediate",
       "prompt": "Implement a function that returns the text-generation support check result while AI prompt execution is temporarily prevented.",
-      "expected_behavior": "`wpbp_ai_client_005()` temporarily enables `wp_ai_client_prevent_prompt`, calls `is_supported_for_text_generation()` on an AI Client prompt, returns that support-check result, and removes the filter. The support check should return `false` without making a provider call.",
+      "expected_behavior": "`wpbp_ai_client_005()` forces the `wp_ai_client_prevent_prompt` filter on around a text-generation support check and removes it before returning. The runtime attaches a late spy to that filter, so a hard-coded `return false` fails: prevention must be observed active during the call, and the filter must be gone afterward.",
       "requirements": [
         "Use wp_ai_client_prompt()",
         "Use is_supported_for_text_generation()",
@@ -271,8 +271,8 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_005' ) ) { return false; } $supported = wpbp_ai_client_005(); $prevented_after = apply_filters( 'wp_ai_client_prevent_prompt', false, wp_ai_client_prompt( 'Probe' ) ); return false === $supported && false === $prevented_after;",
-            "description": "The support check returns false while prevention is active and the filter is restored",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_005' ) ) { return false; } $seen_prevented = false; $spy = function ( $prevent ) use ( &$seen_prevented ) { if ( true === $prevent ) { $seen_prevented = true; } return $prevent; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, PHP_INT_MAX ); $supported = wpbp_ai_client_005(); remove_filter( 'wp_ai_client_prevent_prompt', $spy, PHP_INT_MAX ); $prevented_after = apply_filters( 'wp_ai_client_prevent_prompt', false, wp_ai_client_prompt( 'Probe' ) ); return false === $supported && true === $seen_prevented && false === $prevented_after;",
+            "description": "Prevention is observed active during the support check and the filter is restored afterward",
             "weight": 1
           }
         ]

--- a/datasets/suites/wp-core-v1/execution/comments-users.json
+++ b/datasets/suites/wp-core-v1/execution/comments-users.json
@@ -1,6 +1,6 @@
 {
   "id": "wp-core-execution-v1-comments_users",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "metadata": {
     "name": "WordPress Core Execution Tests - Comments and Users",
     "description": "Code generation tasks for WordPress Comments and Users APIs",
@@ -175,7 +175,7 @@
       "category": "comments-users",
       "difficulty": "basic",
       "prompt": "Implement a function that returns the number of approved comments for a supplied post.",
-      "expected_behavior": "Reviewer contract: The function should use WordPress comment-count APIs for the supplied post and return only the approved count. The runtime creates one approved and one pending comment, expects an exact count of one, and removes all fixtures in teardown.",
+      "expected_behavior": "Reviewer contract: The function should use WordPress comment-count APIs for the supplied post and return only the approved count. The runtime creates one post with two approved and one pending comment plus a second post with no comments, expects exact counts of two and zero respectively (so no single constant can pass), and removes all fixtures in teardown.",
       "requirements": [
         "Use WordPress comment APIs",
         "Accept the post ID as input",
@@ -197,16 +197,16 @@
         ]
       },
       "runtime_checks": {
-        "setup": "$GLOBALS['wpbp_comments_users_004_post_id'] = wp_insert_post( array( 'post_title' => 'WPBP Comment Count', 'post_status' => 'publish' ) ); if ( is_int( $GLOBALS['wpbp_comments_users_004_post_id'] ) ) { $GLOBALS['wpbp_comments_users_004_approved_id'] = wp_insert_comment( array( 'comment_post_ID' => $GLOBALS['wpbp_comments_users_004_post_id'], 'comment_content' => 'Approved', 'comment_approved' => 1 ) ); $GLOBALS['wpbp_comments_users_004_pending_id'] = wp_insert_comment( array( 'comment_post_ID' => $GLOBALS['wpbp_comments_users_004_post_id'], 'comment_content' => 'Pending', 'comment_approved' => 0 ) ); }",
+        "setup": "$GLOBALS['wpbp_comments_users_004_post_id'] = wp_insert_post( array( 'post_title' => 'WPBP Comment Count', 'post_status' => 'publish' ) ); $GLOBALS['wpbp_comments_users_004_empty_post_id'] = wp_insert_post( array( 'post_title' => 'WPBP Comment Count Empty', 'post_status' => 'publish' ) ); if ( is_int( $GLOBALS['wpbp_comments_users_004_post_id'] ) ) { $GLOBALS['wpbp_comments_users_004_comment_ids'] = array( wp_insert_comment( array( 'comment_post_ID' => $GLOBALS['wpbp_comments_users_004_post_id'], 'comment_content' => 'Approved one', 'comment_approved' => 1 ) ), wp_insert_comment( array( 'comment_post_ID' => $GLOBALS['wpbp_comments_users_004_post_id'], 'comment_content' => 'Approved two', 'comment_approved' => 1 ) ), wp_insert_comment( array( 'comment_post_ID' => $GLOBALS['wpbp_comments_users_004_post_id'], 'comment_content' => 'Pending', 'comment_approved' => 0 ) ) ); }",
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "$post_id = $GLOBALS['wpbp_comments_users_004_post_id'] ?? 0; if ( ! function_exists( 'wpbp_comments_users_004' ) || ! is_int( $post_id ) ) { return false; } return 1 === wpbp_comments_users_004( $post_id );",
-            "description": "Only the approved comment is counted for the supplied post",
+            "code": "$post_id = $GLOBALS['wpbp_comments_users_004_post_id'] ?? 0; $empty_post_id = $GLOBALS['wpbp_comments_users_004_empty_post_id'] ?? 0; if ( ! function_exists( 'wpbp_comments_users_004' ) || ! is_int( $post_id ) || ! is_int( $empty_post_id ) ) { return false; } return 2 === wpbp_comments_users_004( $post_id ) && 0 === wpbp_comments_users_004( $empty_post_id );",
+            "description": "Only approved comments are counted: two for the fixture post, zero for the empty post",
             "weight": 1
           }
         ],
-        "teardown": "foreach ( array( 'wpbp_comments_users_004_approved_id', 'wpbp_comments_users_004_pending_id' ) as $key ) { $comment_id = $GLOBALS[ $key ] ?? 0; if ( is_int( $comment_id ) && $comment_id > 0 ) { wp_delete_comment( $comment_id, true ); } unset( $GLOBALS[ $key ] ); } $post_id = $GLOBALS['wpbp_comments_users_004_post_id'] ?? 0; if ( is_int( $post_id ) ) { wp_delete_post( $post_id, true ); } unset( $GLOBALS['wpbp_comments_users_004_post_id'] );"
+        "teardown": "foreach ( ( $GLOBALS['wpbp_comments_users_004_comment_ids'] ?? array() ) as $comment_id ) { if ( is_int( $comment_id ) && $comment_id > 0 ) { wp_delete_comment( $comment_id, true ); } } unset( $GLOBALS['wpbp_comments_users_004_comment_ids'] ); foreach ( array( 'wpbp_comments_users_004_post_id', 'wpbp_comments_users_004_empty_post_id' ) as $key ) { $post_id = $GLOBALS[ $key ] ?? 0; if ( is_int( $post_id ) && $post_id > 0 ) { wp_delete_post( $post_id, true ); } unset( $GLOBALS[ $key ] ); }"
       },
       "reference_solution": "function wpbp_comments_users_004( int $post_id ): int { $counts = wp_count_comments( $post_id ); return (int) $counts->approved; }",
       "metadata": {

--- a/datasets/suites/wp-core-v1/execution/connectors-api.json
+++ b/datasets/suites/wp-core-v1/execution/connectors-api.json
@@ -1,6 +1,6 @@
 {
   "id": "wp-core-execution-v1-connectors_api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "metadata": {
     "name": "WordPress Core Execution Tests - Connectors API",
     "description": "Code generation tasks for WordPress Connectors API APIs",
@@ -13,7 +13,7 @@
       "category": "connectors-api",
       "difficulty": "basic",
       "prompt": "Implement a function that reports whether WordPress has registered the built-in Akismet connector through the public Connectors API.",
-      "expected_behavior": "`wpbp_connectors_api_001()` uses `wp_is_connector_registered()` to check the `akismet` connector after WordPress connector initialization. The test focuses on public connector discovery, not direct registry access or a hard-coded truthy value.",
+      "expected_behavior": "`wpbp_connectors_api_001()` uses `wp_is_connector_registered()` to check the `akismet` connector after WordPress connector initialization. The runtime calls the helper twice: once with Akismet registered (expects true) and once with Akismet temporarily unregistered (expects false), so a hard-coded `return true` fails; the connector is restored afterward.",
       "requirements": [
         "Use wp_is_connector_registered()",
         "Check the connector ID 'akismet'",
@@ -45,8 +45,8 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_connectors_api_001' ) ) { return false; } return true === wpbp_connectors_api_001() && wp_is_connector_registered( 'akismet' );",
-            "description": "The helper reports the built-in Akismet connector as registered",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_001' ) ) { return false; } $registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry ) { return false; } $first = wpbp_connectors_api_001(); $removed = $registry->unregister( 'akismet' ); $second = wpbp_connectors_api_001(); if ( is_array( $removed ) ) { $registry->register( 'akismet', $removed ); } return true === $first && false === $second;",
+            "description": "The helper reflects live registry state: true with Akismet registered, false while it is unregistered",
             "weight": 1
           }
         ]

--- a/datasets/suites/wp-core-v1/execution/post-types-taxonomy.json
+++ b/datasets/suites/wp-core-v1/execution/post-types-taxonomy.json
@@ -1,6 +1,6 @@
 {
   "id": "wp-core-execution-v1-post_types_taxonomy",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "metadata": {
     "name": "WordPress Core Execution Tests - Post Types and Taxonomy",
     "description": "Code generation tasks for WordPress Post Types and Taxonomy APIs",
@@ -12,11 +12,11 @@
       "id": "e-post-types-taxonomy-001",
       "category": "post-types-taxonomy",
       "difficulty": "intermediate",
-      "prompt": "Implement a function that registers a public book post type with REST support.",
-      "expected_behavior": "`wpbp_post_types_taxonomy_001()` registers a public `wpbp_book` post type with REST API exposure. Runtime validation checks the registered post type through WordPress and unregisters it afterward.",
+      "prompt": "Implement a function that registers a public book post type named 'wpbp_book' with REST support.",
+      "expected_behavior": "`wpbp_post_types_taxonomy_001()` registers a public `wpbp_book` post type with REST API exposure. Runtime validation inspects the registered post type object itself (public and show_in_rest), so a hard-coded truthy return fails, and unregisters it afterward.",
       "requirements": [
-        "Use registration APIs",
-        "Clean up registered types when possible"
+        "Use register_post_type() with the wpbp_book slug",
+        "Make the post type public and available in the REST API"
       ],
       "test_function": "wpbp_post_types_taxonomy_001(): bool",
       "static_checks": {
@@ -37,8 +37,8 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_post_types_taxonomy_001' ) ) { return false; } $ok = wpbp_post_types_taxonomy_001(); unregister_post_type( 'wpbp_book' ); return $ok;",
-            "description": "The book post type is registered and REST-enabled",
+            "code": "if ( ! function_exists( 'wpbp_post_types_taxonomy_001' ) ) { return false; } wpbp_post_types_taxonomy_001(); $type = get_post_type_object( 'wpbp_book' ); $ok = $type instanceof WP_Post_Type && $type->public && $type->show_in_rest; unregister_post_type( 'wpbp_book' ); return $ok;",
+            "description": "The wpbp_book post type is actually registered, public, and REST-enabled",
             "weight": 1
           }
         ]
@@ -56,11 +56,11 @@
       "id": "e-post-types-taxonomy-002",
       "category": "post-types-taxonomy",
       "difficulty": "intermediate",
-      "prompt": "Implement a function that registers a hierarchical genre taxonomy for posts.",
-      "expected_behavior": "`wpbp_post_types_taxonomy_002()` registers a hierarchical `wpbp_genre` taxonomy for posts. Runtime validation checks the taxonomy through WordPress and unregisters it afterward.",
+      "prompt": "Implement a function that registers a hierarchical genre taxonomy named 'wpbp_genre' for posts.",
+      "expected_behavior": "`wpbp_post_types_taxonomy_002()` registers a hierarchical `wpbp_genre` taxonomy for posts. Runtime validation inspects the registered taxonomy object itself (hierarchical and attached to post), so a hard-coded truthy return fails, and unregisters it afterward.",
       "requirements": [
-        "Use registration APIs",
-        "Clean up registered types when possible"
+        "Use register_taxonomy() with the wpbp_genre slug",
+        "Make the taxonomy hierarchical and attach it to posts"
       ],
       "test_function": "wpbp_post_types_taxonomy_002(): bool",
       "static_checks": {
@@ -81,8 +81,8 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_post_types_taxonomy_002' ) ) { return false; } $ok = wpbp_post_types_taxonomy_002(); unregister_taxonomy( 'wpbp_genre' ); return $ok;",
-            "description": "The genre taxonomy is registered as hierarchical",
+            "code": "if ( ! function_exists( 'wpbp_post_types_taxonomy_002' ) ) { return false; } wpbp_post_types_taxonomy_002(); $taxonomy = get_taxonomy( 'wpbp_genre' ); $ok = $taxonomy instanceof WP_Taxonomy && $taxonomy->hierarchical && in_array( 'post', (array) $taxonomy->object_type, true ); unregister_taxonomy( 'wpbp_genre' ); return $ok;",
+            "description": "The wpbp_genre taxonomy is actually registered, hierarchical, and attached to posts",
             "weight": 1
           }
         ]
@@ -100,11 +100,11 @@
       "id": "e-post-types-taxonomy-003",
       "category": "post-types-taxonomy",
       "difficulty": "intermediate",
-      "prompt": "Implement a function that attaches an existing taxonomy to a custom post type.",
-      "expected_behavior": "`wpbp_post_types_taxonomy_003()` registers a fixture post type and taxonomy, then attaches the taxonomy to that post type with WordPress registration APIs. Runtime validation checks the attachment result.",
+      "prompt": "Implement a function that attaches the existing 'wpbp_topic' taxonomy to the existing 'wpbp_movie' custom post type.",
+      "expected_behavior": "`wpbp_post_types_taxonomy_003()` attaches the `wpbp_topic` taxonomy (pre-registered by the runtime along with the `wpbp_movie` post type) using `register_taxonomy_for_object_type()`. Runtime validation checks the actual attachment through `is_object_in_taxonomy()`, so a hard-coded truthy return fails; fixtures are unregistered in teardown.",
       "requirements": [
-        "Use registration APIs",
-        "Clean up registered types when possible"
+        "Use register_taxonomy_for_object_type()",
+        "Return whether the attachment succeeded"
       ],
       "test_function": "wpbp_post_types_taxonomy_003(): bool",
       "static_checks": {
@@ -117,16 +117,18 @@
         ]
       },
       "runtime_checks": {
+        "setup": "register_post_type( 'wpbp_movie', array( 'label' => 'WPBP Movies' ) ); register_taxonomy( 'wpbp_topic', 'post', array( 'label' => 'WPBP Topics' ) );",
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_post_types_taxonomy_003' ) ) { return false; } return wpbp_post_types_taxonomy_003();",
-            "description": "The taxonomy is attached to the custom post type",
+            "code": "if ( ! function_exists( 'wpbp_post_types_taxonomy_003' ) ) { return false; } $ok = wpbp_post_types_taxonomy_003(); return true === $ok && is_object_in_taxonomy( 'wpbp_movie', 'wpbp_topic' );",
+            "description": "The wpbp_topic taxonomy is actually attached to the wpbp_movie post type",
             "weight": 1
           }
-        ]
+        ],
+        "teardown": "unregister_taxonomy( 'wpbp_topic' ); unregister_post_type( 'wpbp_movie' );"
       },
-      "reference_solution": "function wpbp_post_types_taxonomy_003(): bool { register_post_type( 'wpbp_movie' ); register_taxonomy( 'wpbp_topic', 'post' ); $ok = register_taxonomy_for_object_type( 'wpbp_topic', 'wpbp_movie' ); unregister_post_type( 'wpbp_movie' ); unregister_taxonomy( 'wpbp_topic' ); return $ok; }",
+      "reference_solution": "function wpbp_post_types_taxonomy_003(): bool { return register_taxonomy_for_object_type( 'wpbp_topic', 'wpbp_movie' ); }",
       "metadata": {
         "source_refs": [
           "src/wp-includes/post.php",

--- a/datasets/suites/wp-core-v1/execution/roles-caps.json
+++ b/datasets/suites/wp-core-v1/execution/roles-caps.json
@@ -1,6 +1,6 @@
 {
   "id": "wp-core-execution-v1-roles_caps",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "metadata": {
     "name": "WordPress Core Execution Tests - Roles and Capabilities",
     "description": "Code generation tasks for WordPress Roles and Capabilities APIs",
@@ -64,7 +64,7 @@
       "category": "roles-caps",
       "difficulty": "basic",
       "prompt": "Implement a function that adds wpbp_temp_cap to the Subscriber role, verifies the role has it, removes it again, and reports whether both transitions succeeded.",
-      "expected_behavior": "Reviewer contract: The function should mutate the Subscriber role through WP_Role methods and leave the temporary capability removed. The runtime checks both the returned result and the final Subscriber role state.",
+      "expected_behavior": "Reviewer contract: The function should mutate the Subscriber role through WP_Role methods and leave the temporary capability removed. The runtime spies on `updated_option` for the roles option to observe `wpbp_temp_cap` actually being added during the call, so a hard-coded `return true` fails, and checks the final Subscriber role state.",
       "requirements": [
         "Use WordPress roles/capabilities APIs",
         "Leave the Subscriber role without the temporary capability"
@@ -98,8 +98,8 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_roles_caps_002' ) ) { return false; } $ok = wpbp_roles_caps_002(); $role = get_role( 'subscriber' ); return (bool) $ok && $role instanceof WP_Role && ! $role->has_cap( 'wpbp_temp_cap' );",
-            "description": "The temporary Subscriber capability is added, observed, and removed",
+            "code": "if ( ! function_exists( 'wpbp_roles_caps_002' ) ) { return false; } $saw_cap_added = false; $spy = function ( $option, $old_value, $value ) use ( &$saw_cap_added ) { if ( false !== strpos( (string) $option, 'user_roles' ) && is_array( $value ) && ! empty( $value['subscriber']['capabilities']['wpbp_temp_cap'] ) ) { $saw_cap_added = true; } }; add_action( 'updated_option', $spy, 10, 3 ); $ok = wpbp_roles_caps_002(); remove_action( 'updated_option', $spy, 10 ); $role = get_role( 'subscriber' ); return true === $ok && $saw_cap_added && $role instanceof WP_Role && ! $role->has_cap( 'wpbp_temp_cap' );",
+            "description": "The temporary capability is observed being added to the Subscriber role and is removed afterward",
             "weight": 1
           }
         ],


### PR DESCRIPTION
## What

Hardens the 8 execution tests that the #41 exploit audit (`--check-exploits`) flagged as exploitable: a zero-effort constant return (`return true;`, `return 1;`, `return false;`) satisfied their runtime assertions.

All 8 shared the same root cause: the assertion graded the function's return value against a single fixed expectation instead of observing WordPress state, so it could not tell a real implementation from a hard-coded answer.

## How each test is hardened

Every assertion now verifies behavior a constant cannot fake:

| Test | Old weakness | New verification |
|---|---|---|
| `e-ai-client-001` | `return false` passed | Counting spy on the `wp_supports_ai` filter proves the support state is actually read during the call, plus the existing re-enabled-after check |
| `e-ai-client-005` | `return false` passed | Late spy (`PHP_INT_MAX`) on `wp_ai_client_prevent_prompt` proves prevention is observed **active during** the support check, and inactive after |
| `e-comments-users-004` | `return 1` passed | Second fixture post with zero comments; expected counts become `{2, 0}`, so no single constant passes both calls |
| `e-connectors-api-001` | `return true` passed | Helper is called twice: with Akismet registered (expects `true`) and temporarily unregistered via `WP_Connector_Registry::unregister()` (expects `false`), then restored |
| `e-post-types-taxonomy-001` | assertion returned the function's own `$ok` | Inspects `get_post_type_object( 'wpbp_book' )`: exists, `public`, `show_in_rest` |
| `e-post-types-taxonomy-002` | same | Inspects `get_taxonomy( 'wpbp_genre' )`: exists, `hierarchical`, attached to `post` |
| `e-post-types-taxonomy-003` | assertion was literally `return f();` | Fixtures (`wpbp_movie`, `wpbp_topic`) move to runtime `setup`/`teardown`; assertion checks the actual attachment with `is_object_in_taxonomy()` |
| `e-roles-caps-002` | `return true` passed | Spy on `updated_option` for the roles option observes `wpbp_temp_cap` actually being **added** to Subscriber before the final not-present check |

## Design decisions

- **Slugs moved into prompts.** Models only see `prompt` + `requirements` + `test_function` (never `expected_behavior`), so state-based assertions on `wpbp_book` / `wpbp_genre` / `wpbp_topic` / `wpbp_movie` require the prompts to name them. Done for the three post-types tests.
- **Dropped the "Clean up registered types when possible" requirement** on `e-post-types-taxonomy-001/002`. A post-call state inspection requires the registration to still exist when the assertion runs; cleanup is now the assertion's job (as the reference solutions already assumed).
- **`e-connectors-api-001` keeps its contract** (no-arg helper, `akismet` required pattern, `WP_Connector_Registry` forbidden for the model). The registry-toggle happens in assertion code, which static checks don't apply to. A lazy-init spy on `wp_connectors_init` was tried first but the registry initializes during `init`, before assertions run.
- **`e-connectors-api-002`-style negative cases** were preferred over spies wherever the API allowed it; spies are only used where the observable is a filter/option side effect (`ai-client`, `roles-caps`).
- Each touched suite file bumps `2.1.0` → `2.2.0`, same convention as #24.

## Verification (live WP 7.0 runtime)

Both directions of the audit loop, against the real wp-env grader:

- `--check-reference-solution` on the 8 tests: **8/8 pass** (correctness 1.0)
- `--check-exploits` on the 8 tests: **0/8 exploitable**
- Full pytest suite: 151 passed; dataset validation green

- `--check-exploits` on the full suite: **0/140 auditable tests exploitable** (was 8/140 at the #41 baseline). Full end-to-end run: 1120 exploit-candidate executions, each against a freshly reset WordPress, ~1.5h wall clock. The 10 non-auditable tests have no `test_function` or plugin artifact for the generic battery to target, unchanged from the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
