### PR TITLE
feat: add 21 execution tests for the WP 7.0 API surfaces (abilities, connectors, ai-client)

### DIFF
--- a/datasets/suites/wp-core-v1/execution/abilities-api.json
+++ b/datasets/suites/wp-core-v1/execution/abilities-api.json
@@ -390,7 +390,7 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "WP_Abilities_Registry::get_instance(); $ability = wp_get_ability( 'wpbp/greet' ); if ( ! $ability instanceof WP_Ability ) { return false; } $schema = $ability->get_input_schema(); return 'wpbp-greetings' === $ability->get_category() && 'world' === ( $schema['default'] ?? null ) && 'hello world' === $ability->execute( null ) && 'hello wp' === $ability->execute( 'wp' );",
+            "code": "WP_Abilities_Registry::get_instance(); $ability = wp_get_ability( 'wpbp/greet' ); if ( ! $ability instanceof WP_Ability ) { return false; } $schema = $ability->get_input_schema(); return 'wpbp-greetings' === $ability->get_category() && 'string' === ( $schema['type'] ?? null ) && 'world' === ( $schema['default'] ?? null ) && 'hello world' === $ability->execute( null ) && 'hello wp' === $ability->execute( 'wp' );",
             "description": "The ability registers with a defaulted input schema and the default applies on null input",
             "weight": 1
           }

--- a/datasets/suites/wp-core-v1/execution/abilities-api.json
+++ b/datasets/suites/wp-core-v1/execution/abilities-api.json
@@ -336,7 +336,7 @@
         ]
       },
       "runtime_checks": {
-        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-transform', array( 'label' => 'WPBP Transform', 'description' => 'Text transformation fixtures.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/uppercase', array( 'label' => 'Uppercase', 'description' => 'Uppercases supplied text.', 'category' => 'wpbp-transform', 'input_schema' => array( 'type' => 'object', 'properties' => array( 'text' => array( 'type' => 'string' ) ), 'required' => array( 'text' ) ), 'output_schema' => array( 'type' => 'string' ), 'execute_callback' => static fn( array $input ): string => strtoupper( $input['text'] ), 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-fixtures', array( 'label' => 'WPBP Fixtures', 'description' => 'Fixture abilities for WPBP tests.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/uppercase', array( 'label' => 'Uppercase', 'description' => 'Uppercases supplied text.', 'category' => 'wpbp-fixtures', 'input_schema' => array( 'type' => 'object', 'properties' => array( 'text' => array( 'type' => 'string' ) ), 'required' => array( 'text' ) ), 'output_schema' => array( 'type' => 'string' ), 'execute_callback' => static fn( array $input ): string => strtoupper( $input['text'] ), 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
         "assertions": [
           {
             "type": "custom_assertion",
@@ -431,7 +431,7 @@
         ]
       },
       "runtime_checks": {
-        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-temp', array( 'label' => 'WPBP Temp', 'description' => 'Temporary fixtures.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/temp-ability', array( 'label' => 'Temp', 'description' => 'Temporary ability.', 'category' => 'wpbp-temp', 'execute_callback' => '__return_true', 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-fixtures', array( 'label' => 'WPBP Fixtures', 'description' => 'Fixture abilities for WPBP tests.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/temp-ability', array( 'label' => 'Temp', 'description' => 'Temporary ability.', 'category' => 'wpbp-fixtures', 'execute_callback' => '__return_true', 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
         "assertions": [
           {
             "type": "custom_assertion",
@@ -483,7 +483,7 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "$found = wp_has_ability_category( 'wpbp-audit' ); if ( ! $found ) { return false; } $category = wp_get_ability_category( 'wpbp-audit' ); $meta = $category instanceof WP_Ability_Category ? $category->get_meta() : array(); return 'WPBP Audit' === $category->get_label() && 'shield' === ( $meta['icon'] ?? null );",
+            "code": "$category = wp_has_ability_category( 'wpbp-audit' ) ? wp_get_ability_category( 'wpbp-audit' ) : null; if ( ! $category instanceof WP_Ability_Category ) { return false; } $meta = $category->get_meta(); return 'WPBP Audit' === $category->get_label() && 'shield' === ( $meta['icon'] ?? null );",
             "description": "The category is actually registered with its label and icon meta",
             "weight": 1
           }
@@ -494,56 +494,6 @@
         "source_refs": [
           "src/wp-includes/abilities-api.php",
           "src/wp-includes/abilities-api/class-wp-ability-category.php"
-        ],
-        "release_focus": "6.9"
-      }
-    },
-    {
-      "id": "e-abilities-api-010",
-      "category": "abilities-api",
-      "difficulty": "advanced",
-      "prompt": "Register a 'wpbp/word-stats' ability in the existing 'wpbp-stats' category. It accepts an object input with a required string 'text' property and returns an object with integer 'words' and 'chars' properties (both required in the output schema): the word count and character count of the text.",
-      "expected_behavior": "The ability registers on `wp_abilities_api_init` with both schemas. The runtime checks the declared output schema (object with required integer `words`/`chars`) and executes it against two different texts, so neither a constant return nor a schema-less registration passes.",
-      "requirements": [
-        "Register during the wp_abilities_api_init action",
-        "Declare both the input schema and the output schema",
-        "Compute words with str_word_count() and chars with strlen()"
-      ],
-      "static_checks": {
-        "required_patterns": [
-          {
-            "pattern": "wp_register_ability",
-            "description": "Registers through the Abilities API",
-            "weight": 1
-          },
-          {
-            "pattern": "output_schema",
-            "description": "Declares the output schema",
-            "weight": 1
-          },
-          {
-            "pattern": "str_word_count",
-            "description": "Computes the word count",
-            "weight": 1
-          }
-        ]
-      },
-      "runtime_checks": {
-        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-stats', array( 'label' => 'WPBP Stats', 'description' => 'Statistics abilities.' ) ); } );",
-        "assertions": [
-          {
-            "type": "custom_assertion",
-            "code": "WP_Abilities_Registry::get_instance(); $ability = wp_get_ability( 'wpbp/word-stats' ); if ( ! $ability instanceof WP_Ability ) { return false; } $out = $ability->get_output_schema(); $required = $out['required'] ?? array(); return 'object' === ( $out['type'] ?? null ) && 'integer' === ( $out['properties']['words']['type'] ?? null ) && 'integer' === ( $out['properties']['chars']['type'] ?? null ) && in_array( 'words', $required, true ) && in_array( 'chars', $required, true ) && array( 'words' => 2, 'chars' => 8 ) === $ability->execute( array( 'text' => 'hi there' ) ) && array( 'words' => 1, 'chars' => 4 ) === $ability->execute( array( 'text' => 'solo' ) );",
-            "description": "The ability declares the full output schema and computes correct stats for two inputs",
-            "weight": 1
-          }
-        ]
-      },
-      "reference_solution": "add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/word-stats', array( 'label' => 'Word stats', 'description' => 'Counts words and characters.', 'category' => 'wpbp-stats', 'input_schema' => array( 'type' => 'object', 'properties' => array( 'text' => array( 'type' => 'string' ) ), 'required' => array( 'text' ) ), 'output_schema' => array( 'type' => 'object', 'properties' => array( 'words' => array( 'type' => 'integer' ), 'chars' => array( 'type' => 'integer' ) ), 'required' => array( 'words', 'chars' ) ), 'execute_callback' => static fn( array $input ): array => array( 'words' => str_word_count( $input['text'] ), 'chars' => strlen( $input['text'] ) ), 'permission_callback' => '__return_true' ) ); } );",
-      "metadata": {
-        "source_refs": [
-          "src/wp-includes/abilities-api.php",
-          "src/wp-includes/abilities-api/class-wp-ability.php"
         ],
         "release_focus": "6.9"
       }
@@ -670,7 +620,7 @@
         ]
       },
       "runtime_checks": {
-        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-forced-cat', array( 'label' => 'WPBP Forced', 'description' => 'Filter fixture category.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp-forced/sample', array( 'label' => 'Forced sample', 'description' => 'Fixture.', 'category' => 'wpbp-forced-cat', 'execute_callback' => '__return_true', 'permission_callback' => '__return_true' ) ); wp_register_ability( 'wpbp/unforced-sample', array( 'label' => 'Unforced sample', 'description' => 'Fixture.', 'category' => 'wpbp-forced-cat', 'execute_callback' => '__return_true', 'permission_callback' => '__return_true' ) ); } );",
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-fixtures', array( 'label' => 'WPBP Fixtures', 'description' => 'Fixture abilities for WPBP tests.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp-forced/sample', array( 'label' => 'Forced sample', 'description' => 'Fixture.', 'category' => 'wpbp-fixtures', 'execute_callback' => '__return_true', 'permission_callback' => '__return_true' ) ); wp_register_ability( 'wpbp/unforced-sample', array( 'label' => 'Unforced sample', 'description' => 'Fixture.', 'category' => 'wpbp-fixtures', 'execute_callback' => '__return_true', 'permission_callback' => '__return_true' ) ); } );",
         "assertions": [
           {
             "type": "custom_assertion",
@@ -721,7 +671,7 @@
         ]
       },
       "runtime_checks": {
-        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-errors', array( 'label' => 'WPBP Errors', 'description' => 'Error handling fixtures.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/throws', array( 'label' => 'Throws', 'description' => 'Always throws.', 'category' => 'wpbp-errors', 'execute_callback' => static function () { throw new RuntimeException( 'boom' ); }, 'permission_callback' => '__return_true' ) ); wp_register_ability( 'wpbp/answer', array( 'label' => 'Answer', 'description' => 'Returns the answer.', 'category' => 'wpbp-errors', 'execute_callback' => static fn(): int => 42, 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-fixtures', array( 'label' => 'WPBP Fixtures', 'description' => 'Fixture abilities for WPBP tests.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/throws', array( 'label' => 'Throws', 'description' => 'Always throws.', 'category' => 'wpbp-fixtures', 'execute_callback' => static function () { throw new RuntimeException( 'boom' ); }, 'permission_callback' => '__return_true' ) ); wp_register_ability( 'wpbp/answer', array( 'label' => 'Answer', 'description' => 'Returns the answer.', 'category' => 'wpbp-fixtures', 'execute_callback' => static fn(): int => 42, 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
         "assertions": [
           {
             "type": "custom_assertion",

--- a/datasets/suites/wp-core-v1/execution/abilities-api.json
+++ b/datasets/suites/wp-core-v1/execution/abilities-api.json
@@ -403,7 +403,11 @@
           "src/wp-includes/abilities-api/class-wp-ability.php"
         ],
         "release_focus": "6.9"
-      }
+      },
+      "exploit_solutions": [
+        "add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/greet', array( 'label' => 'Greet', 'description' => 'Greets.', 'category' => 'wpbp-greetings', 'input_schema' => array( 'type' => 'string', 'default' => 'world' ), 'execute_callback' => static fn( string $input ): string => 'hello world', 'permission_callback' => '__return_true' ) ); } );",
+        "add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/greet', array( 'label' => 'Greet', 'description' => 'Greets.', 'category' => 'wpbp-greetings', 'input_schema' => array( 'type' => 'string' ), 'execute_callback' => static fn( ?string $input = null ): string => 'hello ' . ( $input ?? 'world' ), 'permission_callback' => '__return_true' ) ); } );"
+      ]
     },
     {
       "id": "e-abilities-api-008",
@@ -496,7 +500,11 @@
           "src/wp-includes/abilities-api/class-wp-ability-category.php"
         ],
         "release_focus": "6.9"
-      }
+      },
+      "exploit_solutions": [
+        "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-audit', array( 'label' => 'WPBP Audit', 'description' => 'Audit abilities.' ) ); } );",
+        "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-audit', array( 'label' => 'Audit', 'description' => 'Audit abilities.', 'meta' => array( 'icon' => 'shield' ) ) ); } );"
+      ]
     },
     {
       "id": "e-abilities-api-011",

--- a/datasets/suites/wp-core-v1/execution/abilities-api.json
+++ b/datasets/suites/wp-core-v1/execution/abilities-api.json
@@ -1,6 +1,6 @@
 {
   "id": "wp-core-execution-v1-abilities_api",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "metadata": {
     "name": "WordPress Core Execution Tests - Abilities API",
     "description": "Code generation tasks for WordPress Abilities API APIs",
@@ -250,6 +250,492 @@
           "src/wp-includes/abilities-api/class-wp-ability.php",
           "src/wp-includes/abilities-api/class-wp-abilities-registry.php",
           "src/wp-includes/abilities-api/class-wp-ability-categories-registry.php"
+        ],
+        "release_focus": "6.9"
+      }
+    },
+    {
+      "id": "e-abilities-api-005",
+      "category": "abilities-api",
+      "difficulty": "intermediate",
+      "prompt": "Implement a function that executes the ability registered under the supplied name with no input and reports the outcome: the error code string when execution fails, or 'ok' when it succeeds.",
+      "expected_behavior": "`wpbp_abilities_api_005()` retrieves the ability with `wp_get_ability()` and calls `execute()`. The runtime registers one ability whose permission callback denies execution (expected code `ability_invalid_permissions`) and one open ability (expected `'ok'`), so no constant return passes both.",
+      "requirements": [
+        "Use wp_get_ability() to retrieve the ability",
+        "Execute it through the Abilities API",
+        "Return the WP_Error code on failure and 'ok' on success"
+      ],
+      "test_function": "wpbp_abilities_api_005( string $ability_name ): string",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_get_ability",
+            "description": "Retrieves the ability through the public API",
+            "weight": 1
+          },
+          {
+            "pattern": "execute",
+            "description": "Executes the ability",
+            "weight": 1
+          },
+          {
+            "pattern": "is_wp_error",
+            "description": "Detects failed executions",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-fixtures', array( 'label' => 'WPBP Fixtures', 'description' => 'Fixture abilities for WPBP tests.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/locked-action', array( 'label' => 'Locked action', 'description' => 'Always denied.', 'category' => 'wpbp-fixtures', 'execute_callback' => static fn() => 'ran', 'permission_callback' => '__return_false' ) ); wp_register_ability( 'wpbp/open-action', array( 'label' => 'Open action', 'description' => 'Always permitted.', 'category' => 'wpbp-fixtures', 'execute_callback' => static fn() => 'ran', 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_abilities_api_005' ) ) { return false; } return 'ability_invalid_permissions' === wpbp_abilities_api_005( 'wpbp/locked-action' ) && 'ok' === wpbp_abilities_api_005( 'wpbp/open-action' );",
+            "description": "Denied execution reports ability_invalid_permissions and permitted execution reports ok",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_abilities_api_005( string $ability_name ): string { $ability = wp_get_ability( $ability_name ); if ( ! $ability instanceof WP_Ability ) { return 'missing'; } $result = $ability->execute(); return is_wp_error( $result ) ? $result->get_error_code() : 'ok'; }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/abilities-api.php",
+          "src/wp-includes/abilities-api/class-wp-ability.php"
+        ],
+        "release_focus": "6.9"
+      }
+    },
+    {
+      "id": "e-abilities-api-006",
+      "category": "abilities-api",
+      "difficulty": "intermediate",
+      "prompt": "Implement a function that executes the existing 'wpbp/uppercase' ability with the supplied value as its input, returning the ability's result on success or the error code string when input validation fails.",
+      "expected_behavior": "The fixture ability requires an object input with a required string `text` property. Valid input returns the uppercased text; a wrong-typed property or null input must surface the `ability_invalid_input` error code from `execute()`.",
+      "requirements": [
+        "Use wp_get_ability() and execute() with the supplied input",
+        "Return the WP_Error code when execution fails"
+      ],
+      "test_function": "wpbp_abilities_api_006( $input )",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_get_ability",
+            "description": "Retrieves the ability through the public API",
+            "weight": 1
+          },
+          {
+            "pattern": "execute",
+            "description": "Executes the ability with the supplied input",
+            "weight": 1
+          },
+          {
+            "pattern": "is_wp_error",
+            "description": "Detects failed executions",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-transform', array( 'label' => 'WPBP Transform', 'description' => 'Text transformation fixtures.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/uppercase', array( 'label' => 'Uppercase', 'description' => 'Uppercases supplied text.', 'category' => 'wpbp-transform', 'input_schema' => array( 'type' => 'object', 'properties' => array( 'text' => array( 'type' => 'string' ) ), 'required' => array( 'text' ) ), 'output_schema' => array( 'type' => 'string' ), 'execute_callback' => static fn( array $input ): string => strtoupper( $input['text'] ), 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_abilities_api_006' ) ) { return false; } return 'HOLA' === wpbp_abilities_api_006( array( 'text' => 'hola' ) ) && 'ability_invalid_input' === wpbp_abilities_api_006( array( 'text' => 123 ) ) && 'ability_invalid_input' === wpbp_abilities_api_006( null );",
+            "description": "Valid input executes and invalid or missing input surfaces ability_invalid_input",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_abilities_api_006( $input ) { $ability = wp_get_ability( 'wpbp/uppercase' ); if ( ! $ability instanceof WP_Ability ) { return 'missing'; } $result = $ability->execute( $input ); return is_wp_error( $result ) ? $result->get_error_code() : $result; }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/abilities-api.php",
+          "src/wp-includes/abilities-api/class-wp-ability.php"
+        ],
+        "release_focus": "6.9"
+      }
+    },
+    {
+      "id": "e-abilities-api-007",
+      "category": "abilities-api",
+      "difficulty": "intermediate",
+      "prompt": "Register a 'wpbp/greet' ability in the existing 'wpbp-greetings' category. Its input schema is a string that defaults to 'world', and it returns 'hello ' followed by the input. Register it during the correct Abilities API action.",
+      "expected_behavior": "The ability registers on `wp_abilities_api_init` with `input_schema` `array( 'type' => 'string', 'default' => 'world' )`. Executing with null input applies the schema default (`'hello world'`); executing with `'wp'` returns `'hello wp'`. The runtime inspects the registered schema and both execution paths.",
+      "requirements": [
+        "Register during the wp_abilities_api_init action",
+        "Give the input schema a 'world' default",
+        "Return 'hello ' followed by the input"
+      ],
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_register_ability",
+            "description": "Registers through the Abilities API",
+            "weight": 1
+          },
+          {
+            "pattern": "wp_abilities_api_init",
+            "description": "Uses the registration action",
+            "weight": 1
+          },
+          {
+            "pattern": "default",
+            "description": "Declares the schema default",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-greetings', array( 'label' => 'WPBP Greetings', 'description' => 'Greeting abilities.' ) ); } );",
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "WP_Abilities_Registry::get_instance(); $ability = wp_get_ability( 'wpbp/greet' ); if ( ! $ability instanceof WP_Ability ) { return false; } $schema = $ability->get_input_schema(); return 'wpbp-greetings' === $ability->get_category() && 'world' === ( $schema['default'] ?? null ) && 'hello world' === $ability->execute( null ) && 'hello wp' === $ability->execute( 'wp' );",
+            "description": "The ability registers with a defaulted input schema and the default applies on null input",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/greet', array( 'label' => 'Greet', 'description' => 'Greets the supplied name.', 'category' => 'wpbp-greetings', 'input_schema' => array( 'type' => 'string', 'default' => 'world' ), 'output_schema' => array( 'type' => 'string' ), 'execute_callback' => static fn( string $input ): string => 'hello ' . $input, 'permission_callback' => '__return_true' ) ); } );",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/abilities-api.php",
+          "src/wp-includes/abilities-api/class-wp-ability.php"
+        ],
+        "release_focus": "6.9"
+      }
+    },
+    {
+      "id": "e-abilities-api-008",
+      "category": "abilities-api",
+      "difficulty": "basic",
+      "prompt": "Implement a function that unregisters the ability with the supplied name through the Abilities API and returns true only when a WP_Ability instance was returned and the ability is no longer registered.",
+      "expected_behavior": "`wpbp_abilities_api_008()` calls `wp_unregister_ability()` and verifies both the returned instance and the post-state with `wp_has_ability()`. The runtime independently confirms the fixture ability is gone afterward, so a constant return fails.",
+      "requirements": [
+        "Use wp_unregister_ability()",
+        "Verify the ability is gone with wp_has_ability()"
+      ],
+      "test_function": "wpbp_abilities_api_008( string $ability_name ): bool",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_unregister_ability",
+            "description": "Unregisters through the public API",
+            "weight": 1
+          },
+          {
+            "pattern": "wp_has_ability",
+            "description": "Verifies the post-unregister state",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-temp', array( 'label' => 'WPBP Temp', 'description' => 'Temporary fixtures.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/temp-ability', array( 'label' => 'Temp', 'description' => 'Temporary ability.', 'category' => 'wpbp-temp', 'execute_callback' => '__return_true', 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_abilities_api_008' ) ) { return false; } return true === wpbp_abilities_api_008( 'wpbp/temp-ability' ) && false === wp_has_ability( 'wpbp/temp-ability' );",
+            "description": "The fixture ability is actually unregistered, verified independently of the function's return",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_abilities_api_008( string $ability_name ): bool { $removed = wp_unregister_ability( $ability_name ); return $removed instanceof WP_Ability && ! wp_has_ability( $ability_name ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/abilities-api.php",
+          "src/wp-includes/abilities-api/class-wp-ability.php"
+        ],
+        "release_focus": "6.9"
+      }
+    },
+    {
+      "id": "e-abilities-api-009",
+      "category": "abilities-api",
+      "difficulty": "basic",
+      "prompt": "Register an ability category with the slug 'wpbp-audit', the label 'WPBP Audit', a description, and a meta array containing 'icon' set to 'shield'. Register it during the correct Abilities API action.",
+      "expected_behavior": "The category registers on `wp_abilities_api_categories_init` with the meta array. The runtime inspects the registered `WP_Ability_Category` object's label and meta, so a hard-coded return cannot pass.",
+      "requirements": [
+        "Register during the wp_abilities_api_categories_init action",
+        "Include the meta array with the icon entry"
+      ],
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_register_ability_category",
+            "description": "Registers through the Abilities API",
+            "weight": 1
+          },
+          {
+            "pattern": "wp_abilities_api_categories_init",
+            "description": "Uses the categories registration action",
+            "weight": 1
+          },
+          {
+            "pattern": "meta",
+            "description": "Passes the meta array",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "$found = wp_has_ability_category( 'wpbp-audit' ); if ( ! $found ) { return false; } $category = wp_get_ability_category( 'wpbp-audit' ); $meta = $category instanceof WP_Ability_Category ? $category->get_meta() : array(); return 'WPBP Audit' === $category->get_label() && 'shield' === ( $meta['icon'] ?? null );",
+            "description": "The category is actually registered with its label and icon meta",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-audit', array( 'label' => 'WPBP Audit', 'description' => 'Audit abilities for WPBP.', 'meta' => array( 'icon' => 'shield' ) ) ); } );",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/abilities-api.php",
+          "src/wp-includes/abilities-api/class-wp-ability-category.php"
+        ],
+        "release_focus": "6.9"
+      }
+    },
+    {
+      "id": "e-abilities-api-010",
+      "category": "abilities-api",
+      "difficulty": "advanced",
+      "prompt": "Register a 'wpbp/word-stats' ability in the existing 'wpbp-stats' category. It accepts an object input with a required string 'text' property and returns an object with integer 'words' and 'chars' properties (both required in the output schema): the word count and character count of the text.",
+      "expected_behavior": "The ability registers on `wp_abilities_api_init` with both schemas. The runtime checks the declared output schema (object with required integer `words`/`chars`) and executes it against two different texts, so neither a constant return nor a schema-less registration passes.",
+      "requirements": [
+        "Register during the wp_abilities_api_init action",
+        "Declare both the input schema and the output schema",
+        "Compute words with str_word_count() and chars with strlen()"
+      ],
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_register_ability",
+            "description": "Registers through the Abilities API",
+            "weight": 1
+          },
+          {
+            "pattern": "output_schema",
+            "description": "Declares the output schema",
+            "weight": 1
+          },
+          {
+            "pattern": "str_word_count",
+            "description": "Computes the word count",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-stats', array( 'label' => 'WPBP Stats', 'description' => 'Statistics abilities.' ) ); } );",
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "WP_Abilities_Registry::get_instance(); $ability = wp_get_ability( 'wpbp/word-stats' ); if ( ! $ability instanceof WP_Ability ) { return false; } $out = $ability->get_output_schema(); $required = $out['required'] ?? array(); return 'object' === ( $out['type'] ?? null ) && 'integer' === ( $out['properties']['words']['type'] ?? null ) && 'integer' === ( $out['properties']['chars']['type'] ?? null ) && in_array( 'words', $required, true ) && in_array( 'chars', $required, true ) && array( 'words' => 2, 'chars' => 8 ) === $ability->execute( array( 'text' => 'hi there' ) ) && array( 'words' => 1, 'chars' => 4 ) === $ability->execute( array( 'text' => 'solo' ) );",
+            "description": "The ability declares the full output schema and computes correct stats for two inputs",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/word-stats', array( 'label' => 'Word stats', 'description' => 'Counts words and characters.', 'category' => 'wpbp-stats', 'input_schema' => array( 'type' => 'object', 'properties' => array( 'text' => array( 'type' => 'string' ) ), 'required' => array( 'text' ) ), 'output_schema' => array( 'type' => 'object', 'properties' => array( 'words' => array( 'type' => 'integer' ), 'chars' => array( 'type' => 'integer' ) ), 'required' => array( 'words', 'chars' ) ), 'execute_callback' => static fn( array $input ): array => array( 'words' => str_word_count( $input['text'] ), 'chars' => strlen( $input['text'] ) ), 'permission_callback' => '__return_true' ) ); } );",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/abilities-api.php",
+          "src/wp-includes/abilities-api/class-wp-ability.php"
+        ],
+        "release_focus": "6.9"
+      }
+    },
+    {
+      "id": "e-abilities-api-011",
+      "category": "abilities-api",
+      "difficulty": "intermediate",
+      "prompt": "Implement a function that returns the sorted list of registered ability names belonging to the supplied category slug.",
+      "expected_behavior": "`wpbp_abilities_api_011()` enumerates `wp_get_abilities()` and filters by each ability's `get_category()`. The runtime registers fixtures across two categories plus an empty category, expecting three different results.",
+      "requirements": [
+        "Use wp_get_abilities() to enumerate",
+        "Filter by each ability's category",
+        "Return the names sorted alphabetically"
+      ],
+      "test_function": "wpbp_abilities_api_011( string $category ): array",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_get_abilities",
+            "description": "Enumerates through the public API",
+            "weight": 1
+          },
+          {
+            "pattern": "get_category",
+            "description": "Reads each ability's category",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-fix-a', array( 'label' => 'WPBP Fix A', 'description' => 'Fixture category A.' ) ); wp_register_ability_category( 'wpbp-fix-b', array( 'label' => 'WPBP Fix B', 'description' => 'Fixture category B.' ) ); wp_register_ability_category( 'wpbp-fix-empty', array( 'label' => 'WPBP Fix Empty', 'description' => 'Empty fixture category.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/a-two', array( 'label' => 'A two', 'description' => 'Fixture.', 'category' => 'wpbp-fix-a', 'execute_callback' => '__return_true', 'permission_callback' => '__return_true' ) ); wp_register_ability( 'wpbp/a-one', array( 'label' => 'A one', 'description' => 'Fixture.', 'category' => 'wpbp-fix-a', 'execute_callback' => '__return_true', 'permission_callback' => '__return_true' ) ); wp_register_ability( 'wpbp/b-one', array( 'label' => 'B one', 'description' => 'Fixture.', 'category' => 'wpbp-fix-b', 'execute_callback' => '__return_true', 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_abilities_api_011' ) ) { return false; } return array( 'wpbp/a-one', 'wpbp/a-two' ) === wpbp_abilities_api_011( 'wpbp-fix-a' ) && array( 'wpbp/b-one' ) === wpbp_abilities_api_011( 'wpbp-fix-b' ) && array() === wpbp_abilities_api_011( 'wpbp-fix-empty' );",
+            "description": "Enumeration returns exactly the fixture abilities per category, sorted",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_abilities_api_011( string $category ): array { $names = array(); foreach ( wp_get_abilities() as $name => $ability ) { if ( $ability->get_category() === $category ) { $names[] = $name; } } sort( $names ); return $names; }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/abilities-api.php",
+          "src/wp-includes/abilities-api/class-wp-ability.php"
+        ],
+        "release_focus": "6.9"
+      }
+    },
+    {
+      "id": "e-abilities-api-012",
+      "category": "abilities-api",
+      "difficulty": "basic",
+      "prompt": "Implement a function that reports on the ability registered under the supplied name: whether it is registered at all, and whether it is exposed through REST, as array( 'registered' => bool, 'show_in_rest' => bool ). It must not trigger any registry notice for unknown names.",
+      "expected_behavior": "`wpbp_abilities_api_012()` gates with `wp_has_ability()` (silent) before retrieving, and reads `show_in_rest` via ability meta. The runtime probes the built-in core abilities (`core/get-site-info` is REST-visible, `core/get-user-info` is not) plus an unknown name.",
+      "requirements": [
+        "Gate with wp_has_ability() so unknown names produce no notice",
+        "Read REST visibility from the ability meta"
+      ],
+      "test_function": "wpbp_abilities_api_012( string $ability_name ): array",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_has_ability",
+            "description": "Gates silently on registration state",
+            "weight": 1
+          },
+          {
+            "pattern": "show_in_rest",
+            "description": "Reads REST visibility from meta",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_abilities_api_012' ) ) { return false; } return array( 'registered' => true, 'show_in_rest' => true ) === wpbp_abilities_api_012( 'core/get-site-info' ) && array( 'registered' => true, 'show_in_rest' => false ) === wpbp_abilities_api_012( 'core/get-user-info' ) && array( 'registered' => false, 'show_in_rest' => false ) === wpbp_abilities_api_012( 'wpbp/never-registered' );",
+            "description": "Core abilities report their real REST visibility and unknown names report unregistered without notices",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_abilities_api_012( string $ability_name ): array { if ( ! wp_has_ability( $ability_name ) ) { return array( 'registered' => false, 'show_in_rest' => false ); } $ability = wp_get_ability( $ability_name ); return array( 'registered' => true, 'show_in_rest' => (bool) $ability->get_meta_item( 'show_in_rest', false ) ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/abilities-api.php",
+          "src/wp-includes/abilities.php"
+        ],
+        "release_focus": "6.9"
+      }
+    },
+    {
+      "id": "e-abilities-api-013",
+      "category": "abilities-api",
+      "difficulty": "advanced",
+      "prompt": "Implement a function that hooks the ability registration arguments filter so that every ability whose name starts with 'wpbp-forced/' is registered with meta.show_in_rest forced to true, leaving other abilities untouched.",
+      "expected_behavior": "`wpbp_abilities_api_013()` adds a `wp_register_ability_args` filter keyed off the ability name. The runtime calls the function before triggering registration of two fixture abilities (one in the forced namespace, one outside it) and verifies only the forced one became REST-visible.",
+      "requirements": [
+        "Filter wp_register_ability_args",
+        "Match abilities by the 'wpbp-forced/' name prefix",
+        "Force meta.show_in_rest to true only for matches"
+      ],
+      "test_function": "wpbp_abilities_api_013(): void",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_register_ability_args",
+            "description": "Hooks the registration args filter",
+            "weight": 1
+          },
+          {
+            "pattern": "add_filter",
+            "description": "Registers the filter",
+            "weight": 1
+          },
+          {
+            "pattern": "show_in_rest",
+            "description": "Forces the REST visibility meta",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-forced-cat', array( 'label' => 'WPBP Forced', 'description' => 'Filter fixture category.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp-forced/sample', array( 'label' => 'Forced sample', 'description' => 'Fixture.', 'category' => 'wpbp-forced-cat', 'execute_callback' => '__return_true', 'permission_callback' => '__return_true' ) ); wp_register_ability( 'wpbp/unforced-sample', array( 'label' => 'Unforced sample', 'description' => 'Fixture.', 'category' => 'wpbp-forced-cat', 'execute_callback' => '__return_true', 'permission_callback' => '__return_true' ) ); } );",
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_abilities_api_013' ) ) { return false; } wpbp_abilities_api_013(); WP_Abilities_Registry::get_instance(); $forced = wp_get_ability( 'wpbp-forced/sample' ); $plain = wp_get_ability( 'wpbp/unforced-sample' ); if ( ! $forced instanceof WP_Ability || ! $plain instanceof WP_Ability ) { return false; } return true === $forced->get_meta_item( 'show_in_rest', false ) && false === $plain->get_meta_item( 'show_in_rest', false );",
+            "description": "Only the forced-namespace fixture becomes REST-visible through the filter",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_abilities_api_013(): void { add_filter( 'wp_register_ability_args', function ( array $args, string $name ): array { if ( str_starts_with( $name, 'wpbp-forced/' ) ) { $args['meta']['show_in_rest'] = true; } return $args; }, 10, 2 ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/abilities-api.php",
+          "src/wp-includes/abilities-api/class-wp-ability.php"
+        ],
+        "release_focus": "6.9"
+      }
+    },
+    {
+      "id": "e-abilities-api-014",
+      "category": "abilities-api",
+      "difficulty": "advanced",
+      "prompt": "Implement a function that safely executes the ability registered under the supplied name with the supplied input, reporting array( 'ok' => false, 'code' => <error code> ) when execution fails and array( 'ok' => true, 'value' => <result> ) when it succeeds.",
+      "expected_behavior": "`wpbp_abilities_api_014()` relies on the Abilities API error contract: callbacks that throw are converted by `execute()` into a WP_Error with code `ability_callback_exception`, never surfaced as an exception. The runtime probes a throwing fixture and a working fixture.",
+      "requirements": [
+        "Execute through the Abilities API",
+        "Map WP_Error results to the failure shape with their code",
+        "Map successful results to the success shape"
+      ],
+      "test_function": "wpbp_abilities_api_014( string $ability_name, $input ): array",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_get_ability",
+            "description": "Retrieves the ability through the public API",
+            "weight": 1
+          },
+          {
+            "pattern": "execute",
+            "description": "Executes the ability",
+            "weight": 1
+          },
+          {
+            "pattern": "get_error_code",
+            "description": "Extracts the failure code",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-errors', array( 'label' => 'WPBP Errors', 'description' => 'Error handling fixtures.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/throws', array( 'label' => 'Throws', 'description' => 'Always throws.', 'category' => 'wpbp-errors', 'execute_callback' => static function () { throw new RuntimeException( 'boom' ); }, 'permission_callback' => '__return_true' ) ); wp_register_ability( 'wpbp/answer', array( 'label' => 'Answer', 'description' => 'Returns the answer.', 'category' => 'wpbp-errors', 'execute_callback' => static fn(): int => 42, 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_abilities_api_014' ) ) { return false; } return array( 'ok' => false, 'code' => 'ability_callback_exception' ) === wpbp_abilities_api_014( 'wpbp/throws', null ) && array( 'ok' => true, 'value' => 42 ) === wpbp_abilities_api_014( 'wpbp/answer', null );",
+            "description": "A throwing callback surfaces ability_callback_exception and a working ability surfaces its value",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_abilities_api_014( string $ability_name, $input ): array { $ability = wp_get_ability( $ability_name ); if ( ! $ability instanceof WP_Ability ) { return array( 'ok' => false, 'code' => 'missing' ); } $result = $ability->execute( $input ); if ( is_wp_error( $result ) ) { return array( 'ok' => false, 'code' => $result->get_error_code() ); } return array( 'ok' => true, 'value' => $result ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/abilities-api.php",
+          "src/wp-includes/abilities-api/class-wp-ability.php"
         ],
         "release_focus": "6.9"
       }

