### PR TITLE
fix: grade None provider completions as empty answers instead of crashing

### DIFF
--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -33,6 +33,18 @@ def test_generate_retries_without_temperature_on_deprecated_error(monkeypatch) -
     assert "temperature" not in calls[1]
 
 
+def test_generate_normalizes_none_content_to_empty_string(monkeypatch) -> None:
+    def fake_completion(**kwargs):
+        return SimpleNamespace(choices=[SimpleNamespace(message={"content": None})])
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+
+    model = ModelInterface(ModelConfig(name="gemini/gemini-2.5-pro"))
+    result = model.generate_with_metadata("hello")
+
+    assert result.text == ""
+
+
 def test_generate_does_not_retry_other_bad_request_errors(monkeypatch) -> None:
     def fake_completion(**kwargs):
         raise BadRequestError(

--- a/python/wp_bench/models.py
+++ b/python/wp_bench/models.py
@@ -137,7 +137,10 @@ class ModelInterface:
         choice = response.choices[0]
         usage = _extract_usage(response)
         return ModelGeneration(
-            text=choice.message["content"],  # type: ignore[union-attr, index]
+            # Providers can return None content (safety block, thinking-only
+            # response, truncation). That is a model output, not a harness
+            # fault: normalize to "" so it grades as an empty answer.
+            text=choice.message["content"] or "",  # type: ignore[union-attr, index]
             raw_response=response,
             retry_count=attempt_count - 1,
             latency_ms=latency_ms,


### PR DESCRIPTION
## What

First real multi-model pilot run (gemini-2.5-pro + flash on the hardened dataset) crashed with:

```
File .../wp_bench/utils.py, line 9, in strip_code_fences
    stripped = output.strip()
AttributeError: 'NoneType' object has no attribute 'strip'
```

litellm can hand back a choice whose `message.content` is `None` — providers do this on safety blocks, thinking-only responses, or truncation. `ModelGeneration.text` carried the `None` into `parse_artifact`, killing the entire run on one bad completion.

## Fix

Normalize at the single extraction point in `ModelInterface.generate_with_metadata`: `content or ""`. An empty completion is a *model* output, not a harness fault, so it should grade as an empty answer (score 0 for that test) and let the run continue. This also composes with `run.continue_on_error` for the remaining per-test failure modes.

Includes a regression test with a mocked `None`-content response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)