--- a/datasets/suites/wp-core-v1/execution/ai-client.json
+++ b/datasets/suites/wp-core-v1/execution/ai-client.json
@@ -327,7 +327,7 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_006' ) ) { return false; } $seen = null; $spy = function ( $timeout ) use ( &$seen ) { $seen = $timeout; return $timeout; }; add_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); $builder = wpbp_ai_client_006( 12.5 ); remove_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); remove_all_filters( 'wp_ai_client_default_request_timeout' ); return $builder instanceof WP_AI_Client_Prompt_Builder && 12.5 === (float) $seen;",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_006' ) ) { return false; } $seen = null; $spy = function ( $timeout ) use ( &$seen ) { $seen = $timeout; return $timeout; }; add_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); $builder = wpbp_ai_client_006( 12.5 ); remove_all_filters( 'wp_ai_client_default_request_timeout' ); return $builder instanceof WP_AI_Client_Prompt_Builder && 12.5 === (float) $seen;",
             "description": "The filtered timeout is observed during builder construction and a builder is returned",
             "weight": 1
           }
@@ -415,11 +415,6 @@
             "pattern": "add_filter",
             "description": "Registers the filter",
             "weight": 1
-          },
-          {
-            "pattern": "instanceof",
-            "description": "Type-checks the captured builder",
-            "weight": 1
           }
         ]
       },
@@ -427,7 +422,7 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_008' ) ) { return false; } $calls = 0; $spy = function ( $prevent ) use ( &$calls ) { $calls++; return $prevent; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $result = wpbp_ai_client_008(); remove_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $after = apply_filters( 'wp_ai_client_prevent_prompt', false, wp_ai_client_prompt( 'Probe' ) ); return true === $result && $calls > 0 && false === $after;",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_008' ) ) { return false; } $calls = 0; $spy = function ( $prevent ) use ( &$calls ) { $calls++; return $prevent; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $result = wpbp_ai_client_008(); remove_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); return true === $result && $calls > 0 && false === has_filter( 'wp_ai_client_prevent_prompt' );",
             "description": "The prevention filter chain actually runs, receives a distinct builder clone, and is cleaned up",
             "weight": 1
           }
@@ -588,63 +583,6 @@
       }
     },
     {
-      "id": "e-ai-client-012",
-      "category": "ai-client",
-      "difficulty": "basic",
-      "prompt": "Implement a function that returns the result of the WordPress AI support check while a filter forces the raw supplied value onto it, removing the filter before returning.",
-      "expected_behavior": "`wp_supports_ai()` casts the filtered value to bool, so raw `'0'` and `0` report false while `'yes'` reports true. `wpbp_ai_client_012()` must surface the cast result, and the runtime verifies support is restored afterward.",
-      "requirements": [
-        "Filter wp_supports_ai to return the raw value",
-        "Return the wp_supports_ai() result",
-        "Remove the filter before returning"
-      ],
-      "test_function": "wpbp_ai_client_012( $raw_value ): bool",
-      "static_checks": {
-        "required_patterns": [
-          {
-            "pattern": "wp_supports_ai",
-            "description": "Uses the support check and its filter",
-            "weight": 1
-          },
-          {
-            "pattern": "add_filter",
-            "description": "Forces the raw value",
-            "weight": 1
-          },
-          {
-            "pattern": "remove_filter",
-            "description": "Restores support",
-            "weight": 1
-          }
-        ],
-        "forbidden_patterns": [
-          {
-            "pattern": "/\\b(?:generate_(?:result|text(?:s|_result)?|image(?:s|_result)?|speech(?:es|_result)?|video(?:s|_result)?)|convert_text_to_speech(?:es|_result)?)\\b/",
-            "description": "Does not generate content",
-            "severity": "error"
-          }
-        ]
-      },
-      "runtime_checks": {
-        "assertions": [
-          {
-            "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_012' ) ) { return false; } return false === wpbp_ai_client_012( '0' ) && false === wpbp_ai_client_012( 0 ) && true === wpbp_ai_client_012( 'yes' ) && true === wp_supports_ai();",
-            "description": "The support check reports the boolean cast of each forced raw value and support is restored",
-            "weight": 1
-          }
-        ]
-      },
-      "reference_solution": "function wpbp_ai_client_012( $raw_value ): bool { $filter = static fn() => $raw_value; add_filter( 'wp_supports_ai', $filter ); $supported = wp_supports_ai(); remove_filter( 'wp_supports_ai', $filter ); return $supported; }",
-      "metadata": {
-        "source_refs": [
-          "src/wp-includes/ai-client.php",
-          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
-        ],
-        "release_focus": "7.0"
-      }
-    },
-    {
       "id": "e-ai-client-013",
       "category": "ai-client",
       "difficulty": "basic",
@@ -670,7 +608,7 @@
         ]
       },
       "runtime_checks": {
-        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-ai-summary', array( 'label' => 'WPBP AI Summary', 'description' => 'Summary fixtures.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/summarize', array( 'label' => 'Summarize', 'description' => 'Summarizes text.', 'category' => 'wpbp-ai-summary', 'input_schema' => array( 'type' => 'object', 'properties' => array( 'text' => array( 'type' => 'string' ) ), 'required' => array( 'text' ) ), 'execute_callback' => static fn( array $input ): string => substr( $input['text'], 0, 10 ), 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-ai-fixtures', array( 'label' => 'WPBP AI Fixtures', 'description' => 'Fixtures for AI client tests.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/summarize', array( 'label' => 'Summarize', 'description' => 'Summarizes text.', 'category' => 'wpbp-ai-fixtures', 'input_schema' => array( 'type' => 'object', 'properties' => array( 'text' => array( 'type' => 'string' ) ), 'required' => array( 'text' ) ), 'execute_callback' => static fn( array $input ): string => substr( $input['text'], 0, 10 ), 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
         "assertions": [
           {
             "type": "custom_assertion",
@@ -681,56 +619,6 @@
         ]
       },
       "reference_solution": "function wpbp_ai_client_013(): WP_AI_Client_Prompt_Builder { return wp_ai_client_prompt( 'Summarize the latest posts' )->using_abilities( 'wpbp/summarize' ); }",
-      "metadata": {
-        "source_refs": [
-          "src/wp-includes/ai-client.php",
-          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
-        ],
-        "release_focus": "7.0"
-      }
-    },
-    {
-      "id": "e-ai-client-014",
-      "category": "ai-client",
-      "difficulty": "intermediate",
-      "prompt": "Implement a function that describes the error produced when AI text generation is prevented by the core prevention filter, as array( 'code' => string, 'status' => int, 'message' => string ). Add and remove the prevention filter inside the function.",
-      "expected_behavior": "A filter-prevented generation returns `WP_Error( 'prompt_prevented', 'Prompt execution was prevented by a filter.', array( 'status' => 503 ) )`. The runtime spies on the prevention filter to confirm the attempt actually happened and verifies prevention is inactive afterward.",
-      "requirements": [
-        "Prevent with the wp_ai_client_prevent_prompt filter",
-        "Extract the code, the status from the error data, and the message",
-        "Remove the filter before returning"
-      ],
-      "test_function": "wpbp_ai_client_014(): array",
-      "static_checks": {
-        "required_patterns": [
-          {
-            "pattern": "wp_ai_client_prevent_prompt",
-            "description": "Uses the prevention filter",
-            "weight": 1
-          },
-          {
-            "pattern": "get_error_data",
-            "description": "Reads the status from the error data",
-            "weight": 1
-          },
-          {
-            "pattern": "remove_filter",
-            "description": "Cleans up",
-            "weight": 1
-          }
-        ]
-      },
-      "runtime_checks": {
-        "assertions": [
-          {
-            "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_014' ) ) { return false; } $calls = 0; $spy = function ( $prevent ) use ( &$calls ) { $calls++; return $prevent; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $described = wpbp_ai_client_014(); remove_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $after = apply_filters( 'wp_ai_client_prevent_prompt', false, wp_ai_client_prompt( 'Probe' ) ); return array( 'code' => 'prompt_prevented', 'status' => 503, 'message' => 'Prompt execution was prevented by a filter.' ) === $described && $calls > 0 && false === $after;",
-            "description": "The prevented error carries its code, 503 status, and filter message, produced by a real attempt",
-            "weight": 1
-          }
-        ]
-      },
-      "reference_solution": "function wpbp_ai_client_014(): array { add_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $error = wp_ai_client_prompt( 'Probe' )->generate_text(); remove_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $data = is_wp_error( $error ) ? (array) $error->get_error_data() : array(); return array( 'code' => is_wp_error( $error ) ? $error->get_error_code() : '', 'status' => (int) ( $data['status'] ?? 0 ), 'message' => is_wp_error( $error ) ? $error->get_error_message() : '' ); }",
       "metadata": {
         "source_refs": [
           "src/wp-includes/ai-client.php",

--- a/datasets/suites/wp-core-v1/execution/ai-client.json
+++ b/datasets/suites/wp-core-v1/execution/ai-client.json
@@ -342,7 +342,7 @@
       "category": "ai-client",
       "difficulty": "intermediate",
       "prompt": "Implement a function that returns the error message produced when text generation is attempted while WordPress AI support is disabled through the core support filter. Disable support only around the attempt and re-enable it before returning.",
-      "expected_behavior": "`wpbp_ai_client_007()` forces `wp_supports_ai` off, attempts `generate_text()` (which short-circuits into the disabled-environment `prompt_prevented` error before any provider call), removes the filter, and returns the error message. The runtime spies on the support filter to prove it was actually engaged, and verifies support is restored.",
+      "expected_behavior": "`wpbp_ai_client_007()` forces `wp_supports_ai` off, attempts `generate_text()` (which short-circuits into the disabled-environment `prompt_prevented` error before any provider call), removes the filter, and returns the error message. The runtime spies on the support filter to prove support was observed disabled during the call, verifies a real builder was constructed for the attempt, and checks support is restored.",
       "requirements": [
         "Force support off with the wp_supports_ai filter",
         "Attempt generation and capture the WP_Error message",
@@ -457,8 +457,8 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_011' ) ) { return false; } $constructions = 0; $spy = function ( $timeout ) use ( &$constructions ) { $constructions++; return $timeout; }; add_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); $builder = wpbp_ai_client_011( 'wpbp_made_up_method' ); remove_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); if ( ! $builder instanceof WP_AI_Client_Prompt_Builder || 0 === $constructions ) { return false; } add_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $error = $builder->generate_text(); remove_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); return is_wp_error( $error ) && 'prompt_builder_error' === $error->get_error_code() && $builder->using_temperature( 0.1 ) === $builder;",
-            "description": "The returned builder carries the sticky bad-method error (surfaced before the prevention gate) and stays fluent",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_011' ) ) { return false; } $constructions = 0; $spy = function ( $timeout ) use ( &$constructions ) { $constructions++; return $timeout; }; add_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); $builder = wpbp_ai_client_011( 'wpbp_made_up_method' ); remove_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); if ( ! $builder instanceof WP_AI_Client_Prompt_Builder || 0 === $constructions ) { return false; } add_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $error = $builder->generate_text(); remove_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); return is_wp_error( $error ) && 'prompt_builder_error' === $error->get_error_code();",
+            "description": "The returned builder carries the sticky bad-method error, surfaced before the prevention gate",
             "weight": 1
           }
         ]

--- a/datasets/suites/wp-core-v1/execution/ai-client.json
+++ b/datasets/suites/wp-core-v1/execution/ai-client.json
@@ -1,6 +1,6 @@
 {
   "id": "wp-core-execution-v1-ai_client",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "metadata": {
     "name": "WordPress Core Execution Tests - AI Client",
     "description": "Code generation tasks for WordPress AI Client APIs",
@@ -278,6 +278,516 @@
         ]
       },
       "reference_solution": "function wpbp_ai_client_005(): bool { add_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); try { $supported = wp_ai_client_prompt( 'Check' )->is_supported_for_text_generation(); } finally { remove_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); } return $supported; }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/ai-client.php",
+          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-ai-client-006",
+      "category": "ai-client",
+      "difficulty": "intermediate",
+      "prompt": "Implement a function that sets the default AI client request timeout to the supplied number of seconds for subsequently created prompt builders, using the core filter, and then creates and returns a new prompt builder for the prompt 'Ping'.",
+      "expected_behavior": "`wpbp_ai_client_006()` filters `wp_ai_client_default_request_timeout` (which fires on every builder construction) and returns a fresh `wp_ai_client_prompt( 'Ping' )` builder. The runtime attaches a late spy to the filter and verifies the model's filtered value actually flowed through during construction.",
+      "requirements": [
+        "Filter wp_ai_client_default_request_timeout",
+        "Create the builder with wp_ai_client_prompt()"
+      ],
+      "test_function": "wpbp_ai_client_006( float $seconds ): WP_AI_Client_Prompt_Builder",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_ai_client_default_request_timeout",
+            "description": "Uses the timeout filter",
+            "weight": 1
+          },
+          {
+            "pattern": "wp_ai_client_prompt",
+            "description": "Creates the builder",
+            "weight": 1
+          },
+          {
+            "pattern": "add_filter",
+            "description": "Registers the filter",
+            "weight": 1
+          }
+        ],
+        "forbidden_patterns": [
+          {
+            "pattern": "/\\b(?:generate_(?:result|text(?:s|_result)?|image(?:s|_result)?|speech(?:es|_result)?|video(?:s|_result)?)|convert_text_to_speech(?:es|_result)?)\\b/",
+            "description": "Does not generate content",
+            "severity": "error"
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_006' ) ) { return false; } $seen = null; $spy = function ( $timeout ) use ( &$seen ) { $seen = $timeout; return $timeout; }; add_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); $builder = wpbp_ai_client_006( 12.5 ); remove_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); remove_all_filters( 'wp_ai_client_default_request_timeout' ); return $builder instanceof WP_AI_Client_Prompt_Builder && 12.5 === (float) $seen;",
+            "description": "The filtered timeout is observed during builder construction and a builder is returned",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_ai_client_006( float $seconds ): WP_AI_Client_Prompt_Builder { add_filter( 'wp_ai_client_default_request_timeout', static fn(): float => $seconds ); return wp_ai_client_prompt( 'Ping' ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/ai-client.php",
+          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-ai-client-007",
+      "category": "ai-client",
+      "difficulty": "intermediate",
+      "prompt": "Implement a function that returns the error message produced when text generation is attempted while WordPress AI support is disabled through the core support filter. Disable support only around the attempt and re-enable it before returning.",
+      "expected_behavior": "`wpbp_ai_client_007()` forces `wp_supports_ai` off, attempts `generate_text()` (which short-circuits into the disabled-environment `prompt_prevented` error before any provider call), removes the filter, and returns the error message. The runtime spies on the support filter to prove it was actually engaged, and verifies support is restored.",
+      "requirements": [
+        "Force support off with the wp_supports_ai filter",
+        "Attempt generation and capture the WP_Error message",
+        "Remove the filter before returning"
+      ],
+      "test_function": "wpbp_ai_client_007(): string",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_supports_ai",
+            "description": "Uses the support filter",
+            "weight": 1
+          },
+          {
+            "pattern": "generate_text",
+            "description": "Attempts generation",
+            "weight": 1
+          },
+          {
+            "pattern": "remove_filter",
+            "description": "Restores support",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_007' ) ) { return false; } $calls = 0; $spy = function ( $supported ) use ( &$calls ) { $calls++; return $supported; }; add_filter( 'wp_supports_ai', $spy, 1 ); $message = wpbp_ai_client_007(); remove_filter( 'wp_supports_ai', $spy, 1 ); return 'AI features are not supported in this environment.' === $message && $calls > 0 && true === wp_supports_ai();",
+            "description": "The disabled-environment message is produced through a real attempt and support is restored",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_ai_client_007(): string { add_filter( 'wp_supports_ai', '__return_false' ); $result = wp_ai_client_prompt( 'Probe' )->generate_text(); remove_filter( 'wp_supports_ai', '__return_false' ); return is_wp_error( $result ) ? $result->get_error_message() : ''; }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/ai-client.php",
+          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-ai-client-008",
+      "category": "ai-client",
+      "difficulty": "advanced",
+      "prompt": "Implement a function that proves the AI prompt prevention filter receives a read-only copy of the builder: prevent execution via the core filter while capturing the builder instance the filter receives, attempt text generation on a new builder, clean up the filter, and return whether the captured instance is a WP_AI_Client_Prompt_Builder distinct from the original.",
+      "expected_behavior": "`wpbp_ai_client_008()` hooks `wp_ai_client_prevent_prompt` with two accepted arguments, captures the second, and compares identities. The runtime attaches its own counting spy to the prevention filter, so a hard-coded return fails: the filter chain must actually run.",
+      "requirements": [
+        "Hook wp_ai_client_prevent_prompt accepting the builder argument",
+        "Compare the captured instance against the original builder",
+        "Remove the filter before returning"
+      ],
+      "test_function": "wpbp_ai_client_008(): bool",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_ai_client_prevent_prompt",
+            "description": "Uses the prevention filter",
+            "weight": 1
+          },
+          {
+            "pattern": "add_filter",
+            "description": "Registers the filter",
+            "weight": 1
+          },
+          {
+            "pattern": "instanceof",
+            "description": "Type-checks the captured builder",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_008' ) ) { return false; } $calls = 0; $spy = function ( $prevent ) use ( &$calls ) { $calls++; return $prevent; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $result = wpbp_ai_client_008(); remove_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $after = apply_filters( 'wp_ai_client_prevent_prompt', false, wp_ai_client_prompt( 'Probe' ) ); return true === $result && $calls > 0 && false === $after;",
+            "description": "The prevention filter chain actually runs, receives a distinct builder clone, and is cleaned up",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_ai_client_008(): bool { $captured = null; $filter = function ( $prevent, $builder ) use ( &$captured ) { $captured = $builder; return true; }; add_filter( 'wp_ai_client_prevent_prompt', $filter, 10, 2 ); $builder = wp_ai_client_prompt( 'Probe' ); $builder->generate_text(); remove_filter( 'wp_ai_client_prevent_prompt', $filter, 10 ); return $captured instanceof WP_AI_Client_Prompt_Builder && $captured !== $builder; }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/ai-client.php",
+          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-ai-client-009",
+      "category": "ai-client",
+      "difficulty": "advanced",
+      "prompt": "Implement a function that measures how many times the AI prompt prevention filter runs during a text-generation attempt in each of two states, returning array( 'disabled' => int, 'enabled' => int ): first with AI support forced off via the core support filter, then with support untouched. Clean up all filters you add.",
+      "expected_behavior": "When `wp_supports_ai()` is false the prevention filter is short-circuited and never applied; when support is on it runs once per generating call. The runtime keeps its own spy on the prevention filter during the call to independently confirm exactly one invocation happened.",
+      "requirements": [
+        "Count prevention-filter invocations with your own spy filter",
+        "Force support off only for the first attempt",
+        "Clean up every filter you add"
+      ],
+      "test_function": "wpbp_ai_client_009(): array",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_ai_client_prevent_prompt",
+            "description": "Spies on the prevention filter",
+            "weight": 1
+          },
+          {
+            "pattern": "wp_supports_ai",
+            "description": "Toggles AI support",
+            "weight": 1
+          },
+          {
+            "pattern": "remove_filter",
+            "description": "Cleans up",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_009' ) ) { return false; } $outer = 0; $spy = function ( $prevent ) use ( &$outer ) { $outer++; return true; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $counts = wpbp_ai_client_009(); remove_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); return array( 'disabled' => 0, 'enabled' => 1 ) === $counts && 1 === $outer && true === wp_supports_ai();",
+            "description": "The prevention filter is skipped while AI is disabled and runs exactly once while enabled",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_ai_client_009(): array { $count = 0; $spy = function ( $prevent ) use ( &$count ) { $count++; return $prevent; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 20 ); add_filter( 'wp_supports_ai', '__return_false' ); wp_ai_client_prompt( 'Probe' )->generate_text(); $disabled = $count; remove_filter( 'wp_supports_ai', '__return_false' ); wp_ai_client_prompt( 'Probe' )->generate_text(); $enabled = $count - $disabled; remove_filter( 'wp_ai_client_prevent_prompt', $spy, 20 ); return array( 'disabled' => $disabled, 'enabled' => $enabled ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/ai-client.php",
+          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-ai-client-010",
+      "category": "ai-client",
+      "difficulty": "advanced",
+      "prompt": "Implement a function that executes the supplied AI function call through a WP_AI_Client_Ability_Function_Resolver that allows only the existing 'wpbp/echo-upper' ability, returning the resulting function response payload.",
+      "expected_behavior": "`wpbp_ai_client_010()` constructs the resolver with the single allowed ability and calls `execute_ability()`. The runtime sends an allowed call (executes the real ability), a prefixed-but-disallowed call (payload code `ability_not_allowed`), and a non-ability call (payload code `invalid_ability_call`).",
+      "requirements": [
+        "Construct the resolver allowing only wpbp/echo-upper",
+        "Execute the call with execute_ability()",
+        "Return the FunctionResponse payload"
+      ],
+      "test_function": "wpbp_ai_client_010( $function_call )",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "WP_AI_Client_Ability_Function_Resolver",
+            "description": "Uses the resolver",
+            "weight": 1
+          },
+          {
+            "pattern": "execute_ability",
+            "description": "Executes through the resolver",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-ai-fixtures', array( 'label' => 'WPBP AI Fixtures', 'description' => 'Fixtures for AI client tests.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/echo-upper', array( 'label' => 'Echo upper', 'description' => 'Uppercases text.', 'category' => 'wpbp-ai-fixtures', 'input_schema' => array( 'type' => 'object', 'properties' => array( 'text' => array( 'type' => 'string' ) ), 'required' => array( 'text' ) ), 'execute_callback' => static fn( array $input ): string => strtoupper( $input['text'] ), 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_010' ) ) { return false; } $allowed = new WordPress\\AiClient\\Tools\\DTO\\FunctionCall( 'call-1', 'wpab__wpbp__echo-upper', array( 'text' => 'hola' ) ); $blocked = new WordPress\\AiClient\\Tools\\DTO\\FunctionCall( 'call-2', 'wpab__wpbp__other', array() ); $foreign = new WordPress\\AiClient\\Tools\\DTO\\FunctionCall( 'call-3', 'random_helper', array() ); $ok = wpbp_ai_client_010( $allowed ); $not_allowed = wpbp_ai_client_010( $blocked ); $invalid = wpbp_ai_client_010( $foreign ); return 'HOLA' === $ok && 'ability_not_allowed' === ( $not_allowed['code'] ?? null ) && 'invalid_ability_call' === ( $invalid['code'] ?? null );",
+            "description": "The resolver executes the allowed ability and rejects disallowed and non-ability calls with their codes",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_ai_client_010( $function_call ) { $resolver = new WP_AI_Client_Ability_Function_Resolver( 'wpbp/echo-upper' ); return $resolver->execute_ability( $function_call )->getResponse(); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/ai-client/class-wp-ai-client-ability-function-resolver.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-ai-client-011",
+      "category": "ai-client",
+      "difficulty": "intermediate",
+      "prompt": "Implement a function that calls the supplied nonexistent method name on a fresh AI prompt builder and reports how the builder behaves afterwards, as array( 'error_code' => <code from a subsequent generate_text() call>, 'still_fluent' => <whether using_temperature() still returns the same builder> ).",
+      "expected_behavior": "Unknown builder methods put the builder into a sticky error state: later generating calls return the stored `prompt_builder_error` WP_Error while fluent configuration keeps returning the builder itself. `wpbp_ai_client_011()` exercises exactly that state machine.",
+      "requirements": [
+        "Create the builder with wp_ai_client_prompt()",
+        "Invoke the supplied method name dynamically",
+        "Report the subsequent error code and fluency"
+      ],
+      "test_function": "wpbp_ai_client_011( string $method_name ): array",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_ai_client_prompt",
+            "description": "Creates the builder",
+            "weight": 1
+          },
+          {
+            "pattern": "generate_text",
+            "description": "Probes the stored error",
+            "weight": 1
+          },
+          {
+            "pattern": "using_temperature",
+            "description": "Probes fluency after the failure",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_011' ) ) { return false; } return array( 'error_code' => 'prompt_builder_error', 'still_fluent' => true ) === wpbp_ai_client_011( 'wpbp_made_up_method' );",
+            "description": "A bad method call leaves the builder errored for generation but still fluent",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_ai_client_011( string $method_name ): array { $builder = wp_ai_client_prompt( 'Probe' ); $builder->{$method_name}(); $result = $builder->generate_text(); return array( 'error_code' => is_wp_error( $result ) ? $result->get_error_code() : '', 'still_fluent' => $builder->using_temperature( 0.1 ) === $builder ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/ai-client.php",
+          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-ai-client-012",
+      "category": "ai-client",
+      "difficulty": "basic",
+      "prompt": "Implement a function that returns the result of the WordPress AI support check while a filter forces the raw supplied value onto it, removing the filter before returning.",
+      "expected_behavior": "`wp_supports_ai()` casts the filtered value to bool, so raw `'0'` and `0` report false while `'yes'` reports true. `wpbp_ai_client_012()` must surface the cast result, and the runtime verifies support is restored afterward.",
+      "requirements": [
+        "Filter wp_supports_ai to return the raw value",
+        "Return the wp_supports_ai() result",
+        "Remove the filter before returning"
+      ],
+      "test_function": "wpbp_ai_client_012( $raw_value ): bool",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_supports_ai",
+            "description": "Uses the support check and its filter",
+            "weight": 1
+          },
+          {
+            "pattern": "add_filter",
+            "description": "Forces the raw value",
+            "weight": 1
+          },
+          {
+            "pattern": "remove_filter",
+            "description": "Restores support",
+            "weight": 1
+          }
+        ],
+        "forbidden_patterns": [
+          {
+            "pattern": "/\\b(?:generate_(?:result|text(?:s|_result)?|image(?:s|_result)?|speech(?:es|_result)?|video(?:s|_result)?)|convert_text_to_speech(?:es|_result)?)\\b/",
+            "description": "Does not generate content",
+            "severity": "error"
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_012' ) ) { return false; } return false === wpbp_ai_client_012( '0' ) && false === wpbp_ai_client_012( 0 ) && true === wpbp_ai_client_012( 'yes' ) && true === wp_supports_ai();",
+            "description": "The support check reports the boolean cast of each forced raw value and support is restored",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_ai_client_012( $raw_value ): bool { $filter = static fn() => $raw_value; add_filter( 'wp_supports_ai', $filter ); $supported = wp_supports_ai(); remove_filter( 'wp_supports_ai', $filter ); return $supported; }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/ai-client.php",
+          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-ai-client-013",
+      "category": "ai-client",
+      "difficulty": "basic",
+      "prompt": "Implement a function that creates an AI prompt builder for the prompt 'Summarize the latest posts' and attaches the existing 'wpbp/summarize' ability to it as an AI function, returning the builder.",
+      "expected_behavior": "`wpbp_ai_client_013()` uses `using_abilities()`, which converts the registered ability into a function declaration on the builder. The runtime verifies the returned builder is usable (a prevention-forced generation reports `prompt_prevented`, proving the builder carries no error from the attach).",
+      "requirements": [
+        "Create the builder with wp_ai_client_prompt()",
+        "Attach the ability with using_abilities()"
+      ],
+      "test_function": "wpbp_ai_client_013(): WP_AI_Client_Prompt_Builder",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_ai_client_prompt",
+            "description": "Creates the builder",
+            "weight": 1
+          },
+          {
+            "pattern": "using_abilities",
+            "description": "Attaches the ability",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-ai-summary', array( 'label' => 'WPBP AI Summary', 'description' => 'Summary fixtures.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/summarize', array( 'label' => 'Summarize', 'description' => 'Summarizes text.', 'category' => 'wpbp-ai-summary', 'input_schema' => array( 'type' => 'object', 'properties' => array( 'text' => array( 'type' => 'string' ) ), 'required' => array( 'text' ) ), 'execute_callback' => static fn( array $input ): string => substr( $input['text'], 0, 10 ), 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_013' ) ) { return false; } $builder = wpbp_ai_client_013(); if ( ! $builder instanceof WP_AI_Client_Prompt_Builder ) { return false; } add_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $result = $builder->generate_text(); remove_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); return is_wp_error( $result ) && 'prompt_prevented' === $result->get_error_code();",
+            "description": "The ability attaches without erroring the builder, proven through a prevention-forced generation",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_ai_client_013(): WP_AI_Client_Prompt_Builder { return wp_ai_client_prompt( 'Summarize the latest posts' )->using_abilities( 'wpbp/summarize' ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/ai-client.php",
+          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-ai-client-014",
+      "category": "ai-client",
+      "difficulty": "intermediate",
+      "prompt": "Implement a function that describes the error produced when AI text generation is prevented by the core prevention filter, as array( 'code' => string, 'status' => int, 'message' => string ). Add and remove the prevention filter inside the function.",
+      "expected_behavior": "A filter-prevented generation returns `WP_Error( 'prompt_prevented', 'Prompt execution was prevented by a filter.', array( 'status' => 503 ) )`. The runtime spies on the prevention filter to confirm the attempt actually happened and verifies prevention is inactive afterward.",
+      "requirements": [
+        "Prevent with the wp_ai_client_prevent_prompt filter",
+        "Extract the code, the status from the error data, and the message",
+        "Remove the filter before returning"
+      ],
+      "test_function": "wpbp_ai_client_014(): array",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_ai_client_prevent_prompt",
+            "description": "Uses the prevention filter",
+            "weight": 1
+          },
+          {
+            "pattern": "get_error_data",
+            "description": "Reads the status from the error data",
+            "weight": 1
+          },
+          {
+            "pattern": "remove_filter",
+            "description": "Cleans up",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_014' ) ) { return false; } $calls = 0; $spy = function ( $prevent ) use ( &$calls ) { $calls++; return $prevent; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $described = wpbp_ai_client_014(); remove_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $after = apply_filters( 'wp_ai_client_prevent_prompt', false, wp_ai_client_prompt( 'Probe' ) ); return array( 'code' => 'prompt_prevented', 'status' => 503, 'message' => 'Prompt execution was prevented by a filter.' ) === $described && $calls > 0 && false === $after;",
+            "description": "The prevented error carries its code, 503 status, and filter message, produced by a real attempt",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_ai_client_014(): array { add_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $error = wp_ai_client_prompt( 'Probe' )->generate_text(); remove_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $data = is_wp_error( $error ) ? (array) $error->get_error_data() : array(); return array( 'code' => is_wp_error( $error ) ? $error->get_error_code() : '', 'status' => (int) ( $data['status'] ?? 0 ), 'message' => is_wp_error( $error ) ? $error->get_error_message() : '' ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/ai-client.php",
+          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-ai-client-015",
+      "category": "ai-client",
+      "difficulty": "intermediate",
+      "prompt": "Implement a function that proves a prevented support check leaves the AI prompt builder reusable: run a text-generation support check while prevention is active via the core filter, then remove the filter and return whether the check reported unsupported and the same builder still chains fluent configuration (using_temperature() returns the builder itself).",
+      "expected_behavior": "Prevention makes support checks return false without storing an error on the builder, unlike generating calls. `wpbp_ai_client_015()` verifies both halves. The runtime spies on the prevention filter to confirm the check actually engaged it.",
+      "requirements": [
+        "Prevent with the wp_ai_client_prevent_prompt filter",
+        "Run is_supported_for_text_generation() under prevention",
+        "Verify fluency on the same builder after removing the filter"
+      ],
+      "test_function": "wpbp_ai_client_015(): bool",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "is_supported_for_text_generation",
+            "description": "Runs the support check",
+            "weight": 1
+          },
+          {
+            "pattern": "wp_ai_client_prevent_prompt",
+            "description": "Uses the prevention filter",
+            "weight": 1
+          },
+          {
+            "pattern": "using_temperature",
+            "description": "Probes fluency afterwards",
+            "weight": 1
+          }
+        ],
+        "forbidden_patterns": [
+          {
+            "pattern": "/\\b(?:generate_(?:result|text(?:s|_result)?|image(?:s|_result)?|speech(?:es|_result)?|video(?:s|_result)?)|convert_text_to_speech(?:es|_result)?)\\b/",
+            "description": "Does not generate content",
+            "severity": "error"
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_015' ) ) { return false; } $calls = 0; $spy = function ( $prevent ) use ( &$calls ) { $calls++; return $prevent; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $result = wpbp_ai_client_015(); remove_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); return true === $result && $calls > 0;",
+            "description": "The prevented support check reports false and the builder stays clean and fluent",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_ai_client_015(): bool { add_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $builder = wp_ai_client_prompt( 'Probe' ); $unsupported = false === $builder->is_supported_for_text_generation(); remove_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); return $unsupported && $builder->using_temperature( 0.2 ) === $builder; }",
       "metadata": {
         "source_refs": [
           "src/wp-includes/ai-client.php",

--- a/datasets/suites/wp-core-v1/execution/ai-client.json
+++ b/datasets/suites/wp-core-v1/execution/ai-client.json
@@ -290,23 +290,18 @@
       "id": "e-ai-client-006",
       "category": "ai-client",
       "difficulty": "intermediate",
-      "prompt": "Implement a function that sets the default AI client request timeout to the supplied number of seconds for subsequently created prompt builders, using the core filter, and then creates and returns a new prompt builder for the prompt 'Ping'.",
-      "expected_behavior": "`wpbp_ai_client_006()` filters `wp_ai_client_default_request_timeout` (which fires on every builder construction) and returns a fresh `wp_ai_client_prompt( 'Ping' )` builder. The runtime attaches a late spy to the filter and verifies the model's filtered value actually flowed through during construction.",
+      "prompt": "Implement a function that makes the default AI client request timeout the supplied number of seconds for all subsequently created prompt builders, using the core filter.",
+      "expected_behavior": "`wpbp_ai_client_006()` filters `wp_ai_client_default_request_timeout`, which fires on every builder construction. The runtime probes two different values by constructing its own builders after each call with a late spy on the filter, so hardcoding one value or removing the filter after construction fails.",
       "requirements": [
         "Filter wp_ai_client_default_request_timeout",
-        "Create the builder with wp_ai_client_prompt()"
+        "Make the value apply to builders created after the call"
       ],
-      "test_function": "wpbp_ai_client_006( float $seconds ): WP_AI_Client_Prompt_Builder",
+      "test_function": "wpbp_ai_client_006( float $seconds ): void",
       "static_checks": {
         "required_patterns": [
           {
             "pattern": "wp_ai_client_default_request_timeout",
             "description": "Uses the timeout filter",
-            "weight": 1
-          },
-          {
-            "pattern": "wp_ai_client_prompt",
-            "description": "Creates the builder",
             "weight": 1
           },
           {
@@ -327,13 +322,13 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_006' ) ) { return false; } $seen = null; $spy = function ( $timeout ) use ( &$seen ) { $seen = $timeout; return $timeout; }; add_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); $builder = wpbp_ai_client_006( 12.5 ); remove_all_filters( 'wp_ai_client_default_request_timeout' ); return $builder instanceof WP_AI_Client_Prompt_Builder && 12.5 === (float) $seen;",
-            "description": "The filtered timeout is observed during builder construction and a builder is returned",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_006' ) ) { return false; } $probe = function ( float $expected ): bool { $seen = null; $spy = function ( $timeout ) use ( &$seen ) { $seen = $timeout; return $timeout; }; add_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); $fresh = wp_ai_client_prompt( 'Spy probe' ); remove_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); return $fresh instanceof WP_AI_Client_Prompt_Builder && (float) $seen === $expected; }; wpbp_ai_client_006( 12.5 ); $first = $probe( 12.5 ); remove_all_filters( 'wp_ai_client_default_request_timeout' ); wpbp_ai_client_006( 7.25 ); $second = $probe( 7.25 ); remove_all_filters( 'wp_ai_client_default_request_timeout' ); return $first && $second;",
+            "description": "The filtered timeout applies to builders the runtime creates after each call, for two different values",
             "weight": 1
           }
         ]
       },
-      "reference_solution": "function wpbp_ai_client_006( float $seconds ): WP_AI_Client_Prompt_Builder { add_filter( 'wp_ai_client_default_request_timeout', static fn(): float => $seconds ); return wp_ai_client_prompt( 'Ping' ); }",
+      "reference_solution": "function wpbp_ai_client_006( float $seconds ): void { add_filter( 'wp_ai_client_default_request_timeout', static fn(): float => $seconds ); }",
       "metadata": {
         "source_refs": [
           "src/wp-includes/ai-client.php",
@@ -377,108 +372,13 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_007' ) ) { return false; } $calls = 0; $spy = function ( $supported ) use ( &$calls ) { $calls++; return $supported; }; add_filter( 'wp_supports_ai', $spy, 1 ); $message = wpbp_ai_client_007(); remove_filter( 'wp_supports_ai', $spy, 1 ); return 'AI features are not supported in this environment.' === $message && $calls > 0 && true === wp_supports_ai();",
-            "description": "The disabled-environment message is produced through a real attempt and support is restored",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_007' ) ) { return false; } $saw_disabled = false; $constructions = 0; $support_spy = function ( $supported ) use ( &$saw_disabled ) { if ( false === $supported ) { $saw_disabled = true; } return $supported; }; $construct_spy = function ( $timeout ) use ( &$constructions ) { $constructions++; return $timeout; }; add_filter( 'wp_supports_ai', $support_spy, PHP_INT_MAX ); add_filter( 'wp_ai_client_default_request_timeout', $construct_spy, PHP_INT_MAX ); $message = wpbp_ai_client_007(); remove_filter( 'wp_supports_ai', $support_spy, PHP_INT_MAX ); remove_filter( 'wp_ai_client_default_request_timeout', $construct_spy, PHP_INT_MAX ); return 'AI features are not supported in this environment.' === $message && $saw_disabled && $constructions > 0 && true === wp_supports_ai();",
+            "description": "Support is observed disabled during the call, a real builder is constructed for the attempt, and support is restored",
             "weight": 1
           }
         ]
       },
       "reference_solution": "function wpbp_ai_client_007(): string { add_filter( 'wp_supports_ai', '__return_false' ); $result = wp_ai_client_prompt( 'Probe' )->generate_text(); remove_filter( 'wp_supports_ai', '__return_false' ); return is_wp_error( $result ) ? $result->get_error_message() : ''; }",
-      "metadata": {
-        "source_refs": [
-          "src/wp-includes/ai-client.php",
-          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
-        ],
-        "release_focus": "7.0"
-      }
-    },
-    {
-      "id": "e-ai-client-008",
-      "category": "ai-client",
-      "difficulty": "advanced",
-      "prompt": "Implement a function that proves the AI prompt prevention filter receives a read-only copy of the builder: prevent execution via the core filter while capturing the builder instance the filter receives, attempt text generation on a new builder, clean up the filter, and return whether the captured instance is a WP_AI_Client_Prompt_Builder distinct from the original.",
-      "expected_behavior": "`wpbp_ai_client_008()` hooks `wp_ai_client_prevent_prompt` with two accepted arguments, captures the second, and compares identities. The runtime attaches its own counting spy to the prevention filter, so a hard-coded return fails: the filter chain must actually run.",
-      "requirements": [
-        "Hook wp_ai_client_prevent_prompt accepting the builder argument",
-        "Compare the captured instance against the original builder",
-        "Remove the filter before returning"
-      ],
-      "test_function": "wpbp_ai_client_008(): bool",
-      "static_checks": {
-        "required_patterns": [
-          {
-            "pattern": "wp_ai_client_prevent_prompt",
-            "description": "Uses the prevention filter",
-            "weight": 1
-          },
-          {
-            "pattern": "add_filter",
-            "description": "Registers the filter",
-            "weight": 1
-          }
-        ]
-      },
-      "runtime_checks": {
-        "assertions": [
-          {
-            "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_008' ) ) { return false; } $calls = 0; $spy = function ( $prevent ) use ( &$calls ) { $calls++; return $prevent; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $result = wpbp_ai_client_008(); remove_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); return true === $result && $calls > 0 && false === has_filter( 'wp_ai_client_prevent_prompt' );",
-            "description": "The prevention filter chain actually runs, receives a distinct builder clone, and is cleaned up",
-            "weight": 1
-          }
-        ]
-      },
-      "reference_solution": "function wpbp_ai_client_008(): bool { $captured = null; $filter = function ( $prevent, $builder ) use ( &$captured ) { $captured = $builder; return true; }; add_filter( 'wp_ai_client_prevent_prompt', $filter, 10, 2 ); $builder = wp_ai_client_prompt( 'Probe' ); $builder->generate_text(); remove_filter( 'wp_ai_client_prevent_prompt', $filter, 10 ); return $captured instanceof WP_AI_Client_Prompt_Builder && $captured !== $builder; }",
-      "metadata": {
-        "source_refs": [
-          "src/wp-includes/ai-client.php",
-          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
-        ],
-        "release_focus": "7.0"
-      }
-    },
-    {
-      "id": "e-ai-client-009",
-      "category": "ai-client",
-      "difficulty": "advanced",
-      "prompt": "Implement a function that measures how many times the AI prompt prevention filter runs during a text-generation attempt in each of two states, returning array( 'disabled' => int, 'enabled' => int ): first with AI support forced off via the core support filter, then with support untouched. Clean up all filters you add.",
-      "expected_behavior": "When `wp_supports_ai()` is false the prevention filter is short-circuited and never applied; when support is on it runs once per generating call. The runtime keeps its own spy on the prevention filter during the call to independently confirm exactly one invocation happened.",
-      "requirements": [
-        "Count prevention-filter invocations with your own spy filter",
-        "Force support off only for the first attempt",
-        "Clean up every filter you add"
-      ],
-      "test_function": "wpbp_ai_client_009(): array",
-      "static_checks": {
-        "required_patterns": [
-          {
-            "pattern": "wp_ai_client_prevent_prompt",
-            "description": "Spies on the prevention filter",
-            "weight": 1
-          },
-          {
-            "pattern": "wp_supports_ai",
-            "description": "Toggles AI support",
-            "weight": 1
-          },
-          {
-            "pattern": "remove_filter",
-            "description": "Cleans up",
-            "weight": 1
-          }
-        ]
-      },
-      "runtime_checks": {
-        "assertions": [
-          {
-            "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_009' ) ) { return false; } $outer = 0; $spy = function ( $prevent ) use ( &$outer ) { $outer++; return true; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $counts = wpbp_ai_client_009(); remove_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); return array( 'disabled' => 0, 'enabled' => 1 ) === $counts && 1 === $outer && true === wp_supports_ai();",
-            "description": "The prevention filter is skipped while AI is disabled and runs exactly once while enabled",
-            "weight": 1
-          }
-        ]
-      },
-      "reference_solution": "function wpbp_ai_client_009(): array { $count = 0; $spy = function ( $prevent ) use ( &$count ) { $count++; return $prevent; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 20 ); add_filter( 'wp_supports_ai', '__return_false' ); wp_ai_client_prompt( 'Probe' )->generate_text(); $disabled = $count; remove_filter( 'wp_supports_ai', '__return_false' ); wp_ai_client_prompt( 'Probe' )->generate_text(); $enabled = $count - $disabled; remove_filter( 'wp_ai_client_prevent_prompt', $spy, 20 ); return array( 'disabled' => $disabled, 'enabled' => $enabled ); }",
       "metadata": {
         "source_refs": [
           "src/wp-includes/ai-client.php",
@@ -536,29 +436,19 @@
       "id": "e-ai-client-011",
       "category": "ai-client",
       "difficulty": "intermediate",
-      "prompt": "Implement a function that calls the supplied nonexistent method name on a fresh AI prompt builder and reports how the builder behaves afterwards, as array( 'error_code' => <code from a subsequent generate_text() call>, 'still_fluent' => <whether using_temperature() still returns the same builder> ).",
-      "expected_behavior": "Unknown builder methods put the builder into a sticky error state: later generating calls return the stored `prompt_builder_error` WP_Error while fluent configuration keeps returning the builder itself. `wpbp_ai_client_011()` exercises exactly that state machine.",
+      "prompt": "Implement a function that calls the supplied nonexistent method name on a fresh AI prompt builder and returns that same builder.",
+      "expected_behavior": "Unknown builder methods store a sticky `prompt_builder_error` on the builder while keeping it fluent. The runtime verifies the returned builder was really constructed (construction spy), then generates under an active prevention filter: a poisoned builder surfaces its stored `prompt_builder_error` (the sticky error is checked before the prevention gate), while a clean builder would surface `prompt_prevented`.",
       "requirements": [
         "Create the builder with wp_ai_client_prompt()",
-        "Invoke the supplied method name dynamically",
-        "Report the subsequent error code and fluency"
+        "Invoke the supplied method name dynamically on it",
+        "Return the same builder"
       ],
-      "test_function": "wpbp_ai_client_011( string $method_name ): array",
+      "test_function": "wpbp_ai_client_011( string $method_name ): WP_AI_Client_Prompt_Builder",
       "static_checks": {
         "required_patterns": [
           {
             "pattern": "wp_ai_client_prompt",
             "description": "Creates the builder",
-            "weight": 1
-          },
-          {
-            "pattern": "generate_text",
-            "description": "Probes the stored error",
-            "weight": 1
-          },
-          {
-            "pattern": "using_temperature",
-            "description": "Probes fluency after the failure",
             "weight": 1
           }
         ]
@@ -567,58 +457,13 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_011' ) ) { return false; } return array( 'error_code' => 'prompt_builder_error', 'still_fluent' => true ) === wpbp_ai_client_011( 'wpbp_made_up_method' );",
-            "description": "A bad method call leaves the builder errored for generation but still fluent",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_011' ) ) { return false; } $constructions = 0; $spy = function ( $timeout ) use ( &$constructions ) { $constructions++; return $timeout; }; add_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); $builder = wpbp_ai_client_011( 'wpbp_made_up_method' ); remove_filter( 'wp_ai_client_default_request_timeout', $spy, PHP_INT_MAX ); if ( ! $builder instanceof WP_AI_Client_Prompt_Builder || 0 === $constructions ) { return false; } add_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $error = $builder->generate_text(); remove_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); return is_wp_error( $error ) && 'prompt_builder_error' === $error->get_error_code() && $builder->using_temperature( 0.1 ) === $builder;",
+            "description": "The returned builder carries the sticky bad-method error (surfaced before the prevention gate) and stays fluent",
             "weight": 1
           }
         ]
       },
-      "reference_solution": "function wpbp_ai_client_011( string $method_name ): array { $builder = wp_ai_client_prompt( 'Probe' ); $builder->{$method_name}(); $result = $builder->generate_text(); return array( 'error_code' => is_wp_error( $result ) ? $result->get_error_code() : '', 'still_fluent' => $builder->using_temperature( 0.1 ) === $builder ); }",
-      "metadata": {
-        "source_refs": [
-          "src/wp-includes/ai-client.php",
-          "src/wp-includes/ai-client/class-wp-ai-client-prompt-builder.php"
-        ],
-        "release_focus": "7.0"
-      }
-    },
-    {
-      "id": "e-ai-client-013",
-      "category": "ai-client",
-      "difficulty": "basic",
-      "prompt": "Implement a function that creates an AI prompt builder for the prompt 'Summarize the latest posts' and attaches the existing 'wpbp/summarize' ability to it as an AI function, returning the builder.",
-      "expected_behavior": "`wpbp_ai_client_013()` uses `using_abilities()`, which converts the registered ability into a function declaration on the builder. The runtime verifies the returned builder is usable (a prevention-forced generation reports `prompt_prevented`, proving the builder carries no error from the attach).",
-      "requirements": [
-        "Create the builder with wp_ai_client_prompt()",
-        "Attach the ability with using_abilities()"
-      ],
-      "test_function": "wpbp_ai_client_013(): WP_AI_Client_Prompt_Builder",
-      "static_checks": {
-        "required_patterns": [
-          {
-            "pattern": "wp_ai_client_prompt",
-            "description": "Creates the builder",
-            "weight": 1
-          },
-          {
-            "pattern": "using_abilities",
-            "description": "Attaches the ability",
-            "weight": 1
-          }
-        ]
-      },
-      "runtime_checks": {
-        "setup": "add_action( 'wp_abilities_api_categories_init', function () { wp_register_ability_category( 'wpbp-ai-fixtures', array( 'label' => 'WPBP AI Fixtures', 'description' => 'Fixtures for AI client tests.' ) ); } ); add_action( 'wp_abilities_api_init', function () { wp_register_ability( 'wpbp/summarize', array( 'label' => 'Summarize', 'description' => 'Summarizes text.', 'category' => 'wpbp-ai-fixtures', 'input_schema' => array( 'type' => 'object', 'properties' => array( 'text' => array( 'type' => 'string' ) ), 'required' => array( 'text' ) ), 'execute_callback' => static fn( array $input ): string => substr( $input['text'], 0, 10 ), 'permission_callback' => '__return_true' ) ); } ); WP_Abilities_Registry::get_instance();",
-        "assertions": [
-          {
-            "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_013' ) ) { return false; } $builder = wpbp_ai_client_013(); if ( ! $builder instanceof WP_AI_Client_Prompt_Builder ) { return false; } add_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $result = $builder->generate_text(); remove_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); return is_wp_error( $result ) && 'prompt_prevented' === $result->get_error_code();",
-            "description": "The ability attaches without erroring the builder, proven through a prevention-forced generation",
-            "weight": 1
-          }
-        ]
-      },
-      "reference_solution": "function wpbp_ai_client_013(): WP_AI_Client_Prompt_Builder { return wp_ai_client_prompt( 'Summarize the latest posts' )->using_abilities( 'wpbp/summarize' ); }",
+      "reference_solution": "function wpbp_ai_client_011( string $method_name ): WP_AI_Client_Prompt_Builder { $builder = wp_ai_client_prompt( 'Probe' ); $builder->{$method_name}(); return $builder; }",
       "metadata": {
         "source_refs": [
           "src/wp-includes/ai-client.php",
@@ -631,14 +476,14 @@
       "id": "e-ai-client-015",
       "category": "ai-client",
       "difficulty": "intermediate",
-      "prompt": "Implement a function that proves a prevented support check leaves the AI prompt builder reusable: run a text-generation support check while prevention is active via the core filter, then remove the filter and return whether the check reported unsupported and the same builder still chains fluent configuration (using_temperature() returns the builder itself).",
-      "expected_behavior": "Prevention makes support checks return false without storing an error on the builder, unlike generating calls. `wpbp_ai_client_015()` verifies both halves. The runtime spies on the prevention filter to confirm the check actually engaged it.",
+      "prompt": "Implement a function that runs a text-generation support check on a fresh AI prompt builder while prevention is active via the core prevention filter, removes the filter, and returns the builder only when the check reported unsupported (null otherwise).",
+      "expected_behavior": "Prevention makes support checks return false without storing an error on the builder, unlike generating calls. `wpbp_ai_client_015()` returns the builder that ran the prevented check; the runtime proves it is unpoisoned by generating under prevention and expecting `prompt_prevented` (a stored error would surface first as `prompt_builder_error`), and verifies the model's filter is gone.",
       "requirements": [
         "Prevent with the wp_ai_client_prevent_prompt filter",
         "Run is_supported_for_text_generation() under prevention",
-        "Verify fluency on the same builder after removing the filter"
+        "Return the builder that ran the check, or null when it reported supported"
       ],
-      "test_function": "wpbp_ai_client_015(): bool",
+      "test_function": "wpbp_ai_client_015(): ?WP_AI_Client_Prompt_Builder",
       "static_checks": {
         "required_patterns": [
           {
@@ -652,8 +497,8 @@
             "weight": 1
           },
           {
-            "pattern": "using_temperature",
-            "description": "Probes fluency afterwards",
+            "pattern": "remove_filter",
+            "description": "Cleans up the prevention filter",
             "weight": 1
           }
         ],
@@ -669,13 +514,13 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_ai_client_015' ) ) { return false; } $calls = 0; $spy = function ( $prevent ) use ( &$calls ) { $calls++; return $prevent; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $result = wpbp_ai_client_015(); remove_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); return true === $result && $calls > 0;",
-            "description": "The prevented support check reports false and the builder stays clean and fluent",
+            "code": "if ( ! function_exists( 'wpbp_ai_client_015' ) ) { return false; } $calls = 0; $spy = function ( $prevent ) use ( &$calls ) { $calls++; return $prevent; }; add_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); $builder = wpbp_ai_client_015(); remove_filter( 'wp_ai_client_prevent_prompt', $spy, 1 ); if ( ! $builder instanceof WP_AI_Client_Prompt_Builder || 0 === $calls || false !== has_filter( 'wp_ai_client_prevent_prompt' ) ) { return false; } add_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $error = $builder->generate_text(); remove_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); return is_wp_error( $error ) && 'prompt_prevented' === $error->get_error_code();",
+            "description": "The returned builder ran a real prevented support check and carries no stored error: prevented generation reports prompt_prevented, not a sticky builder error",
             "weight": 1
           }
         ]
       },
-      "reference_solution": "function wpbp_ai_client_015(): bool { add_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $builder = wp_ai_client_prompt( 'Probe' ); $unsupported = false === $builder->is_supported_for_text_generation(); remove_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); return $unsupported && $builder->using_temperature( 0.2 ) === $builder; }",
+      "reference_solution": "function wpbp_ai_client_015(): ?WP_AI_Client_Prompt_Builder { add_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); $builder = wp_ai_client_prompt( 'Probe' ); $unsupported = false === $builder->is_supported_for_text_generation(); remove_filter( 'wp_ai_client_prevent_prompt', '__return_true' ); return $unsupported ? $builder : null; }",
       "metadata": {
         "source_refs": [
           "src/wp-includes/ai-client.php",

--- a/datasets/suites/wp-core-v1/execution/connectors-api.json
+++ b/datasets/suites/wp-core-v1/execution/connectors-api.json
@@ -219,60 +219,9 @@
             "description": "The connector registers with the auto-generated setting name and default plugin callback",
             "weight": 1
           }
-        ],
-        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $registry->is_registered( 'wpbp_crm' ) ) { $registry->unregister( 'wpbp_crm' ); }"
-      },
-      "reference_solution": "add_action( 'wp_connectors_init', function ( WP_Connector_Registry $registry ) { $registry->register( 'wpbp_crm', array( 'name' => 'WPBP CRM', 'type' => 'crm', 'authentication' => array( 'method' => 'api_key' ) ) ); } );",
-      "metadata": {
-        "source_refs": [
-          "src/wp-includes/connectors.php",
-          "src/wp-includes/class-wp-connector-registry.php"
-        ],
-        "release_focus": "7.0"
-      }
-    },
-    {
-      "id": "e-connectors-api-005",
-      "category": "connectors-api",
-      "difficulty": "basic",
-      "prompt": "Register a connector with the ID 'wpbp_webhook' through the Connectors API extension action: name 'WPBP Webhook', type 'automation', no authentication, and the plugin file 'wpbp-webhook/wpbp-webhook.php'.",
-      "expected_behavior": "With `authentication => array( 'method' => 'none' )` the registry stores no key-related fields at all. The runtime verifies the stored authentication array is exactly `array( 'method' => 'none' )` and the plugin file is kept.",
-      "requirements": [
-        "Register from the wp_connectors_init action",
-        "Use the 'none' authentication method",
-        "Include the plugin file"
-      ],
-      "static_checks": {
-        "required_patterns": [
-          {
-            "pattern": "wp_connectors_init",
-            "description": "Uses the extension action",
-            "weight": 1
-          },
-          {
-            "pattern": "none",
-            "description": "Declares no authentication",
-            "weight": 1
-          },
-          {
-            "pattern": "wpbp-webhook/wpbp-webhook.php",
-            "description": "Supplies the plugin file",
-            "weight": 1
-          }
         ]
       },
-      "runtime_checks": {
-        "assertions": [
-          {
-            "type": "custom_assertion",
-            "code": "$registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry ) { return false; } do_action( 'wp_connectors_init', $registry ); if ( ! wp_is_connector_registered( 'wpbp_webhook' ) ) { return false; } $connector = wp_get_connector( 'wpbp_webhook' ); return 'automation' === $connector['type'] && array( 'method' => 'none' ) === $connector['authentication'] && 'wpbp-webhook/wpbp-webhook.php' === ( $connector['plugin']['file'] ?? null );",
-            "description": "The stored authentication is exactly method none with no key fields and the plugin file is kept",
-            "weight": 1
-          }
-        ],
-        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $registry->is_registered( 'wpbp_webhook' ) ) { $registry->unregister( 'wpbp_webhook' ); }"
-      },
-      "reference_solution": "add_action( 'wp_connectors_init', function ( WP_Connector_Registry $registry ) { $registry->register( 'wpbp_webhook', array( 'name' => 'WPBP Webhook', 'type' => 'automation', 'authentication' => array( 'method' => 'none' ), 'plugin' => array( 'file' => 'wpbp-webhook/wpbp-webhook.php' ) ) ); } );",
+      "reference_solution": "add_action( 'wp_connectors_init', function ( WP_Connector_Registry $registry ) { $registry->register( 'wpbp_crm', array( 'name' => 'WPBP CRM', 'type' => 'crm', 'authentication' => array( 'method' => 'api_key' ) ) ); } );",
       "metadata": {
         "source_refs": [
           "src/wp-includes/connectors.php",
@@ -318,59 +267,9 @@
             "description": "Enumeration reflects live registry contents per type, sorted",
             "weight": 1
           }
-        ],
-        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry ) { foreach ( array( 'wpbp_zeta', 'wpbp_alpha' ) as $id ) { if ( $registry->is_registered( $id ) ) { $registry->unregister( $id ); } } }"
+        ]
       },
       "reference_solution": "function wpbp_connectors_api_006( string $type ): array { $ids = array(); foreach ( wp_get_connectors() as $id => $connector ) { if ( ( $connector['type'] ?? null ) === $type ) { $ids[] = $id; } } sort( $ids ); return $ids; }",
-      "metadata": {
-        "source_refs": [
-          "src/wp-includes/connectors.php",
-          "src/wp-includes/class-wp-connector-registry.php"
-        ],
-        "release_focus": "7.0"
-      }
-    },
-    {
-      "id": "e-connectors-api-007",
-      "category": "connectors-api",
-      "difficulty": "intermediate",
-      "prompt": "Implement a function that temporarily removes the connector with the supplied ID and immediately restores it, reporting array( 'before' => bool, 'during' => bool, 'after' => bool ) for the connector's registration state at each step. Unknown IDs must produce all-false without triggering any registry notice.",
-      "expected_behavior": "`wpbp_connectors_api_007()` gates on `wp_is_connector_registered()` before touching the registry (an ungated `unregister()` on an unknown ID triggers `_doing_it_wrong`), removes with `WP_Connector_Registry::unregister()`, and restores by re-registering the returned connector array.",
-      "requirements": [
-        "Gate with wp_is_connector_registered() before mutating",
-        "Restore the connector by re-registering the array unregister() returns"
-      ],
-      "test_function": "wpbp_connectors_api_007( string $connector_id ): array",
-      "static_checks": {
-        "required_patterns": [
-          {
-            "pattern": "wp_is_connector_registered",
-            "description": "Gates on registration state",
-            "weight": 1
-          },
-          {
-            "pattern": "unregister",
-            "description": "Removes through the registry",
-            "weight": 1
-          },
-          {
-            "pattern": "register",
-            "description": "Restores the connector",
-            "weight": 1
-          }
-        ]
-      },
-      "runtime_checks": {
-        "assertions": [
-          {
-            "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_connectors_api_007' ) ) { return false; } $result = wpbp_connectors_api_007( 'akismet' ); $ghost = wpbp_connectors_api_007( 'wpbp_ghost_connector' ); return array( 'before' => true, 'during' => false, 'after' => true ) === $result && wp_is_connector_registered( 'akismet' ) && array( 'before' => false, 'during' => false, 'after' => false ) === $ghost;",
-            "description": "Akismet round-trips through removal and restoration and unknown IDs stay silent",
-            "weight": 1
-          }
-        ]
-      },
-      "reference_solution": "function wpbp_connectors_api_007( string $connector_id ): array { if ( ! wp_is_connector_registered( $connector_id ) ) { return array( 'before' => false, 'during' => false, 'after' => false ); } $registry = WP_Connector_Registry::get_instance(); $removed = $registry->unregister( $connector_id ); $during = wp_is_connector_registered( $connector_id ); if ( is_array( $removed ) ) { $registry->register( $connector_id, $removed ); } return array( 'before' => true, 'during' => $during, 'after' => wp_is_connector_registered( $connector_id ) ); }",
       "metadata": {
         "source_refs": [
           "src/wp-includes/connectors.php",
@@ -413,8 +312,7 @@
             "description": "Registration succeeds with AI enabled and is silently rejected with AI disabled",
             "weight": 1
           }
-        ],
-        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $registry->is_registered( 'wpbp_ai_probe' ) ) { $registry->unregister( 'wpbp_ai_probe' ); }"
+        ]
       },
       "reference_solution": "function wpbp_connectors_api_008(): bool { $registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry ) { return false; } $stored = $registry->register( 'wpbp_ai_probe', array( 'name' => 'WPBP AI Probe', 'type' => 'ai_provider', 'authentication' => array( 'method' => 'api_key' ) ) ); return is_array( $stored ); }",
       "metadata": {
@@ -447,11 +345,6 @@
             "pattern": "is_active",
             "description": "Uses the plugin activity callback",
             "weight": 1
-          },
-          {
-            "pattern": "is_callable",
-            "description": "Validates the callback before invoking",
-            "weight": 1
           }
         ],
         "forbidden_patterns": [
@@ -471,8 +364,7 @@
             "description": "The callback reports real plugin activity per connector and unknown IDs return null silently",
             "weight": 1
           }
-        ],
-        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $registry->is_registered( 'wpbp_always_on' ) ) { $registry->unregister( 'wpbp_always_on' ); }"
+        ]
       },
       "reference_solution": "function wpbp_connectors_api_009( string $connector_id ): ?bool { if ( ! wp_is_connector_registered( $connector_id ) ) { return null; } $connector = wp_get_connector( $connector_id ); $callback = $connector['plugin']['is_active'] ?? null; if ( ! is_callable( $callback ) ) { return null; } return (bool) call_user_func( $callback ); }",
       "metadata": {
@@ -512,12 +404,11 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_connectors_api_010' ) ) { return false; } $before = wp_get_connector( 'akismet' ); $GLOBALS['wpbp_connectors_api_010_snapshot'] = $before; if ( ! is_array( $before ) ) { return false; } wpbp_connectors_api_010(); $after = wp_get_connector( 'akismet' ); if ( ! is_array( $after ) || 'WPBP Antispam' !== $after['name'] ) { return false; } $expected = $before; $expected['name'] = 'WPBP Antispam'; return $expected == $after;",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_010' ) ) { return false; } $before = wp_get_connector( 'akismet' ); if ( ! is_array( $before ) ) { return false; } wpbp_connectors_api_010(); $after = wp_get_connector( 'akismet' ); if ( ! is_array( $after ) || 'WPBP Antispam' !== $after['name'] ) { return false; } $expected = $before; $expected['name'] = 'WPBP Antispam'; return $expected == $after;",
             "description": "Only the name changes; every other stored field survives the round-trip",
             "weight": 1
           }
-        ],
-        "teardown": "$snapshot = $GLOBALS['wpbp_connectors_api_010_snapshot'] ?? null; unset( $GLOBALS['wpbp_connectors_api_010_snapshot'] ); $registry = WP_Connector_Registry::get_instance(); if ( is_array( $snapshot ) && $registry instanceof WP_Connector_Registry ) { if ( $registry->is_registered( 'akismet' ) ) { $registry->unregister( 'akismet' ); } $registry->register( 'akismet', $snapshot ); }"
+        ]
       },
       "reference_solution": "function wpbp_connectors_api_010(): bool { $registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry || ! $registry->is_registered( 'akismet' ) ) { return false; } $data = $registry->unregister( 'akismet' ); if ( ! is_array( $data ) ) { return false; } $data['name'] = 'WPBP Antispam'; return is_array( $registry->register( 'akismet', $data ) ); }",
       "metadata": {
@@ -542,11 +433,6 @@
       "static_checks": {
         "required_patterns": [
           {
-            "pattern": "preg_match",
-            "description": "Pre-validates the connector ID",
-            "weight": 1
-          },
-          {
             "pattern": "register",
             "description": "Registers valid IDs through the registry",
             "weight": 1
@@ -561,55 +447,9 @@
             "description": "Valid IDs register and invalid IDs are rejected before reaching the registry",
             "weight": 1
           }
-        ],
-        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $registry->is_registered( 'wpbp_valid-id' ) ) { $registry->unregister( 'wpbp_valid-id' ); }"
+        ]
       },
       "reference_solution": "function wpbp_connectors_api_011( string $connector_id ): bool { if ( ! preg_match( '/^[a-z0-9_-]+$/', $connector_id ) ) { return false; } $registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry ) { return false; } $stored = $registry->register( $connector_id, array( 'name' => 'WPBP Probe', 'type' => 'wpbp_probe', 'authentication' => array( 'method' => 'none' ) ) ); return is_array( $stored ); }",
-      "metadata": {
-        "source_refs": [
-          "src/wp-includes/connectors.php",
-          "src/wp-includes/class-wp-connector-registry.php"
-        ],
-        "release_focus": "7.0"
-      }
-    },
-    {
-      "id": "e-connectors-api-012",
-      "category": "connectors-api",
-      "difficulty": "basic",
-      "prompt": "Implement a function that returns the current number of registered connectors, using the public Connectors API.",
-      "expected_behavior": "`wpbp_connectors_api_012()` counts `wp_get_connectors()`. The runtime compares against its own count, registers an extra fixture connector, and expects the reported number to increase by exactly one, so a constant return fails.",
-      "requirements": [
-        "Use wp_get_connectors()"
-      ],
-      "test_function": "wpbp_connectors_api_012(): int",
-      "static_checks": {
-        "required_patterns": [
-          {
-            "pattern": "wp_get_connectors",
-            "description": "Counts through the public API",
-            "weight": 1
-          }
-        ],
-        "forbidden_patterns": [
-          {
-            "pattern": "WP_Connector_Registry",
-            "description": "Does not access the connector registry directly",
-            "severity": "error"
-          }
-        ]
-      },
-      "runtime_checks": {
-        "assertions": [
-          {
-            "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_connectors_api_012' ) ) { return false; } $baseline = wpbp_connectors_api_012(); if ( count( wp_get_connectors() ) !== $baseline ) { return false; } $registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry ) { return false; } $registry->register( 'wpbp_count_probe', array( 'name' => 'WPBP Count Probe', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'none' ) ) ); $grown = wpbp_connectors_api_012(); $registry->unregister( 'wpbp_count_probe' ); return $grown === $baseline + 1;",
-            "description": "The reported count tracks live registry mutations",
-            "weight": 1
-          }
-        ]
-      },
-      "reference_solution": "function wpbp_connectors_api_012(): int { return count( wp_get_connectors() ); }",
       "metadata": {
         "source_refs": [
           "src/wp-includes/connectors.php",
@@ -653,12 +493,11 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_connectors_api_013' ) ) { return false; } $valid_args = array( 'name' => 'WPBP Fresh', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'none' ) ); $exists = wpbp_connectors_api_013( 'akismet', $valid_args ); $invalid = wpbp_connectors_api_013( 'wpbp_fresh', array( 'name' => 'WPBP Fresh', 'type' => 'wpbp_probe_type' ) ); $registered = wpbp_connectors_api_013( 'wpbp_fresh', $valid_args ); return 'exists' === $exists && 'invalid' === $invalid && ! ( 'invalid' === $registered ) && 'registered' === $registered && wp_is_connector_registered( 'wpbp_fresh' );",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_013' ) ) { return false; } $valid_args = array( 'name' => 'WPBP Fresh', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'none' ) ); $exists = wpbp_connectors_api_013( 'akismet', $valid_args ); $invalid = wpbp_connectors_api_013( 'wpbp_fresh', array( 'name' => 'WPBP Fresh', 'type' => 'wpbp_probe_type' ) ); $registered = wpbp_connectors_api_013( 'wpbp_fresh', $valid_args ); return 'exists' === $exists && 'invalid' === $invalid && 'registered' === $registered && wp_is_connector_registered( 'wpbp_fresh' );",
             "description": "All three outcomes are reported correctly and no registry notice fires",
             "weight": 1
           }
-        ],
-        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $registry->is_registered( 'wpbp_fresh' ) ) { $registry->unregister( 'wpbp_fresh' ); }"
+        ]
       },
       "reference_solution": "function wpbp_connectors_api_013( string $connector_id, array $args ): string { if ( wp_is_connector_registered( $connector_id ) ) { return 'exists'; } $method = $args['authentication']['method'] ?? null; if ( ! is_array( $args['authentication'] ?? null ) || ! in_array( $method, array( 'api_key', 'none' ), true ) ) { return 'invalid'; } $registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry ) { return 'invalid'; } return is_array( $registry->register( $connector_id, $args ) ) ? 'registered' : 'invalid'; }",
       "metadata": {

--- a/datasets/suites/wp-core-v1/execution/connectors-api.json
+++ b/datasets/suites/wp-core-v1/execution/connectors-api.json
@@ -228,7 +228,11 @@
           "src/wp-includes/class-wp-connector-registry.php"
         ],
         "release_focus": "7.0"
-      }
+      },
+      "exploit_solutions": [
+        "add_action( 'wp_connectors_init', function ( WP_Connector_Registry $registry ) { $registry->register( 'wpbp_crm', array( 'name' => 'WPBP CRM', 'type' => 'crm', 'authentication' => array( 'method' => 'api_key', 'setting_name' => 'wpbp_crm_key' ) ) ); } );",
+        "add_action( 'wp_connectors_init', function ( WP_Connector_Registry $registry ) { $registry->register( 'wpbp_crm', array( 'name' => 'WPBP CRM', 'type' => 'crm', 'authentication' => array( 'method' => 'none' ) ) ); } );"
+      ]
     },
     {
       "id": "e-connectors-api-006",

--- a/datasets/suites/wp-core-v1/execution/connectors-api.json
+++ b/datasets/suites/wp-core-v1/execution/connectors-api.json
@@ -1,6 +1,6 @@
 {
   "id": "wp-core-execution-v1-connectors_api",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "metadata": {
     "name": "WordPress Core Execution Tests - Connectors API",
     "description": "Code generation tasks for WordPress Connectors API APIs",
@@ -174,6 +174,493 @@
         ]
       },
       "reference_solution": "add_action( 'wp_connectors_init', function ( WP_Connector_Registry $registry ) { $registry->register( 'wpbp_supportdesk', array( 'name' => 'WPBP Support Desk', 'description' => 'Connects WPBP to a support desk provider.', 'type' => 'support_desk', 'authentication' => array( 'method' => 'none' ), 'plugin' => array( 'file' => 'wpbp-supportdesk/wpbp-supportdesk.php', 'is_active' => '__return_true' ) ) ); } );",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/connectors.php",
+          "src/wp-includes/class-wp-connector-registry.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-connectors-api-004",
+      "category": "connectors-api",
+      "difficulty": "basic",
+      "prompt": "Register a connector with the ID 'wpbp_crm' through the Connectors API extension action: name 'WPBP CRM', type 'crm', API-key authentication with no explicit setting name.",
+      "expected_behavior": "The connector registers from a `wp_connectors_init` callback with `authentication => array( 'method' => 'api_key' )`. The runtime re-fires the action and verifies the stored connector, including the registry's auto-generated setting name `connectors_crm_wpbp_crm_api_key` and the default `plugin.is_active` callback.",
+      "requirements": [
+        "Register from the wp_connectors_init action",
+        "Use api_key authentication without a setting name"
+      ],
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_connectors_init",
+            "description": "Uses the extension action",
+            "weight": 1
+          },
+          {
+            "pattern": "api_key",
+            "description": "Declares API-key authentication",
+            "weight": 1
+          },
+          {
+            "pattern": "add_action",
+            "description": "Hooks the registration",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "$registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry ) { return false; } do_action( 'wp_connectors_init', $registry ); if ( ! wp_is_connector_registered( 'wpbp_crm' ) ) { return false; } $connector = wp_get_connector( 'wpbp_crm' ); return 'WPBP CRM' === $connector['name'] && 'crm' === $connector['type'] && 'api_key' === $connector['authentication']['method'] && 'connectors_crm_wpbp_crm_api_key' === $connector['authentication']['setting_name'] && '__return_true' === $connector['plugin']['is_active'];",
+            "description": "The connector registers with the auto-generated setting name and default plugin callback",
+            "weight": 1
+          }
+        ],
+        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $registry->is_registered( 'wpbp_crm' ) ) { $registry->unregister( 'wpbp_crm' ); }"
+      },
+      "reference_solution": "add_action( 'wp_connectors_init', function ( WP_Connector_Registry $registry ) { $registry->register( 'wpbp_crm', array( 'name' => 'WPBP CRM', 'type' => 'crm', 'authentication' => array( 'method' => 'api_key' ) ) ); } );",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/connectors.php",
+          "src/wp-includes/class-wp-connector-registry.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-connectors-api-005",
+      "category": "connectors-api",
+      "difficulty": "basic",
+      "prompt": "Register a connector with the ID 'wpbp_webhook' through the Connectors API extension action: name 'WPBP Webhook', type 'automation', no authentication, and the plugin file 'wpbp-webhook/wpbp-webhook.php'.",
+      "expected_behavior": "With `authentication => array( 'method' => 'none' )` the registry stores no key-related fields at all. The runtime verifies the stored authentication array is exactly `array( 'method' => 'none' )` and the plugin file is kept.",
+      "requirements": [
+        "Register from the wp_connectors_init action",
+        "Use the 'none' authentication method",
+        "Include the plugin file"
+      ],
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_connectors_init",
+            "description": "Uses the extension action",
+            "weight": 1
+          },
+          {
+            "pattern": "none",
+            "description": "Declares no authentication",
+            "weight": 1
+          },
+          {
+            "pattern": "wpbp-webhook/wpbp-webhook.php",
+            "description": "Supplies the plugin file",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "$registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry ) { return false; } do_action( 'wp_connectors_init', $registry ); if ( ! wp_is_connector_registered( 'wpbp_webhook' ) ) { return false; } $connector = wp_get_connector( 'wpbp_webhook' ); return 'automation' === $connector['type'] && array( 'method' => 'none' ) === $connector['authentication'] && 'wpbp-webhook/wpbp-webhook.php' === ( $connector['plugin']['file'] ?? null );",
+            "description": "The stored authentication is exactly method none with no key fields and the plugin file is kept",
+            "weight": 1
+          }
+        ],
+        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $registry->is_registered( 'wpbp_webhook' ) ) { $registry->unregister( 'wpbp_webhook' ); }"
+      },
+      "reference_solution": "add_action( 'wp_connectors_init', function ( WP_Connector_Registry $registry ) { $registry->register( 'wpbp_webhook', array( 'name' => 'WPBP Webhook', 'type' => 'automation', 'authentication' => array( 'method' => 'none' ), 'plugin' => array( 'file' => 'wpbp-webhook/wpbp-webhook.php' ) ) ); } );",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/connectors.php",
+          "src/wp-includes/class-wp-connector-registry.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-connectors-api-006",
+      "category": "connectors-api",
+      "difficulty": "intermediate",
+      "prompt": "Implement a function that returns the sorted IDs of every registered connector of the supplied type, using the public Connectors API.",
+      "expected_behavior": "`wpbp_connectors_api_006()` enumerates `wp_get_connectors()` and filters on each connector's `type`. The runtime registers two fixture connectors of a private type and probes three different types, so no constant return passes.",
+      "requirements": [
+        "Use wp_get_connectors() to enumerate",
+        "Filter by connector type",
+        "Return the IDs sorted alphabetically"
+      ],
+      "test_function": "wpbp_connectors_api_006( string $type ): array",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_get_connectors",
+            "description": "Enumerates through the public API",
+            "weight": 1
+          }
+        ],
+        "forbidden_patterns": [
+          {
+            "pattern": "WP_Connector_Registry",
+            "description": "Does not access the connector registry directly",
+            "severity": "error"
+          }
+        ]
+      },
+      "runtime_checks": {
+        "setup": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry ) { $registry->register( 'wpbp_zeta', array( 'name' => 'WPBP Zeta', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'none' ) ) ); $registry->register( 'wpbp_alpha', array( 'name' => 'WPBP Alpha', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'none' ) ) ); }",
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_006' ) ) { return false; } return array( 'wpbp_alpha', 'wpbp_zeta' ) === wpbp_connectors_api_006( 'wpbp_probe_type' ) && array( 'akismet' ) === wpbp_connectors_api_006( 'spam_filtering' ) && array() === wpbp_connectors_api_006( 'wpbp_absent_type' );",
+            "description": "Enumeration reflects live registry contents per type, sorted",
+            "weight": 1
+          }
+        ],
+        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry ) { foreach ( array( 'wpbp_zeta', 'wpbp_alpha' ) as $id ) { if ( $registry->is_registered( $id ) ) { $registry->unregister( $id ); } } }"
+      },
+      "reference_solution": "function wpbp_connectors_api_006( string $type ): array { $ids = array(); foreach ( wp_get_connectors() as $id => $connector ) { if ( ( $connector['type'] ?? null ) === $type ) { $ids[] = $id; } } sort( $ids ); return $ids; }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/connectors.php",
+          "src/wp-includes/class-wp-connector-registry.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-connectors-api-007",
+      "category": "connectors-api",
+      "difficulty": "intermediate",
+      "prompt": "Implement a function that temporarily removes the connector with the supplied ID and immediately restores it, reporting array( 'before' => bool, 'during' => bool, 'after' => bool ) for the connector's registration state at each step. Unknown IDs must produce all-false without triggering any registry notice.",
+      "expected_behavior": "`wpbp_connectors_api_007()` gates on `wp_is_connector_registered()` before touching the registry (an ungated `unregister()` on an unknown ID triggers `_doing_it_wrong`), removes with `WP_Connector_Registry::unregister()`, and restores by re-registering the returned connector array.",
+      "requirements": [
+        "Gate with wp_is_connector_registered() before mutating",
+        "Restore the connector by re-registering the array unregister() returns"
+      ],
+      "test_function": "wpbp_connectors_api_007( string $connector_id ): array",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_is_connector_registered",
+            "description": "Gates on registration state",
+            "weight": 1
+          },
+          {
+            "pattern": "unregister",
+            "description": "Removes through the registry",
+            "weight": 1
+          },
+          {
+            "pattern": "register",
+            "description": "Restores the connector",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_007' ) ) { return false; } $result = wpbp_connectors_api_007( 'akismet' ); $ghost = wpbp_connectors_api_007( 'wpbp_ghost_connector' ); return array( 'before' => true, 'during' => false, 'after' => true ) === $result && wp_is_connector_registered( 'akismet' ) && array( 'before' => false, 'during' => false, 'after' => false ) === $ghost;",
+            "description": "Akismet round-trips through removal and restoration and unknown IDs stay silent",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_connectors_api_007( string $connector_id ): array { if ( ! wp_is_connector_registered( $connector_id ) ) { return array( 'before' => false, 'during' => false, 'after' => false ); } $registry = WP_Connector_Registry::get_instance(); $removed = $registry->unregister( $connector_id ); $during = wp_is_connector_registered( $connector_id ); if ( is_array( $removed ) ) { $registry->register( $connector_id, $removed ); } return array( 'before' => true, 'during' => $during, 'after' => wp_is_connector_registered( $connector_id ) ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/connectors.php",
+          "src/wp-includes/class-wp-connector-registry.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-connectors-api-008",
+      "category": "connectors-api",
+      "difficulty": "advanced",
+      "prompt": "Implement a function that attempts to register an 'ai_provider' connector with the ID 'wpbp_ai_probe' (name 'WPBP AI Probe', API-key authentication) and returns whether the registry accepted it.",
+      "expected_behavior": "Registering an `ai_provider` connector silently returns null when `wp_supports_ai()` is false. The runtime calls the function with AI enabled (expects registration) and again with AI force-disabled through the `wp_supports_ai` filter (expects rejection), so the function must reflect real registry behavior.",
+      "requirements": [
+        "Register through WP_Connector_Registry",
+        "Use the 'ai_provider' type with api_key authentication",
+        "Report acceptance from the registry's return value or registration state"
+      ],
+      "test_function": "wpbp_connectors_api_008(): bool",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "ai_provider",
+            "description": "Uses the ai_provider connector type",
+            "weight": 1
+          },
+          {
+            "pattern": "register",
+            "description": "Registers through the registry",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_008' ) ) { return false; } $enabled = wpbp_connectors_api_008(); $present = wp_is_connector_registered( 'wpbp_ai_probe' ); $registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $present ) { $registry->unregister( 'wpbp_ai_probe' ); } add_filter( 'wp_supports_ai', '__return_false' ); $disabled = wpbp_connectors_api_008(); $absent = ! wp_is_connector_registered( 'wpbp_ai_probe' ); remove_filter( 'wp_supports_ai', '__return_false' ); return true === $enabled && $present && false === $disabled && $absent;",
+            "description": "Registration succeeds with AI enabled and is silently rejected with AI disabled",
+            "weight": 1
+          }
+        ],
+        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $registry->is_registered( 'wpbp_ai_probe' ) ) { $registry->unregister( 'wpbp_ai_probe' ); }"
+      },
+      "reference_solution": "function wpbp_connectors_api_008(): bool { $registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry ) { return false; } $stored = $registry->register( 'wpbp_ai_probe', array( 'name' => 'WPBP AI Probe', 'type' => 'ai_provider', 'authentication' => array( 'method' => 'api_key' ) ) ); return is_array( $stored ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/connectors.php",
+          "src/wp-includes/class-wp-connector-registry.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-connectors-api-009",
+      "category": "connectors-api",
+      "difficulty": "basic",
+      "prompt": "Implement a function that reports whether the plugin backing the supplied connector is currently active, by invoking the connector's own plugin is_active callback. Return null when the connector is not registered, without triggering any registry notice.",
+      "expected_behavior": "`wpbp_connectors_api_009()` gates with `wp_is_connector_registered()`, reads `plugin.is_active` from the connector data, and invokes it. The runtime probes akismet (inactive in this environment), a fixture with the default always-active callback, and an unknown ID.",
+      "requirements": [
+        "Gate with wp_is_connector_registered()",
+        "Invoke the connector's plugin is_active callback"
+      ],
+      "test_function": "wpbp_connectors_api_009( string $connector_id ): ?bool",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_is_connector_registered",
+            "description": "Gates on registration state",
+            "weight": 1
+          },
+          {
+            "pattern": "is_active",
+            "description": "Uses the plugin activity callback",
+            "weight": 1
+          },
+          {
+            "pattern": "is_callable",
+            "description": "Validates the callback before invoking",
+            "weight": 1
+          }
+        ],
+        "forbidden_patterns": [
+          {
+            "pattern": "WP_Connector_Registry",
+            "description": "Does not access the connector registry directly",
+            "severity": "error"
+          }
+        ]
+      },
+      "runtime_checks": {
+        "setup": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry ) { $registry->register( 'wpbp_always_on', array( 'name' => 'WPBP Always On', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'none' ) ) ); }",
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_009' ) ) { return false; } return false === wpbp_connectors_api_009( 'akismet' ) && true === wpbp_connectors_api_009( 'wpbp_always_on' ) && null === wpbp_connectors_api_009( 'wpbp_ghost_connector' );",
+            "description": "The callback reports real plugin activity per connector and unknown IDs return null silently",
+            "weight": 1
+          }
+        ],
+        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $registry->is_registered( 'wpbp_always_on' ) ) { $registry->unregister( 'wpbp_always_on' ); }"
+      },
+      "reference_solution": "function wpbp_connectors_api_009( string $connector_id ): ?bool { if ( ! wp_is_connector_registered( $connector_id ) ) { return null; } $connector = wp_get_connector( $connector_id ); $callback = $connector['plugin']['is_active'] ?? null; if ( ! is_callable( $callback ) ) { return null; } return (bool) call_user_func( $callback ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/connectors.php",
+          "src/wp-includes/class-wp-connector-registry.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-connectors-api-010",
+      "category": "connectors-api",
+      "difficulty": "intermediate",
+      "prompt": "Implement a function that renames the built-in 'akismet' connector to 'WPBP Antispam' while preserving every other field, using the Connectors API's supported override approach: unregister, modify the returned data, and re-register.",
+      "expected_behavior": "`wpbp_connectors_api_010()` follows the documented override recipe. The runtime snapshots the connector before the call and verifies afterward that only the name changed and every other stored field is identical.",
+      "requirements": [
+        "Unregister akismet and capture the returned connector data",
+        "Re-register the modified data under the same ID"
+      ],
+      "test_function": "wpbp_connectors_api_010(): bool",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "unregister",
+            "description": "Removes the built-in connector",
+            "weight": 1
+          },
+          {
+            "pattern": "register",
+            "description": "Re-registers the modified data",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_010' ) ) { return false; } $before = wp_get_connector( 'akismet' ); $GLOBALS['wpbp_connectors_api_010_snapshot'] = $before; if ( ! is_array( $before ) ) { return false; } wpbp_connectors_api_010(); $after = wp_get_connector( 'akismet' ); if ( ! is_array( $after ) || 'WPBP Antispam' !== $after['name'] ) { return false; } $expected = $before; $expected['name'] = 'WPBP Antispam'; return $expected == $after;",
+            "description": "Only the name changes; every other stored field survives the round-trip",
+            "weight": 1
+          }
+        ],
+        "teardown": "$snapshot = $GLOBALS['wpbp_connectors_api_010_snapshot'] ?? null; unset( $GLOBALS['wpbp_connectors_api_010_snapshot'] ); $registry = WP_Connector_Registry::get_instance(); if ( is_array( $snapshot ) && $registry instanceof WP_Connector_Registry ) { if ( $registry->is_registered( 'akismet' ) ) { $registry->unregister( 'akismet' ); } $registry->register( 'akismet', $snapshot ); }"
+      },
+      "reference_solution": "function wpbp_connectors_api_010(): bool { $registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry || ! $registry->is_registered( 'akismet' ) ) { return false; } $data = $registry->unregister( 'akismet' ); if ( ! is_array( $data ) ) { return false; } $data['name'] = 'WPBP Antispam'; return is_array( $registry->register( 'akismet', $data ) ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/connectors.php",
+          "src/wp-includes/class-wp-connector-registry.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-connectors-api-011",
+      "category": "connectors-api",
+      "difficulty": "advanced",
+      "prompt": "Implement a function that registers a connector under the supplied ID with name 'WPBP Probe', type 'wpbp_probe', and no authentication, but only when the ID is valid for the Connectors API (lowercase alphanumerics, hyphens, and underscores). Return true when registered, false otherwise. Invalid IDs must not reach the registry.",
+      "expected_behavior": "`wpbp_connectors_api_011()` validates the ID against the registry's `^[a-z0-9_-]+$` contract before calling `register()`, because an invalid ID passed to the registry triggers `_doing_it_wrong`. The runtime probes a valid ID and two invalid ones; any registry notice fails the test.",
+      "requirements": [
+        "Validate the ID with the Connectors API pattern before registering",
+        "Never call the registry with an invalid ID"
+      ],
+      "test_function": "wpbp_connectors_api_011( string $connector_id ): bool",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "preg_match",
+            "description": "Pre-validates the connector ID",
+            "weight": 1
+          },
+          {
+            "pattern": "register",
+            "description": "Registers valid IDs through the registry",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_011' ) ) { return false; } return true === wpbp_connectors_api_011( 'wpbp_valid-id' ) && wp_is_connector_registered( 'wpbp_valid-id' ) && false === wpbp_connectors_api_011( 'WPBP Invalid' ) && false === wpbp_connectors_api_011( 'wpbp/slash' ) && ! wp_is_connector_registered( 'WPBP Invalid' ) && ! wp_is_connector_registered( 'wpbp/slash' );",
+            "description": "Valid IDs register and invalid IDs are rejected before reaching the registry",
+            "weight": 1
+          }
+        ],
+        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $registry->is_registered( 'wpbp_valid-id' ) ) { $registry->unregister( 'wpbp_valid-id' ); }"
+      },
+      "reference_solution": "function wpbp_connectors_api_011( string $connector_id ): bool { if ( ! preg_match( '/^[a-z0-9_-]+$/', $connector_id ) ) { return false; } $registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry ) { return false; } $stored = $registry->register( $connector_id, array( 'name' => 'WPBP Probe', 'type' => 'wpbp_probe', 'authentication' => array( 'method' => 'none' ) ) ); return is_array( $stored ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/connectors.php",
+          "src/wp-includes/class-wp-connector-registry.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-connectors-api-012",
+      "category": "connectors-api",
+      "difficulty": "basic",
+      "prompt": "Implement a function that returns the current number of registered connectors, using the public Connectors API.",
+      "expected_behavior": "`wpbp_connectors_api_012()` counts `wp_get_connectors()`. The runtime compares against its own count, registers an extra fixture connector, and expects the reported number to increase by exactly one, so a constant return fails.",
+      "requirements": [
+        "Use wp_get_connectors()"
+      ],
+      "test_function": "wpbp_connectors_api_012(): int",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_get_connectors",
+            "description": "Counts through the public API",
+            "weight": 1
+          }
+        ],
+        "forbidden_patterns": [
+          {
+            "pattern": "WP_Connector_Registry",
+            "description": "Does not access the connector registry directly",
+            "severity": "error"
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_012' ) ) { return false; } $baseline = wpbp_connectors_api_012(); if ( count( wp_get_connectors() ) !== $baseline ) { return false; } $registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry ) { return false; } $registry->register( 'wpbp_count_probe', array( 'name' => 'WPBP Count Probe', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'none' ) ) ); $grown = wpbp_connectors_api_012(); $registry->unregister( 'wpbp_count_probe' ); return $grown === $baseline + 1;",
+            "description": "The reported count tracks live registry mutations",
+            "weight": 1
+          }
+        ]
+      },
+      "reference_solution": "function wpbp_connectors_api_012(): int { return count( wp_get_connectors() ); }",
+      "metadata": {
+        "source_refs": [
+          "src/wp-includes/connectors.php",
+          "src/wp-includes/class-wp-connector-registry.php"
+        ],
+        "release_focus": "7.0"
+      }
+    },
+    {
+      "id": "e-connectors-api-013",
+      "category": "connectors-api",
+      "difficulty": "intermediate",
+      "prompt": "Implement a function that registers connector data under the supplied ID only when it is safe to do so, returning 'exists' when the ID is already registered, 'invalid' when the args lack a valid authentication array (method 'api_key' or 'none'), and 'registered' on success. It must never trigger a registry notice.",
+      "expected_behavior": "`wpbp_connectors_api_013()` checks `wp_is_connector_registered()` first and validates the authentication shape before calling the registry, because the registry rejects bad args with `_doing_it_wrong`. The runtime probes all three paths.",
+      "requirements": [
+        "Return 'exists' for already-registered IDs without touching the registry",
+        "Validate the authentication array before registering",
+        "Register through WP_Connector_Registry only when the args are valid"
+      ],
+      "test_function": "wpbp_connectors_api_013( string $connector_id, array $args ): string",
+      "static_checks": {
+        "required_patterns": [
+          {
+            "pattern": "wp_is_connector_registered",
+            "description": "Gates on registration state",
+            "weight": 1
+          },
+          {
+            "pattern": "authentication",
+            "description": "Validates the authentication shape",
+            "weight": 1
+          },
+          {
+            "pattern": "register",
+            "description": "Registers valid data",
+            "weight": 1
+          }
+        ]
+      },
+      "runtime_checks": {
+        "assertions": [
+          {
+            "type": "custom_assertion",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_013' ) ) { return false; } $valid_args = array( 'name' => 'WPBP Fresh', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'none' ) ); $exists = wpbp_connectors_api_013( 'akismet', $valid_args ); $invalid = wpbp_connectors_api_013( 'wpbp_fresh', array( 'name' => 'WPBP Fresh', 'type' => 'wpbp_probe_type' ) ); $registered = wpbp_connectors_api_013( 'wpbp_fresh', $valid_args ); return 'exists' === $exists && 'invalid' === $invalid && ! ( 'invalid' === $registered ) && 'registered' === $registered && wp_is_connector_registered( 'wpbp_fresh' );",
+            "description": "All three outcomes are reported correctly and no registry notice fires",
+            "weight": 1
+          }
+        ],
+        "teardown": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $registry->is_registered( 'wpbp_fresh' ) ) { $registry->unregister( 'wpbp_fresh' ); }"
+      },
+      "reference_solution": "function wpbp_connectors_api_013( string $connector_id, array $args ): string { if ( wp_is_connector_registered( $connector_id ) ) { return 'exists'; } $method = $args['authentication']['method'] ?? null; if ( ! is_array( $args['authentication'] ?? null ) || ! in_array( $method, array( 'api_key', 'none' ), true ) ) { return 'invalid'; } $registry = WP_Connector_Registry::get_instance(); if ( ! $registry instanceof WP_Connector_Registry ) { return 'invalid'; } return is_array( $registry->register( $connector_id, $args ) ) ? 'registered' : 'invalid'; }",
       "metadata": {
         "source_refs": [
           "src/wp-includes/connectors.php",

--- a/datasets/suites/wp-core-v1/execution/connectors-api.json
+++ b/datasets/suites/wp-core-v1/execution/connectors-api.json
@@ -428,7 +428,7 @@
       "category": "connectors-api",
       "difficulty": "advanced",
       "prompt": "Implement a function that registers a connector under the supplied ID with name 'WPBP Probe', type 'wpbp_probe', and no authentication, but only when the ID is valid for the Connectors API (lowercase alphanumerics, hyphens, and underscores). Return true when registered, false otherwise. Invalid IDs must not reach the registry.",
-      "expected_behavior": "`wpbp_connectors_api_011()` validates the ID against the registry's `^[a-z0-9_-]+$` contract before calling `register()`, because an invalid ID passed to the registry triggers `_doing_it_wrong`. The runtime probes a valid ID (and inspects the stored data) plus four invalid IDs covering uppercase, spaces, slashes, and periods; any registry notice fails the test.",
+      "expected_behavior": "`wpbp_connectors_api_011()` validates the ID against the registry's `^[a-z0-9_-]+$` contract before calling `register()`, because an invalid ID passed to the registry triggers `_doing_it_wrong` (which fails the test outright). The runtime probes a valid ID (and inspects the stored data) plus four invalid IDs isolating spaces, uppercase, slashes, and periods.",
       "requirements": [
         "Validate the ID with the Connectors API pattern before registering",
         "Never call the registry with an invalid ID"
@@ -447,8 +447,8 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_connectors_api_011' ) ) { return false; } if ( true !== wpbp_connectors_api_011( 'wpbp_valid-id' ) || ! wp_is_connector_registered( 'wpbp_valid-id' ) ) { return false; } $stored = wp_get_connector( 'wpbp_valid-id' ); if ( 'WPBP Probe' !== $stored['name'] || 'wpbp_probe' !== $stored['type'] || array( 'method' => 'none' ) !== $stored['authentication'] ) { return false; } return false === wpbp_connectors_api_011( 'WPBP Invalid' ) && false === wpbp_connectors_api_011( 'WPBP_Invalid' ) && false === wpbp_connectors_api_011( 'wpbp/slash' ) && false === wpbp_connectors_api_011( 'wpbp.dot' ) && ! wp_is_connector_registered( 'WPBP Invalid' ) && ! wp_is_connector_registered( 'WPBP_Invalid' ) && ! wp_is_connector_registered( 'wpbp/slash' ) && ! wp_is_connector_registered( 'wpbp.dot' );",
-            "description": "Valid IDs register with the requested data; uppercase, slash, and dot IDs are all rejected before the registry",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_011' ) ) { return false; } if ( true !== wpbp_connectors_api_011( 'wpbp_valid-id' ) || ! wp_is_connector_registered( 'wpbp_valid-id' ) ) { return false; } $stored = wp_get_connector( 'wpbp_valid-id' ); if ( 'WPBP Probe' !== $stored['name'] || 'wpbp_probe' !== $stored['type'] || array( 'method' => 'none' ) !== $stored['authentication'] ) { return false; } return false === wpbp_connectors_api_011( 'wpbp invalid' ) && false === wpbp_connectors_api_011( 'WPBP_Invalid' ) && false === wpbp_connectors_api_011( 'wpbp/slash' ) && false === wpbp_connectors_api_011( 'wpbp.dot' );",
+            "description": "Valid IDs register with the requested data; space, uppercase, slash, and period IDs are all rejected before the registry",
             "weight": 1
           }
         ]
@@ -467,7 +467,7 @@
       "category": "connectors-api",
       "difficulty": "intermediate",
       "prompt": "Implement a function that registers connector data under the supplied ID only when it is safe to do so, returning 'exists' when the ID is already registered, 'invalid' when the args lack a valid authentication array (method 'api_key' or 'none'), and 'registered' on success. Already-registered IDs and missing or invalid authentication must never reach the registry.",
-      "expected_behavior": "`wpbp_connectors_api_013()` checks `wp_is_connector_registered()` first and validates the authentication shape before calling the registry, because the registry rejects bad args with `_doing_it_wrong`. The runtime probes all three paths with otherwise-valid connector data.",
+      "expected_behavior": "`wpbp_connectors_api_013()` checks `wp_is_connector_registered()` first and validates the authentication shape before calling the registry, because the registry rejects bad args with `_doing_it_wrong`. The runtime probes all three outcomes, including two invalid authentication shapes, with otherwise-valid connector data.",
       "requirements": [
         "Return 'exists' for already-registered IDs without touching the registry",
         "Validate the authentication array before registering",

--- a/datasets/suites/wp-core-v1/execution/connectors-api.json
+++ b/datasets/suites/wp-core-v1/execution/connectors-api.json
@@ -308,8 +308,8 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_connectors_api_008' ) ) { return false; } $enabled = wpbp_connectors_api_008(); $present = wp_is_connector_registered( 'wpbp_ai_probe' ); $registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $present ) { $registry->unregister( 'wpbp_ai_probe' ); } add_filter( 'wp_supports_ai', '__return_false' ); $disabled = wpbp_connectors_api_008(); $absent = ! wp_is_connector_registered( 'wpbp_ai_probe' ); remove_filter( 'wp_supports_ai', '__return_false' ); return true === $enabled && $present && false === $disabled && $absent;",
-            "description": "Registration succeeds with AI enabled and is silently rejected with AI disabled",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_008' ) ) { return false; } $enabled = wpbp_connectors_api_008(); $present = wp_is_connector_registered( 'wpbp_ai_probe' ); $stored = $present ? wp_get_connector( 'wpbp_ai_probe' ) : null; $registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry && $present ) { $registry->unregister( 'wpbp_ai_probe' ); } add_filter( 'wp_supports_ai', '__return_false' ); $disabled = wpbp_connectors_api_008(); $absent = ! wp_is_connector_registered( 'wpbp_ai_probe' ); remove_filter( 'wp_supports_ai', '__return_false' ); return true === $enabled && $present && is_array( $stored ) && 'WPBP AI Probe' === $stored['name'] && 'ai_provider' === $stored['type'] && 'api_key' === $stored['authentication']['method'] && false === $disabled && $absent;",
+            "description": "The ai_provider connector registers with the requested data when AI is on and is silently rejected when AI is off",
             "weight": 1
           }
         ]
@@ -328,7 +328,7 @@
       "category": "connectors-api",
       "difficulty": "basic",
       "prompt": "Implement a function that reports whether the plugin backing the supplied connector is currently active, by invoking the connector's own plugin is_active callback. Return null when the connector is not registered, without triggering any registry notice.",
-      "expected_behavior": "`wpbp_connectors_api_009()` gates with `wp_is_connector_registered()`, reads `plugin.is_active` from the connector data, and invokes it. The runtime probes akismet (inactive in this environment), a fixture with the default always-active callback, and an unknown ID.",
+      "expected_behavior": "`wpbp_connectors_api_009()` gates with `wp_is_connector_registered()`, reads `plugin.is_active` from the connector data, and invokes it. The runtime registers a fixture whose callback reads a mutable global and probes both toggle states on the same connector (forcing real invocation), plus akismet (inactive here) and an unknown ID.",
       "requirements": [
         "Gate with wp_is_connector_registered()",
         "Invoke the connector's plugin is_active callback"
@@ -356,12 +356,12 @@
         ]
       },
       "runtime_checks": {
-        "setup": "$registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry ) { $registry->register( 'wpbp_always_on', array( 'name' => 'WPBP Always On', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'none' ) ) ); }",
+        "setup": "$GLOBALS['wpbp_toggle_active'] = true; $registry = WP_Connector_Registry::get_instance(); if ( $registry instanceof WP_Connector_Registry ) { $registry->register( 'wpbp_toggle', array( 'name' => 'WPBP Toggle', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'none' ), 'plugin' => array( 'file' => 'wpbp-toggle/wpbp-toggle.php', 'is_active' => static function () { return ! empty( $GLOBALS['wpbp_toggle_active'] ); } ) ) ); }",
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_connectors_api_009' ) ) { return false; } return false === wpbp_connectors_api_009( 'akismet' ) && true === wpbp_connectors_api_009( 'wpbp_always_on' ) && null === wpbp_connectors_api_009( 'wpbp_ghost_connector' );",
-            "description": "The callback reports real plugin activity per connector and unknown IDs return null silently",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_009' ) ) { return false; } $GLOBALS['wpbp_toggle_active'] = true; $on = wpbp_connectors_api_009( 'wpbp_toggle' ); $GLOBALS['wpbp_toggle_active'] = false; $off = wpbp_connectors_api_009( 'wpbp_toggle' ); unset( $GLOBALS['wpbp_toggle_active'] ); return true === $on && false === $off && false === wpbp_connectors_api_009( 'akismet' ) && null === wpbp_connectors_api_009( 'wpbp_ghost_connector' );",
+            "description": "The connector's own is_active callback is actually invoked: the same connector reports both states as the fixture toggles",
             "weight": 1
           }
         ]
@@ -424,7 +424,7 @@
       "category": "connectors-api",
       "difficulty": "advanced",
       "prompt": "Implement a function that registers a connector under the supplied ID with name 'WPBP Probe', type 'wpbp_probe', and no authentication, but only when the ID is valid for the Connectors API (lowercase alphanumerics, hyphens, and underscores). Return true when registered, false otherwise. Invalid IDs must not reach the registry.",
-      "expected_behavior": "`wpbp_connectors_api_011()` validates the ID against the registry's `^[a-z0-9_-]+$` contract before calling `register()`, because an invalid ID passed to the registry triggers `_doing_it_wrong`. The runtime probes a valid ID and two invalid ones; any registry notice fails the test.",
+      "expected_behavior": "`wpbp_connectors_api_011()` validates the ID against the registry's `^[a-z0-9_-]+$` contract before calling `register()`, because an invalid ID passed to the registry triggers `_doing_it_wrong`. The runtime probes a valid ID (and inspects the stored data) plus four invalid IDs covering uppercase, spaces, slashes, and periods; any registry notice fails the test.",
       "requirements": [
         "Validate the ID with the Connectors API pattern before registering",
         "Never call the registry with an invalid ID"
@@ -443,8 +443,8 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_connectors_api_011' ) ) { return false; } return true === wpbp_connectors_api_011( 'wpbp_valid-id' ) && wp_is_connector_registered( 'wpbp_valid-id' ) && false === wpbp_connectors_api_011( 'WPBP Invalid' ) && false === wpbp_connectors_api_011( 'wpbp/slash' ) && ! wp_is_connector_registered( 'WPBP Invalid' ) && ! wp_is_connector_registered( 'wpbp/slash' );",
-            "description": "Valid IDs register and invalid IDs are rejected before reaching the registry",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_011' ) ) { return false; } if ( true !== wpbp_connectors_api_011( 'wpbp_valid-id' ) || ! wp_is_connector_registered( 'wpbp_valid-id' ) ) { return false; } $stored = wp_get_connector( 'wpbp_valid-id' ); if ( 'WPBP Probe' !== $stored['name'] || 'wpbp_probe' !== $stored['type'] || array( 'method' => 'none' ) !== $stored['authentication'] ) { return false; } return false === wpbp_connectors_api_011( 'WPBP Invalid' ) && false === wpbp_connectors_api_011( 'WPBP_Invalid' ) && false === wpbp_connectors_api_011( 'wpbp/slash' ) && false === wpbp_connectors_api_011( 'wpbp.dot' ) && ! wp_is_connector_registered( 'WPBP Invalid' ) && ! wp_is_connector_registered( 'WPBP_Invalid' ) && ! wp_is_connector_registered( 'wpbp/slash' ) && ! wp_is_connector_registered( 'wpbp.dot' );",
+            "description": "Valid IDs register with the requested data; uppercase, slash, and dot IDs are all rejected before the registry",
             "weight": 1
           }
         ]
@@ -462,8 +462,8 @@
       "id": "e-connectors-api-013",
       "category": "connectors-api",
       "difficulty": "intermediate",
-      "prompt": "Implement a function that registers connector data under the supplied ID only when it is safe to do so, returning 'exists' when the ID is already registered, 'invalid' when the args lack a valid authentication array (method 'api_key' or 'none'), and 'registered' on success. It must never trigger a registry notice.",
-      "expected_behavior": "`wpbp_connectors_api_013()` checks `wp_is_connector_registered()` first and validates the authentication shape before calling the registry, because the registry rejects bad args with `_doing_it_wrong`. The runtime probes all three paths.",
+      "prompt": "Implement a function that registers connector data under the supplied ID only when it is safe to do so, returning 'exists' when the ID is already registered, 'invalid' when the args lack a valid authentication array (method 'api_key' or 'none'), and 'registered' on success. Already-registered IDs and missing or invalid authentication must never reach the registry.",
+      "expected_behavior": "`wpbp_connectors_api_013()` checks `wp_is_connector_registered()` first and validates the authentication shape before calling the registry, because the registry rejects bad args with `_doing_it_wrong`. The runtime probes all three paths with otherwise-valid connector data.",
       "requirements": [
         "Return 'exists' for already-registered IDs without touching the registry",
         "Validate the authentication array before registering",
@@ -493,7 +493,7 @@
         "assertions": [
           {
             "type": "custom_assertion",
-            "code": "if ( ! function_exists( 'wpbp_connectors_api_013' ) ) { return false; } $valid_args = array( 'name' => 'WPBP Fresh', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'none' ) ); $exists = wpbp_connectors_api_013( 'akismet', $valid_args ); $invalid = wpbp_connectors_api_013( 'wpbp_fresh', array( 'name' => 'WPBP Fresh', 'type' => 'wpbp_probe_type' ) ); $registered = wpbp_connectors_api_013( 'wpbp_fresh', $valid_args ); return 'exists' === $exists && 'invalid' === $invalid && 'registered' === $registered && wp_is_connector_registered( 'wpbp_fresh' );",
+            "code": "if ( ! function_exists( 'wpbp_connectors_api_013' ) ) { return false; } $valid_args = array( 'name' => 'WPBP Fresh', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'none' ) ); $exists = wpbp_connectors_api_013( 'akismet', $valid_args ); $invalid = wpbp_connectors_api_013( 'wpbp_fresh', array( 'name' => 'WPBP Fresh', 'type' => 'wpbp_probe_type' ) ); $bad_method = wpbp_connectors_api_013( 'wpbp_fresh', array( 'name' => 'WPBP Fresh', 'type' => 'wpbp_probe_type', 'authentication' => array( 'method' => 'oauth' ) ) ); $registered = wpbp_connectors_api_013( 'wpbp_fresh', $valid_args ); return 'exists' === $exists && 'invalid' === $invalid && 'invalid' === $bad_method && 'registered' === $registered && wp_is_connector_registered( 'wpbp_fresh' );",
             "description": "All three outcomes are reported correctly and no registry notice fires",
             "weight": 1
           }

--- a/python/tests/test_execution_dataset.py
+++ b/python/tests/test_execution_dataset.py
@@ -38,8 +38,8 @@ def _execution_tests() -> list[dict[str, Any]]:
     return tests
 
 
-def test_execution_suite_has_exactly_164_tests() -> None:
-    assert len(_execution_tests()) == 164
+def test_execution_suite_has_exactly_194_tests() -> None:
+    assert len(_execution_tests()) == 194
 
 
 def test_execution_test_ids_are_unique() -> None:

--- a/python/tests/test_execution_dataset.py
+++ b/python/tests/test_execution_dataset.py
@@ -38,8 +38,8 @@ def _execution_tests() -> list[dict[str, Any]]:
     return tests
 
 
-def test_execution_suite_has_exactly_194_tests() -> None:
-    assert len(_execution_tests()) == 194
+def test_execution_suite_has_exactly_188_tests() -> None:
+    assert len(_execution_tests()) == 188
 
 
 def test_execution_test_ids_are_unique() -> None:

--- a/python/tests/test_execution_dataset.py
+++ b/python/tests/test_execution_dataset.py
@@ -38,8 +38,8 @@ def _execution_tests() -> list[dict[str, Any]]:
     return tests
 
 
-def test_execution_suite_has_exactly_188_tests() -> None:
-    assert len(_execution_tests()) == 188
+def test_execution_suite_has_exactly_185_tests() -> None:
+    assert len(_execution_tests()) == 185
 
 
 def test_execution_test_ids_are_unique() -> None:


### PR DESCRIPTION
## What

Expands the three weakest-covered WP 7.0 API categories — exactly where the first full benchmark runs showed models failing hardest (ai-client 1/5, abilities-api 1/4 execution pass):

| Category | Before | Added | After |
|---|---|---|---|
| abilities-api | 4 | +9 | 13 |
| connectors-api | 3 | +7 | 10 |
| ai-client | 5 | +5 | 10 |

Execution suite: 150 → **171** tests (count pin updated).

## What the new tests measure

- **abilities-api 005-014** (010 dropped in review): the `execute()` pipeline stage by stage — permission denial, input/output schema validation, callback exceptions — each surfacing its distinct error code; registration with schema defaults on the correct init action; unregistration state; category meta; enumeration by category; the built-in core abilities; the `wp_register_ability_args` filter.
- **connectors-api 004-013** (005/007/012 dropped): registration arg shapes (auto-generated setting names, method-`none` field stripping); the unregister/re-register override recipe; `ai_provider` gating via `wp_supports_ai`; and a theme the first runs showed models failing: knowing which inputs the registry rejects with `_doing_it_wrong` and guarding before calling it.
- **ai-client 006-015** (008/009/012/013/014 dropped): the default-timeout filter; prevention-filter anatomy; sticky builder error state; support-check non-poisoning; the ability function resolver's allow-list codes. Everything is provider-free by construction (prevention filters or support toggles short-circuit before any network call).

## Authoring method

Written against the actual WP 7.0 sources in the runtime image (exact signatures, hook timings, error codes — e.g. abilities registration is only valid during `wp_abilities_api_init`, callbacks receive input only when an `input_schema` exists, the connector registry initializes during `init` so tests re-fire `wp_connectors_init`).

Every assertion follows the #43 hardening patterns: filter/action spies prove the mechanism actually ran, multi-fixture contracts give different expected outputs per probe, and state is inspected independently of the function's return. Two findings from this batch worth stealing for future tests:

- A builder-construction spy on `wp_ai_client_default_request_timeout` proves a real prompt builder was created (it fires on every construction).
- The sticky builder error is checked **before** the prevention gate in `__call`, so generating under an active prevention filter cleanly distinguishes a poisoned builder (`prompt_builder_error`) from a clean one (`prompt_prevented`).

## Review process

Started at 30 tests; two adversarial review rounds (independent reviewer prompted to find plausible-cheat paths) plus a 4-angle cleanup pass cut it to **21**: six re-measured contracts existing tests already grade, and three had knowledge that is simply unobservable from assertion code (any clean builder passed). Dropped rather than shipped weak — duplicate signal inflates category scores without discriminating, and the goal is scores that go **down**. Dropped ids leave gaps (005/007/012 in connectors, 008/009/012/013/014 in ai-client, 010 in abilities); ids are stable identifiers so the survivors keep their numbers.

## Verification (live WP 7.0 runtime)

- `--check-reference-solution`: **1.0 across the batch** (re-run after every review round)
- `--check-exploits`: **0 exploitable**; the hook-based tests (no `test_function`) are not coverable by the generic battery — they are the target case for #45's authored `exploit_solutions`, and I'll add authored cheats to them once #45 lands
- `pytest` 152, `ruff`, `mypy` green; all snippets PHP-linted

## Coordination with #45

Both PRs move the execution count pin (this one 150→171, #45 150→164). Whichever lands second rebases; final total 185. Happy to rebase this one after #45 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)