### PR TITLE
fix: adopt ruff 0.16 defaults and pin the version CI installs

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -30,10 +30,14 @@ dependencies = [
 
 [project.optional-dependencies]
 http = ["uvicorn>=0.30", "fastapi>=0.111"]
-dev = ["pytest>=8.3", "ruff>=0.6", "mypy>=1.10", "types-PyYAML>=6.0"]
+dev = ["pytest>=8.3", "ruff>=0.16,<0.17", "mypy>=1.10", "types-PyYAML>=6.0"]
 
 [project.scripts]
 wp-bench = "wp_bench.cli:app"
 
 [tool.hatch.metadata]
 allow-direct-references = true
+
+[tool.ruff.lint.flake8-bugbear]
+# typer declares CLI options via function-call defaults by design.
+extend-immutable-calls = ["typer.Option"]

--- a/python/tests/test_artifacts.py
+++ b/python/tests/test_artifacts.py
@@ -5,8 +5,8 @@ import json
 from pathlib import Path
 
 import pytest
-
 from conftest import fake_generation
+
 from wp_bench.artifacts import (
     MAX_ARTIFACT_FILES,
     Artifact,

--- a/python/tests/test_continue_on_error.py
+++ b/python/tests/test_continue_on_error.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from conftest import fake_generation
 
 from wp_bench.config import (
     DatasetConfig,
@@ -17,8 +18,6 @@ from wp_bench.config import (
 from wp_bench.core import BenchmarkRunner
 from wp_bench.datasets import ExecutionTest, KnowledgeTest
 from wp_bench.environment import ExecutionResult
-
-from conftest import fake_generation
 
 
 def _execution_test(test_id: str) -> ExecutionTest:

--- a/python/tests/test_dataset_filtering.py
+++ b/python/tests/test_dataset_filtering.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import pytest
 
 from wp_bench.cli import _normalize_test_ids
-from wp_bench.datasets import KnowledgeTest, ensure_test_ids_match_type, filter_tests_by_ids
+from wp_bench.datasets import (
+    KnowledgeTest,
+    ensure_test_ids_match_type,
+    filter_tests_by_ids,
+)
 
 
 def _knowledge_test(test_id: str) -> KnowledgeTest:

--- a/python/tests/test_dataset_metadata.py
+++ b/python/tests/test_dataset_metadata.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from conftest import fake_generation
 
 from wp_bench.config import (
     DatasetConfig,
@@ -23,8 +24,6 @@ from wp_bench.datasets import (
     load_tests,
 )
 from wp_bench.environment import ExecutionResult
-
-from conftest import fake_generation
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 

--- a/python/tests/test_environment.py
+++ b/python/tests/test_environment.py
@@ -2,17 +2,16 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Optional
 
 from wp_bench.config import GraderConfig
 from wp_bench.environment import WordPressEnvironment
 
 
 def test_execute_code_uses_internal_runtime_verifier_for_wp_env() -> None:
-    calls: list[tuple[list[str], Optional[str]]] = []
+    calls: list[tuple[list[str], str | None]] = []
     environment = WordPressEnvironment(GraderConfig(kind="docker", wp_env_dir=Path("runtime")))
 
-    def fake_exec(command: list[str], *, stdin: Optional[str] = None) -> tuple[str, str, int, bool]:
+    def fake_exec(command: list[str], *, stdin: str | None = None) -> tuple[str, str, int, bool]:
         calls.append((command, stdin))
         assert stdin is not None
         payload = json.loads(stdin)

--- a/python/tests/test_execution_dataset.py
+++ b/python/tests/test_execution_dataset.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import orjson
 
-
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 EXECUTION_DIR = PROJECT_ROOT / "datasets" / "suites" / "wp-core-v1" / "execution"
 

--- a/python/tests/test_execution_isolation.py
+++ b/python/tests/test_execution_isolation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from conftest import fake_generation
 
 from wp_bench.config import (
     DatasetConfig,
@@ -17,8 +18,6 @@ from wp_bench.config import (
 from wp_bench.core import BenchmarkRunner, MultiModelRunner
 from wp_bench.datasets import ExecutionTest
 from wp_bench.environment import ExecutionResult
-
-from conftest import fake_generation
 
 
 def _execution_test(test_id: str) -> ExecutionTest:

--- a/python/tests/test_knowledge.py
+++ b/python/tests/test_knowledge.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import wp_bench.datasets as datasets_module
 from wp_bench.config import DatasetConfig
 from wp_bench.datasets import KnowledgeTest, _parse_knowledge_suite
 from wp_bench.knowledge import render_knowledge_prompt, score_knowledge_answer
-import wp_bench.datasets as datasets_module
 
 
 def test_render_knowledge_prompt_uses_choice_instructions_for_multiple_choice() -> None:

--- a/python/tests/test_model_retries.py
+++ b/python/tests/test_model_retries.py
@@ -28,12 +28,12 @@ def _timeout() -> Timeout:
 
 def _fast_config(**overrides: object) -> ModelConfig:
     """Retry config with sub-second backoff so tests stay fast."""
-    defaults: dict = dict(
-        name="gpt-4o-mini",
-        max_retries=3,
-        retry_min_seconds=0.01,
-        retry_max_seconds=0.02,
-    )
+    defaults: dict = {
+        "name": "gpt-4o-mini",
+        "max_retries": 3,
+        "retry_min_seconds": 0.01,
+        "retry_max_seconds": 0.02,
+    }
     defaults.update(overrides)
     return ModelConfig.model_validate(defaults)
 

--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -4,9 +4,9 @@ from types import SimpleNamespace
 
 from litellm.exceptions import BadRequestError
 
+import wp_bench.models as models_module
 from wp_bench.config import ModelConfig
 from wp_bench.models import ModelInterface
-import wp_bench.models as models_module
 
 
 def test_generate_retries_without_temperature_on_deprecated_error(monkeypatch) -> None:

--- a/python/tests/test_result_schema.py
+++ b/python/tests/test_result_schema.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, Set
+from typing import Any
 
 import pytest
+from conftest import fake_generation
 
 from wp_bench.config import (
     DatasetConfig,
@@ -19,8 +20,6 @@ from wp_bench.core import BenchmarkRunner, SingleModelRunner
 from wp_bench.datasets import ExecutionTest, KnowledgeTest
 from wp_bench.environment import ExecutionResult
 from wp_bench.records import RESULT_SCHEMA_VERSION
-
-from conftest import fake_generation
 
 
 def _execution_test(test_id: str = "e-one") -> ExecutionTest:
@@ -63,9 +62,9 @@ def _passing_result() -> ExecutionResult:
     return ExecutionResult(success=True, raw=raw, stdout="out", stderr="")
 
 
-def _key_paths(record: Dict[str, Any], prefix: str = "") -> Set[str]:
+def _key_paths(record: dict[str, Any], prefix: str = "") -> set[str]:
     """Flatten a record into dotted key paths for structural comparison."""
-    paths: Set[str] = set()
+    paths: set[str] = set()
     for key, value in record.items():
         path = f"{prefix}{key}"
         paths.add(path)

--- a/python/tests/test_scoring.py
+++ b/python/tests/test_scoring.py
@@ -1,7 +1,7 @@
 """Tests for runtime-primary execution scoring (SCORING_VERSION 2.0)."""
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 from wp_bench.core import BenchmarkRunner
 from wp_bench.datasets import ExecutionTest
@@ -9,8 +9,8 @@ from wp_bench.scoring import ScoreAggregator
 
 
 def _make_test(
-    static_checks: Dict[str, Any] | None = None,
-    runtime_checks: Dict[str, Any] | None = None,
+    static_checks: dict[str, Any] | None = None,
+    runtime_checks: dict[str, Any] | None = None,
 ) -> ExecutionTest:
     return ExecutionTest(
         id="e-test-001",

--- a/python/tests/test_static_analysis_runtime.py
+++ b/python/tests/test_static_analysis_runtime.py
@@ -4,7 +4,6 @@ import json
 import subprocess
 from pathlib import Path
 
-
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 

--- a/python/wp_bench/artifacts.py
+++ b/python/wp_bench/artifacts.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any
 
 from .utils import strip_code_fences
 
@@ -40,11 +40,11 @@ class Artifact:
 
     kind: str
     code: str = ""
-    files: Dict[str, str] = field(default_factory=dict)
+    files: dict[str, str] = field(default_factory=dict)
 
-    def payload_fields(self) -> Dict[str, Any]:
+    def payload_fields(self) -> dict[str, Any]:
         """Fields merged into the runtime verification payload."""
-        fields: Dict[str, Any] = {"artifact_kind": self.kind, "code": self.code}
+        fields: dict[str, Any] = {"artifact_kind": self.kind, "code": self.code}
         if self.files:
             fields["files"] = self.files
         return fields
@@ -77,7 +77,7 @@ def _parse_plugin_files(completion: str) -> Artifact:
     if not isinstance(data, dict) or not isinstance(data.get("files"), dict):
         raise ArtifactError("Plugin artifact JSON must contain a 'files' object.")
 
-    files: Dict[str, str] = {}
+    files: dict[str, str] = {}
     total_bytes = 0
     for raw_path, content in data["files"].items():
         if not isinstance(raw_path, str) or not isinstance(content, str):
@@ -121,7 +121,7 @@ def _validate_relative_path(raw_path: str) -> str:
     return path
 
 
-def _find_main_plugin_file(files: Dict[str, str]) -> Optional[str]:
+def _find_main_plugin_file(files: dict[str, str]) -> str | None:
     """Locate the top-level PHP file carrying the plugin header."""
     for path, content in files.items():
         if "/" in path or not path.endswith(".php"):

--- a/python/wp_bench/cli.py
+++ b/python/wp_bench/cli.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Optional
 
 import typer
 from dotenv import load_dotenv
@@ -25,12 +24,12 @@ def main() -> None:
     """WP-Bench command line interface."""
 
 
-def _normalize_test_ids(values: Optional[List[str]]) -> List[str]:
+def _normalize_test_ids(values: list[str] | None) -> list[str]:
     """Normalize repeated and comma-separated --test-id values."""
     if not values:
         return []
 
-    normalized: List[str] = []
+    normalized: list[str] = []
     seen: set[str] = set()
     for value in values:
         for test_id in value.split(","):
@@ -96,12 +95,12 @@ def _print_dry_run_counts(
 
 @app.command()
 def run(
-    config: Optional[Path] = typer.Option(None, help="Path to wp-bench YAML config"),
-    suite: Optional[str] = typer.Option(None, help="Override suite name"),
-    model_name: Optional[str] = typer.Option(None, help="Override model name (single model mode)"),
-    limit: Optional[int] = typer.Option(None, help="Limit number of tests (seeded stratified selection)"),
-    seed: Optional[int] = typer.Option(None, help="Seed for deterministic limited-test selection"),
-    test_type: Optional[str] = typer.Option(None, help="Run only 'knowledge' or 'execution' tests"),
+    config: Path | None = typer.Option(None, help="Path to wp-bench YAML config"),
+    suite: str | None = typer.Option(None, help="Override suite name"),
+    model_name: str | None = typer.Option(None, help="Override model name (single model mode)"),
+    limit: int | None = typer.Option(None, help="Limit number of tests (seeded stratified selection)"),
+    seed: int | None = typer.Option(None, help="Seed for deterministic limited-test selection"),
+    test_type: str | None = typer.Option(None, help="Run only 'knowledge' or 'execution' tests"),
     dry_run: bool = typer.Option(False, help="Load and filter tests without calling models"),
     check_reference_solution: bool = typer.Option(
         False,
@@ -111,7 +110,7 @@ def run(
         False,
         help="Adversarial assertion audit: flag execution tests a zero-effort cheat can pass",
     ),
-    test_id: Optional[List[str]] = typer.Option(
+    test_id: list[str] | None = typer.Option(
         None,
         "--test-id",
         help="Run only the given dataset test ID. May be repeated or comma-separated.",
@@ -121,7 +120,7 @@ def run(
     harness_config = HarnessConfig.from_file(config) if config else HarnessConfig()
     if suite:
         harness_config.run.suite = suite
-        harness_config.dataset.name = suite if "/" not in suite else suite
+        harness_config.dataset.name = suite
     if limit is not None:
         harness_config.run.limit = limit
     if seed is not None:

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -7,7 +7,7 @@ at load time instead of becoming silent no-ops: config means behavior.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Literal, Optional
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -30,9 +30,9 @@ class StrictModel(BaseModel):
 class DatasetConfig(StrictModel):
     source: Literal["huggingface", "local"] = "huggingface"
     name: str = "WordPress/wp-bench-v1"
-    revision: Optional[str] = None
+    revision: str | None = None
     split: str = "test"
-    cache_dir: Optional[Path] = None
+    cache_dir: Path | None = None
 
 
 class ModelConfig(StrictModel):
@@ -41,8 +41,8 @@ class ModelConfig(StrictModel):
     kind: Literal["openai", "anthropic", "ollama", "openai-compatible"] = "openai"
     name: str = "gpt-4o-mini"
     temperature: float = 0.0
-    max_tokens: Optional[int] = None
-    top_p: Optional[float] = None
+    max_tokens: int | None = None
+    top_p: float | None = None
     request_timeout: float = Field(default=300.0, gt=0)
     #: Additional attempts after the first call fails with a transient
     #: provider error (rate limit, timeout, connection, 5xx).
@@ -61,13 +61,13 @@ class ModelConfig(StrictModel):
 
     @field_validator("top_p")
     @classmethod
-    def _validate_top_p(cls, value: Optional[float]) -> Optional[float]:
+    def _validate_top_p(cls, value: float | None) -> float | None:
         if value is not None and not 0 <= value <= 1:
             raise ValueError("top_p must be between 0 and 1")
         return value
 
     @model_validator(mode="after")
-    def _validate_retry_policy(self) -> "ModelConfig":
+    def _validate_retry_policy(self) -> ModelConfig:
         if self.max_retries < 0:
             raise ValueError("model.max_retries must be >= 0")
         if self.retry_min_seconds <= 0 or self.retry_max_seconds <= 0:
@@ -86,7 +86,7 @@ class GraderConfig(StrictModel):
     base_url: str = "http://localhost:8888"
     timeout_seconds: int = Field(default=90, gt=0)
     setup_timeout_seconds: int = Field(default=600, gt=0)
-    wp_env_dir: Optional[Path] = None
+    wp_env_dir: Path | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -109,9 +109,9 @@ ExecutionIsolation = Literal["reset_per_test", "none"]
 
 class RunConfig(StrictModel):
     suite: str = "wp-core-v1"
-    test_type: Optional[Literal["knowledge", "execution"]] = None
-    limit: Optional[int] = Field(default=None, gt=0)
-    test_ids: List[str] = Field(default_factory=list)
+    test_type: Literal["knowledge", "execution"] | None = None
+    limit: int | None = Field(default=None, gt=0)
+    test_ids: list[str] = Field(default_factory=list)
     #: Reserved for deterministic subset selection; wired by seeded
     #: stratified test limiting. Not yet consumed elsewhere.
     seed: int = 1337
@@ -139,7 +139,7 @@ class RunConfig(StrictModel):
     skip_static: bool = False
 
     @model_validator(mode="after")
-    def _validate_execution_concurrency(self) -> "RunConfig":
+    def _validate_execution_concurrency(self) -> RunConfig:
         """Reject concurrency the isolation strategy cannot support.
 
         ``reset_per_test`` isolation resets one shared WordPress runtime
@@ -160,7 +160,7 @@ class RunConfig(StrictModel):
         return self
 
     @model_validator(mode="after")
-    def _validate_skips(self) -> "RunConfig":
+    def _validate_skips(self) -> RunConfig:
         if self.skip_runtime and self.skip_static:
             raise ValueError(
                 "run.skip_runtime and run.skip_static cannot both be true: "
@@ -169,7 +169,7 @@ class RunConfig(StrictModel):
         return self
 
     @model_validator(mode="after")
-    def _validate_exclusive_modes(self) -> "RunConfig":
+    def _validate_exclusive_modes(self) -> RunConfig:
         if self.check_exploits and self.check_reference_solution:
             raise ValueError(
                 "run.check_exploits and run.check_reference_solution are "
@@ -182,18 +182,18 @@ class RunConfig(StrictModel):
 
 class OutputConfig(StrictModel):
     path: Path = Path("results.json")
-    jsonl_path: Optional[Path] = Field(default=Path("results.jsonl"))
+    jsonl_path: Path | None = Field(default=Path("results.jsonl"))
 
 
 class HarnessConfig(StrictModel):
     dataset: DatasetConfig = DatasetConfig()
-    model: Optional[ModelConfig] = None  # Single model (legacy)
-    models: Optional[List[ModelConfig]] = None  # Multiple models
+    model: ModelConfig | None = None  # Single model (legacy)
+    models: list[ModelConfig] | None = None  # Multiple models
     grader: GraderConfig = GraderConfig()
     run: RunConfig = RunConfig()
     output: OutputConfig = OutputConfig()
 
-    def get_models(self) -> List[ModelConfig]:
+    def get_models(self) -> list[ModelConfig]:
         """Return list of models to evaluate."""
         if self.models:
             return self.models
@@ -202,14 +202,14 @@ class HarnessConfig(StrictModel):
         return [ModelConfig()]  # Default
 
     @classmethod
-    def from_file(cls, path: Path) -> "HarnessConfig":
+    def from_file(cls, path: Path) -> HarnessConfig:
         import yaml
 
         with path.open("r", encoding="utf-8") as handle:
             data = yaml.safe_load(handle) or {}
         base_dir = path.parent
 
-        def resolve_path(value: Optional[str | Path]) -> Optional[str]:
+        def resolve_path(value: str | Path | None) -> str | None:
             if value is None:
                 return None
             candidate = Path(value)

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 import threading
 import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import orjson
 
+from .artifacts import (
+    Artifact,
+    ArtifactError,
+    parse_artifact,
+    render_artifact_instructions,
+)
 from .config import HarnessConfig, ModelConfig
 from .datasets import (
     ExecutionTest,
@@ -19,6 +25,7 @@ from .datasets import (
     load_tests,
 )
 from .environment import WordPressEnvironment
+from .exploits import exploit_candidates, gateway_name
 from .knowledge import render_knowledge_prompt, score_knowledge_answer
 from .models import ModelInterface
 from .output import (
@@ -33,8 +40,6 @@ from .output import (
     print_test_error,
     print_test_warning,
 )
-from .artifacts import Artifact, ArtifactError, parse_artifact, render_artifact_instructions
-from .exploits import exploit_candidates, gateway_name
 from .records import (
     RESULT_SCHEMA_VERSION,
     build_error_record,
@@ -63,11 +68,11 @@ class TestError(Exception):
 
 def _timestamped_path(path: Path) -> Path:
     """Add timestamp to filename: results.json -> results_20231216_143052.json"""
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     return path.parent / f"{path.stem}_{timestamp}{path.suffix}"
 
 
-def _limit_tests(tests: List[Any], config: HarnessConfig) -> List[Any]:
+def _limit_tests(tests: list[Any], config: HarnessConfig) -> list[Any]:
     """Select tests for this run (seeded stratified selection when limited)."""
     return select_tests(
         tests,
@@ -77,7 +82,7 @@ def _limit_tests(tests: List[Any], config: HarnessConfig) -> List[Any]:
     )
 
 
-def _build_verification_spec(test: Any, config: HarnessConfig) -> Dict[str, Any]:
+def _build_verification_spec(test: Any, config: HarnessConfig) -> dict[str, Any]:
     """Build the verifier payload honoring run.skip_runtime/skip_static.
 
     A skipped dimension is sent as empty checks so the runtime does not
@@ -91,7 +96,7 @@ def _build_verification_spec(test: Any, config: HarnessConfig) -> Dict[str, Any]
     """
     static_checks = {} if config.run.skip_static else test.static_checks
     if config.run.skip_runtime:
-        runtime_checks: Dict[str, Any] = {}
+        runtime_checks: dict[str, Any] = {}
     else:
         runtime_checks = dict(test.runtime_checks)
         if test.test_function:
@@ -115,7 +120,7 @@ def _build_verification_spec(test: Any, config: HarnessConfig) -> Dict[str, Any]
     }
 
 
-def _artifact_failure_scores() -> Dict[str, Any]:
+def _artifact_failure_scores() -> dict[str, Any]:
     """Scores for a completion that failed artifact parsing/validation."""
     return {
         "knowledge": None,
@@ -143,7 +148,7 @@ class _ArtifactFailureResult:
         }
 
 
-def _model_call_info(generation: Any) -> Dict[str, Any]:
+def _model_call_info(generation: Any) -> dict[str, Any]:
     """Call-reliability metadata recorded alongside each test result."""
     return {
         "retry_count": generation.retry_count,
@@ -157,8 +162,8 @@ def _error_record(
     error: TestError,
     *,
     mode: str,
-    model_config: Optional[ModelConfig],
-) -> Dict[str, Any]:
+    model_config: ModelConfig | None,
+) -> dict[str, Any]:
     """Canonical record for a test the runner caught erroring.
 
     Unwraps the TestError (type/message/test-type) so each ``on_error``
@@ -229,7 +234,7 @@ class _ContinueOnErrorPolicy:
 
 def _run_isolated_execution_loop(
     *,
-    tests_to_run: List[Any],
+    tests_to_run: list[Any],
     config: HarnessConfig,
     environment: WordPressEnvironment,
     process_test: Any,
@@ -293,13 +298,13 @@ def _run_isolated_execution_loop(
 
 def _run_concurrent_loop(
     *,
-    tests_to_run: List[Any],
+    tests_to_run: list[Any],
     max_workers: int,
     progress_label: str,
     process_test: Any,
     on_result: Any,
     on_error: Any,
-    policy: "_ContinueOnErrorPolicy",
+    policy: _ContinueOnErrorPolicy,
 ) -> None:
     """Run tests concurrently, honoring the continue-on-error policy.
 
@@ -331,7 +336,7 @@ def _run_concurrent_loop(
 
 def _run_knowledge_loop(
     *,
-    tests_to_run: List[Any],
+    tests_to_run: list[Any],
     config: HarnessConfig,
     process_test: Any,
     on_result: Any,
@@ -371,10 +376,10 @@ class BenchmarkRunner:
         self.environment = WordPressEnvironment(config.grader)
         self.aggregator = ScoreAggregator()
         self.usage_aggregator = UsageAggregator()
-        self.records: List[Dict[str, Any]] = []
+        self.records: list[dict[str, Any]] = []
         self._lock = threading.Lock()
 
-    def run(self) -> Dict[str, Any]:
+    def run(self) -> dict[str, Any]:
         """Execute the full benchmark pipeline.
 
         Loads tests, sets up the WordPress environment, runs knowledge and execution
@@ -457,7 +462,7 @@ class BenchmarkRunner:
                 raise SystemExit(1)
         return payload
 
-    def _run_knowledge_tests(self, tests: List[KnowledgeTest]) -> None:
+    def _run_knowledge_tests(self, tests: list[KnowledgeTest]) -> None:
         """Run knowledge tests in parallel.
 
         Prompts the model with WordPress knowledge questions and scores responses
@@ -471,7 +476,7 @@ class BenchmarkRunner:
         """
         tests_to_run = _limit_tests(tests, self.config)
 
-        def process_test(test: KnowledgeTest) -> Dict[str, Any]:
+        def process_test(test: KnowledgeTest) -> dict[str, Any]:
             try:
                 prompt = self._render_knowledge_prompt(test)
                 generation = self.model.generate_with_metadata(prompt)
@@ -491,14 +496,14 @@ class BenchmarkRunner:
             except Exception as e:
                 raise TestError(test.id, "knowledge", e) from e
 
-        def on_result(result: Dict[str, Any]) -> None:
+        def on_result(result: dict[str, Any]) -> None:
             with self._lock:
                 if result.get("error") is None:
                     self.aggregator.add_knowledge(result["scores"]["knowledge"])
                 self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
 
-        def on_error(test: KnowledgeTest, error: TestError) -> Dict[str, Any]:
+        def on_error(test: KnowledgeTest, error: TestError) -> dict[str, Any]:
             return _error_record(test, error, mode="model", model_config=self.config.model)
 
         _run_knowledge_loop(
@@ -509,7 +514,7 @@ class BenchmarkRunner:
             on_error=on_error,
         )
 
-    def _run_execution_tests(self, tests: List[ExecutionTest]) -> None:
+    def _run_execution_tests(self, tests: list[ExecutionTest]) -> None:
         """Run code generation execution tests in parallel.
 
         Prompts the model to generate PHP code, executes it in the WordPress
@@ -523,7 +528,7 @@ class BenchmarkRunner:
         """
         tests_to_run = _limit_tests(tests, self.config)
 
-        def process_test(test: ExecutionTest) -> Dict[str, Any]:
+        def process_test(test: ExecutionTest) -> dict[str, Any]:
             """Process a single execution test."""
             try:
                 prompt = self._render_execution_prompt(test)
@@ -567,14 +572,14 @@ class BenchmarkRunner:
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
 
-        def on_result(result: Dict[str, Any]) -> None:
+        def on_result(result: dict[str, Any]) -> None:
             with self._lock:
                 if result.get("error") is None:
                     self.aggregator.add_execution(result["scores"])
                 self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
 
-        def on_error(test: ExecutionTest, error: TestError) -> Dict[str, Any]:
+        def on_error(test: ExecutionTest, error: TestError) -> dict[str, Any]:
             return _error_record(test, error, mode="model", model_config=self.config.model)
 
         _run_isolated_execution_loop(
@@ -587,11 +592,11 @@ class BenchmarkRunner:
             progress_label="Execution",
         )
 
-    def _run_reference_solution_tests(self, tests: List[ExecutionTest]) -> None:
+    def _run_reference_solution_tests(self, tests: list[ExecutionTest]) -> None:
         """Run execution tests using their reference_solution as candidate code."""
         tests_to_run = _limit_tests(tests, self.config)
 
-        def process_test(test: ExecutionTest) -> Dict[str, Any]:
+        def process_test(test: ExecutionTest) -> dict[str, Any]:
             try:
                 artifact_kind = getattr(test, "artifact_kind", "php_snippet")
                 if artifact_kind == "wp_plugin_files":
@@ -623,14 +628,14 @@ class BenchmarkRunner:
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
 
-        def on_result(result: Dict[str, Any]) -> None:
+        def on_result(result: dict[str, Any]) -> None:
             with self._lock:
                 if result.get("error") is None:
                     self.aggregator.add_execution(result["scores"])
                 self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
 
-        def on_error(test: ExecutionTest, error: TestError) -> Dict[str, Any]:
+        def on_error(test: ExecutionTest, error: TestError) -> dict[str, Any]:
             return _error_record(test, error, mode="reference_solution", model_config=None)
 
         _run_isolated_execution_loop(
@@ -643,7 +648,7 @@ class BenchmarkRunner:
             progress_label="Reference solutions",
         )
 
-    def _run_exploit_audit(self, tests: Dict[str, List[Any]]) -> Dict[str, Any]:
+    def _run_exploit_audit(self, tests: dict[str, list[Any]]) -> dict[str, Any]:
         """Adversarial assertion audit: prove zero-effort cheats fail.
 
         For every execution test, run each exploit candidate (generic
@@ -694,7 +699,7 @@ class BenchmarkRunner:
             raise SystemExit(1)
         return payload
 
-    def _run_exploit_audit_tests(self, tests: List[ExecutionTest]) -> None:
+    def _run_exploit_audit_tests(self, tests: list[ExecutionTest]) -> None:
         """Run every exploit candidate for each test; record exploitable ones.
 
         Serial and reset-before-each-candidate: candidates share a gateway
@@ -723,8 +728,8 @@ class BenchmarkRunner:
     def _first_passing_exploit(
         self,
         test: ExecutionTest,
-        candidates: List[Tuple[str, str]],
-    ) -> Optional[Tuple[str, str]]:
+        candidates: list[tuple[str, str]],
+    ) -> tuple[str, str] | None:
         """Return the first (label, code) cheat that satisfies the assertions.
 
         The verification spec is identical across a test's candidates, so it
@@ -748,7 +753,7 @@ class BenchmarkRunner:
                 return (label, code)
         return None
 
-    def _ensure_execution_only_ids(self, mode_flag: str, tests: Dict[str, List[Any]]) -> None:
+    def _ensure_execution_only_ids(self, mode_flag: str, tests: dict[str, list[Any]]) -> None:
         """Ensure explicitly selected test ids are execution tests for audit modes."""
         selected_ids = self.config.run.test_ids
         if not selected_ids:
@@ -796,12 +801,12 @@ class BenchmarkRunner:
 
     @staticmethod
     def _score_execution(
-        raw: Dict[str, Any],
+        raw: dict[str, Any],
         test: ExecutionTest,
         *,
         skip_runtime: bool = False,
         skip_static: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Score an execution test with runtime behavior as the primary signal.
 
         Scoring model (SCORING_VERSION 2.0):
@@ -896,7 +901,7 @@ class BenchmarkRunner:
         )
 
     @staticmethod
-    def _runtime_crashed(raw: Dict[str, Any]) -> bool:
+    def _runtime_crashed(raw: dict[str, Any]) -> bool:
         """Detect a hard execution failure in the runtime result.
 
         Only call this when the test defines runtime assertions. A crash shows
@@ -924,7 +929,7 @@ class BenchmarkRunner:
             for assertion in assertions
         )
 
-    def _write_outputs(self, payload: Dict[str, Any]) -> None:
+    def _write_outputs(self, payload: dict[str, Any]) -> None:
         """Write benchmark results to JSON and JSONL files.
 
         Args:
@@ -958,9 +963,9 @@ class MultiModelRunner:
         """
         self.config = config
         self.environment = WordPressEnvironment(config.grader)
-        self.results: Dict[str, Dict[str, Any]] = {}
+        self.results: dict[str, dict[str, Any]] = {}
 
-    def run(self) -> Dict[str, Any]:
+    def run(self) -> dict[str, Any]:
         """Execute benchmarks for all configured models.
 
         Sets up the WordPress environment once, then runs each model sequentially.
@@ -1045,7 +1050,7 @@ class SingleModelRunner:
         config: HarnessConfig,
         model_config: ModelConfig,
         environment: WordPressEnvironment,
-        tests: Dict[str, List[Any]],
+        tests: dict[str, list[Any]],
     ):
         """Initialize runner for a specific model.
 
@@ -1062,10 +1067,10 @@ class SingleModelRunner:
         self.tests = tests
         self.aggregator = ScoreAggregator()
         self.usage_aggregator = UsageAggregator()
-        self.records: List[Dict[str, Any]] = []
+        self.records: list[dict[str, Any]] = []
         self._lock = threading.Lock()
 
-    def run(self) -> Dict[str, Any]:
+    def run(self) -> dict[str, Any]:
         """Run all tests and return scores for this model.
 
         Returns:
@@ -1093,11 +1098,11 @@ class SingleModelRunner:
             "results": sort_records(self.records),
         }
 
-    def _run_knowledge_tests(self, tests: List[KnowledgeTest]) -> None:
+    def _run_knowledge_tests(self, tests: list[KnowledgeTest]) -> None:
         """Run knowledge tests in parallel. See BenchmarkRunner._run_knowledge_tests."""
         tests_to_run = _limit_tests(tests, self.config)
 
-        def process_test(test: KnowledgeTest) -> Dict[str, Any]:
+        def process_test(test: KnowledgeTest) -> dict[str, Any]:
             try:
                 prompt = BenchmarkRunner._render_knowledge_prompt(test)
                 generation = self.model.generate_with_metadata(prompt)
@@ -1117,14 +1122,14 @@ class SingleModelRunner:
             except Exception as e:
                 raise TestError(test.id, "knowledge", e) from e
 
-        def on_result(result: Dict[str, Any]) -> None:
+        def on_result(result: dict[str, Any]) -> None:
             with self._lock:
                 if result.get("error") is None:
                     self.aggregator.add_knowledge(result["scores"]["knowledge"])
                 self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
 
-        def on_error(test: KnowledgeTest, error: TestError) -> Dict[str, Any]:
+        def on_error(test: KnowledgeTest, error: TestError) -> dict[str, Any]:
             return _error_record(test, error, mode="model", model_config=self.model_config)
 
         _run_knowledge_loop(
@@ -1135,11 +1140,11 @@ class SingleModelRunner:
             on_error=on_error,
         )
 
-    def _run_execution_tests(self, tests: List[ExecutionTest]) -> None:
+    def _run_execution_tests(self, tests: list[ExecutionTest]) -> None:
         """Run execution tests with isolation. See BenchmarkRunner._run_execution_tests."""
         tests_to_run = _limit_tests(tests, self.config)
 
-        def process_test(test: ExecutionTest) -> Dict[str, Any]:
+        def process_test(test: ExecutionTest) -> dict[str, Any]:
             try:
                 prompt = BenchmarkRunner._render_execution_prompt(test)
                 generation = self.model.generate_with_metadata(prompt)
@@ -1182,14 +1187,14 @@ class SingleModelRunner:
             except Exception as e:
                 raise TestError(test.id, "execution", e) from e
 
-        def on_result(result: Dict[str, Any]) -> None:
+        def on_result(result: dict[str, Any]) -> None:
             with self._lock:
                 if result.get("error") is None:
                     self.aggregator.add_execution(result["scores"])
                 self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
 
-        def on_error(test: ExecutionTest, error: TestError) -> Dict[str, Any]:
+        def on_error(test: ExecutionTest, error: TestError) -> dict[str, Any]:
             return _error_record(test, error, mode="model", model_config=self.model_config)
 
         _run_isolated_execution_loop(

--- a/python/wp_bench/datasets.py
+++ b/python/wp_bench/datasets.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import orjson
 from datasets import load_dataset as hf_load_dataset  # type: ignore[attr-defined]
@@ -23,17 +23,17 @@ class ExecutionTest:
     test_type: str
     category: str
     difficulty: str
-    requirements: List[str]
-    test_function: Optional[str]
-    static_checks: Dict[str, Any]
-    runtime_checks: Dict[str, Any]
-    reference_solution: Optional[str]
-    metadata: Dict[str, Any]
+    requirements: list[str]
+    test_function: str | None
+    static_checks: dict[str, Any]
+    runtime_checks: dict[str, Any]
+    reference_solution: str | None
+    metadata: dict[str, Any]
     #: What the model must produce: 'php_snippet' (default) or
     #: 'wp_plugin_files' (JSON files map installed as a plugin).
     artifact_kind: str = "php_snippet"
     #: Reference files for wp_plugin_files reference-solution runs.
-    reference_files: Optional[Dict[str, str]] = None
+    reference_files: dict[str, str] | None = None
 
 
 @dataclass
@@ -44,14 +44,14 @@ class KnowledgeTest:
     test_type: str
     category: str
     difficulty: str
-    choices: Optional[List[Dict[str, Any]]] = None
-    correct_answer: Optional[str] = None
-    answer_type: Optional[str] = None
-    answer: Optional[str] = None
-    metadata: Optional[Dict[str, Any]] = None
+    choices: list[dict[str, Any]] | None = None
+    correct_answer: str | None = None
+    answer_type: str | None = None
+    answer: str | None = None
+    metadata: dict[str, Any] | None = None
 
 
-def load_tests(config: DatasetConfig) -> Dict[str, List[Any]]:
+def load_tests(config: DatasetConfig) -> dict[str, list[Any]]:
     """Load both execution and knowledge tests for a suite."""
     if config.source == "huggingface":
         return _load_from_huggingface(config)
@@ -59,9 +59,9 @@ def load_tests(config: DatasetConfig) -> Dict[str, List[Any]]:
 
 
 def filter_tests_by_ids(
-    tests: Dict[str, List[Any]],
-    test_ids: List[str],
-) -> Dict[str, List[Any]]:
+    tests: dict[str, list[Any]],
+    test_ids: list[str],
+) -> dict[str, list[Any]]:
     """Filter loaded tests to the requested dataset test IDs."""
     if not test_ids:
         return tests
@@ -79,9 +79,9 @@ def filter_tests_by_ids(
 
 
 def ensure_test_ids_match_type(
-    tests: Dict[str, List[Any]],
+    tests: dict[str, list[Any]],
     test_type: str | None,
-    test_ids: List[str],
+    test_ids: list[str],
 ) -> None:
     """Fail clearly when requested IDs do not match an explicit test type."""
     if not test_ids or test_type is None:
@@ -92,7 +92,7 @@ def ensure_test_ids_match_type(
         )
 
 
-def _load_from_huggingface(config: DatasetConfig) -> Dict[str, List[Any]]:
+def _load_from_huggingface(config: DatasetConfig) -> dict[str, list[Any]]:
     """Load dataset from Hugging Face Hub (Parquet format)."""
     dataset = hf_load_dataset(
         config.name,
@@ -100,8 +100,8 @@ def _load_from_huggingface(config: DatasetConfig) -> Dict[str, List[Any]]:
         split=config.split,
         cache_dir=str(config.cache_dir) if config.cache_dir else None,
     )
-    execution: List[ExecutionTest] = []
-    knowledge: List[KnowledgeTest] = []
+    execution: list[ExecutionTest] = []
+    knowledge: list[KnowledgeTest] = []
 
     for row in dataset:
         # Parse JSON-encoded fields from Parquet format
@@ -159,7 +159,7 @@ def _parse_json_field(value: Any) -> Any:
     return value
 
 
-def _merge_metadata(task_metadata: Any, suite_metadata: Any) -> Dict[str, Any]:
+def _merge_metadata(task_metadata: Any, suite_metadata: Any) -> dict[str, Any]:
     """Combine per-task and suite-level metadata without losing either.
 
     Task fields (source_refs, release_focus, version targets, ...) sit at
@@ -167,29 +167,29 @@ def _merge_metadata(task_metadata: Any, suite_metadata: Any) -> Dict[str, Any]:
     ``suite_metadata``. A task field named ``suite_metadata`` would be
     shadowed, which is acceptable and documented in the dataset README.
     """
-    merged: Dict[str, Any] = dict(task_metadata) if isinstance(task_metadata, dict) else {}
+    merged: dict[str, Any] = dict(task_metadata) if isinstance(task_metadata, dict) else {}
     merged["suite_metadata"] = suite_metadata if isinstance(suite_metadata, dict) else {}
     return merged
 
 
-def _row_metadata(row: Dict[str, Any]) -> Dict[str, Any]:
+def _row_metadata(row: dict[str, Any]) -> dict[str, Any]:
     """Parse the metadata column from a Hugging Face row."""
     parsed = _parse_json_field(row.get("metadata", "{}"))
     return parsed if isinstance(parsed, dict) else {}
 
 
-def _parse_optional_dict(value: Any) -> Optional[Dict[str, Any]]:
+def _parse_optional_dict(value: Any) -> dict[str, Any] | None:
     """Parse an optional JSON-encoded dict column; empty means None."""
     parsed = _parse_json_field(value) if value else None
     return parsed if isinstance(parsed, dict) and parsed else None
 
 
-def _load_from_local_files(config: DatasetConfig) -> Dict[str, List[Any]]:
+def _load_from_local_files(config: DatasetConfig) -> dict[str, list[Any]]:
     suite = config.name.split("/")[-1]
     suite_dir = DATASET_SUITES_DIR / suite
 
-    execution: List[ExecutionTest] = []
-    knowledge: List[KnowledgeTest] = []
+    execution: list[ExecutionTest] = []
+    knowledge: list[KnowledgeTest] = []
 
     # Load all execution test files from execution/ directory
     execution_dir = suite_dir / "execution"
@@ -208,7 +208,7 @@ def _load_from_local_files(config: DatasetConfig) -> Dict[str, List[Any]]:
     return {"execution": execution, "knowledge": knowledge}
 
 
-def _parse_execution_suite(path: Path) -> List[ExecutionTest]:
+def _parse_execution_suite(path: Path) -> list[ExecutionTest]:
     data = _read_json(path)
     suite_id = data.get("id", path.stem)
     metadata = data.get("metadata", {})
@@ -236,7 +236,7 @@ def _parse_execution_suite(path: Path) -> List[ExecutionTest]:
     return tests
 
 
-def _parse_knowledge_suite(path: Path) -> List[KnowledgeTest]:
+def _parse_knowledge_suite(path: Path) -> list[KnowledgeTest]:
     data = _read_json(path)
     suite_id = data.get("id", path.stem)
     metadata = data.get("metadata", {})
@@ -259,6 +259,6 @@ def _parse_knowledge_suite(path: Path) -> List[KnowledgeTest]:
     return tests
 
 
-def _read_json(path: Path) -> Dict[str, Any]:
+def _read_json(path: Path) -> dict[str, Any]:
     with path.open("rb") as handle:
         return orjson.loads(handle.read())

--- a/python/wp_bench/environment.py
+++ b/python/wp_bench/environment.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import subprocess
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any
 
 from .config import GraderConfig
 
@@ -24,7 +24,7 @@ class EnvironmentSetupTimeout(RuntimeError):
 @dataclass
 class ExecutionResult:
     success: bool
-    raw: Dict[str, Any]
+    raw: dict[str, Any]
     stdout: str
     stderr: str
     timed_out: bool = False
@@ -83,7 +83,7 @@ class WordPressEnvironment:
             self._exec(["wp", "db", "reset", "--yes"])
             self._exec(install_cmd)
 
-    def execute_code(self, code: str, verification_spec: Dict[str, Any]) -> ExecutionResult:
+    def execute_code(self, code: str, verification_spec: dict[str, Any]) -> ExecutionResult:
         """Run a candidate PHP snippet through the runtime verifier.
 
         Compatibility wrapper over execute_artifact() for snippet payloads.
@@ -95,7 +95,7 @@ class WordPressEnvironment:
         }
         return self._run_verifier(payload)
 
-    def execute_artifact(self, artifact: Any, verification_spec: Dict[str, Any]) -> ExecutionResult:
+    def execute_artifact(self, artifact: Any, verification_spec: dict[str, Any]) -> ExecutionResult:
         """Run a candidate artifact (snippet or plugin files) through the verifier.
 
         Args:
@@ -109,7 +109,7 @@ class WordPressEnvironment:
         }
         return self._run_verifier(payload)
 
-    def _run_verifier(self, payload: Dict[str, Any]) -> ExecutionResult:
+    def _run_verifier(self, payload: dict[str, Any]) -> ExecutionResult:
         """Send a payload to the runtime verifier and parse the result.
 
         A runtime timeout is a per-test failure, not a harness crash: it
@@ -132,7 +132,7 @@ class WordPressEnvironment:
                 stderr=stderr,
                 timed_out=True,
             )
-        data: Dict[str, Any] = {}
+        data: dict[str, Any] = {}
         if stdout.strip():
             try:
                 data = json.loads(stdout)
@@ -142,7 +142,7 @@ class WordPressEnvironment:
         return ExecutionResult(success=success, raw=data, stdout=stdout, stderr=stderr)
 
     # Internal helpers --------------------------------------------------
-    def _timeout_raw_result(self) -> Dict[str, Any]:
+    def _timeout_raw_result(self) -> dict[str, Any]:
         """Build the stable raw payload recorded for a runtime timeout."""
         return {
             "success": False,
@@ -174,10 +174,10 @@ class WordPressEnvironment:
         self,
         command: list[str],
         *,
-        cwd: Optional[str] = None,
-        timeout: Optional[float] = None,
+        cwd: str | None = None,
+        timeout: float | None = None,
         capture_output: bool = True,
-        stdin: Optional[str] = None,
+        stdin: str | None = None,
     ) -> ProcessResult:
         """Run a subprocess with a hard timeout.
 
@@ -263,7 +263,7 @@ class WordPressEnvironment:
         self,
         command: list[str],
         *,
-        stdin: Optional[str] = None,
+        stdin: str | None = None,
     ) -> tuple[str, str, int, bool]:
         """Execute a command in the WordPress runtime.
 

--- a/python/wp_bench/exploits.py
+++ b/python/wp_bench/exploits.py
@@ -14,12 +14,12 @@ for cheats the generic battery cannot express; the runner appends those.
 from __future__ import annotations
 
 import re
-from typing import Any, List, Optional, Tuple
+from typing import Any
 
 #: (label, PHP return expression) — trivial values a model could emit
 #: without doing the task. A single-fixture assertion checking `=== <value>`
 #: is satisfied by whichever constant matches that fixture's answer.
-_GENERIC_RETURNS: List[Tuple[str, str]] = [
+_GENERIC_RETURNS: list[tuple[str, str]] = [
     ("return-1", "1"),
     ("return-0", "0"),
     ("return-true", "true"),
@@ -32,7 +32,7 @@ _GENERIC_RETURNS: List[Tuple[str, str]] = [
 _FUNCTION_NAME = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 
-def gateway_name(test: Any) -> Optional[str]:
+def gateway_name(test: Any) -> str | None:
     """Extract the gateway function name from a test's test_function signature."""
     signature = getattr(test, "test_function", None)
     if not signature:
@@ -41,7 +41,7 @@ def gateway_name(test: Any) -> Optional[str]:
     return match.group(0) if match else None
 
 
-def generic_exploit_candidates(test: Any) -> List[Tuple[str, str]]:
+def generic_exploit_candidates(test: Any) -> list[tuple[str, str]]:
     """Synthesize zero-effort cheat snippets for one execution test.
 
     Each candidate declares the test's gateway function with a trivial body
@@ -70,7 +70,7 @@ def generic_exploit_candidates(test: Any) -> List[Tuple[str, str]]:
     return candidates
 
 
-def exploit_candidates(test: Any) -> List[Tuple[str, str]]:
+def exploit_candidates(test: Any) -> list[tuple[str, str]]:
     """All exploit candidates for a test: generic battery + authored ones."""
     candidates = generic_exploit_candidates(test)
     authored = getattr(test, "exploit_solutions", None) or []

--- a/python/wp_bench/models.py
+++ b/python/wp_bench/models.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 from litellm import completion, completion_cost
 from litellm.exceptions import (
@@ -48,15 +48,15 @@ class ModelGeneration:
     """A completion plus the call metadata needed for audit and reporting."""
 
     text: str
-    raw_response: Optional[ModelResponse]
+    raw_response: ModelResponse | None
     retry_count: int
     latency_ms: float
-    provider_response_id: Optional[str]
+    provider_response_id: str | None
     temperature_fallback: bool = False
-    prompt_tokens: Optional[int] = None
-    completion_tokens: Optional[int] = None
-    total_tokens: Optional[int] = None
-    cost_usd: Optional[float] = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+    cost_usd: float | None = None
 
     def usage_dict(self) -> dict[str, Any]:
         """Usage object in the canonical result-record shape."""
@@ -107,7 +107,7 @@ class ModelInterface:
             nonlocal attempt_count
             attempt_count = retry_state.attempt_number
 
-        response: Optional[ModelResponse] = None
+        response: ModelResponse | None = None
         for attempt in Retrying(
             stop=stop_after_attempt(self.config.max_retries + 1),
             wait=wait_random_exponential(
@@ -180,13 +180,13 @@ def _is_deprecated_temperature_error(error: BadRequestError) -> bool:
     return "`temperature` is deprecated" in str(error)
 
 
-def _extract_usage(response: Any) -> dict[str, Optional[int]]:
+def _extract_usage(response: Any) -> dict[str, int | None]:
     """Read token usage defensively; providers may omit any field."""
     usage = getattr(response, "usage", None)
     if usage is None and isinstance(response, dict):
         usage = response.get("usage")
 
-    def _read(field: str) -> Optional[int]:
+    def _read(field: str) -> int | None:
         if usage is None:
             return None
         value = getattr(usage, field, None)
@@ -201,7 +201,7 @@ def _extract_usage(response: Any) -> dict[str, Optional[int]]:
     }
 
 
-def _estimate_cost_safe(response: Any) -> Optional[float]:
+def _estimate_cost_safe(response: Any) -> float | None:
     """Best-effort cost estimate via LiteLLM; None when unpriceable.
 
     Cost is an estimate, not billing truth: unknown models, custom
@@ -210,6 +210,6 @@ def _estimate_cost_safe(response: Any) -> Optional[float]:
     """
     try:
         cost = completion_cost(response)
-    except Exception:
+    except Exception:  # noqa: BLE001 -- best-effort estimate over arbitrary providers
         return None
     return float(cost) if isinstance(cost, (int, float)) else None

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -1,7 +1,7 @@
 """Rich console output formatting for WP-Bench."""
 from __future__ import annotations
 
-from typing import Any, Dict, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from rich import box
 from rich.console import Console
@@ -12,6 +12,7 @@ from rich.text import Text
 
 if TYPE_CHECKING:
     from pathlib import Path
+
     from .core import TestError
 
 console = Console()
@@ -90,7 +91,7 @@ def print_results_path(path: Path) -> None:
     console.print(f"Results written to: {path}")
 
 
-def print_comparison_table(results: Dict[str, Dict[str, Any]]) -> None:
+def print_comparison_table(results: dict[str, dict[str, Any]]) -> None:
     """Print a formatted table comparing scores across all models.
 
     Args:
@@ -130,7 +131,7 @@ def print_comparison_table(results: Dict[str, Dict[str, Any]]) -> None:
     console.print(table)
 
 
-def print_reference_solution_failures(records: list[Dict[str, Any]]) -> None:
+def print_reference_solution_failures(records: list[dict[str, Any]]) -> None:
     """Print reference solution failures in a compact table."""
     table = Table(title="Reference Solution Failures")
     table.add_column("Test ID", style="cyan")
@@ -155,7 +156,7 @@ def print_reference_solution_failures(records: list[Dict[str, Any]]) -> None:
     console.print(table)
 
 
-def print_exploit_findings(audit: Dict[str, Any], exploitable: list[Dict[str, Any]]) -> None:
+def print_exploit_findings(audit: dict[str, Any], exploitable: list[dict[str, Any]]) -> None:
     """Render the adversarial assertion audit summary and exploitable tests.
 
     ``audit`` is the summary dict assembled by the runner (counts +

--- a/python/wp_bench/records.py
+++ b/python/wp_bench/records.py
@@ -7,7 +7,7 @@ do not hand-roll record dicts in runner code.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from .config import ModelConfig
 
@@ -15,7 +15,7 @@ from .config import ModelConfig
 RESULT_SCHEMA_VERSION = "1.0"
 
 
-def _model_info(model_config: Optional[ModelConfig]) -> Optional[Dict[str, Any]]:
+def _model_info(model_config: ModelConfig | None) -> dict[str, Any] | None:
     """Serialize the model configuration relevant to reproducibility."""
     if model_config is None:
         return None
@@ -28,7 +28,7 @@ def _model_info(model_config: Optional[ModelConfig]) -> Optional[Dict[str, Any]]
     }
 
 
-def _empty_usage() -> Dict[str, Any]:
+def _empty_usage() -> dict[str, Any]:
     """Usage placeholders; populated when usage capture is implemented."""
     return {
         "prompt_tokens": None,
@@ -39,7 +39,7 @@ def _empty_usage() -> Dict[str, Any]:
     }
 
 
-def _null_scores() -> Dict[str, Any]:
+def _null_scores() -> dict[str, Any]:
     """The full score key set, all null — a record that carries no score."""
     return {
         "knowledge": None,
@@ -56,8 +56,8 @@ def _base_record(
     test: Any,
     test_type: str,
     mode: str,
-    model_config: Optional[ModelConfig],
-) -> Dict[str, Any]:
+    model_config: ModelConfig | None,
+) -> dict[str, Any]:
     """The canonical per-test record skeleton shared by every builder.
 
     Every field defaults to its null/empty form; each builder overrides only
@@ -87,14 +87,14 @@ def build_knowledge_record(
     *,
     test: Any,
     mode: str,
-    model_config: Optional[ModelConfig],
+    model_config: ModelConfig | None,
     prompt_hash: str,
     raw_completion: str,
     answer: str,
     knowledge_score: float,
-    usage: Optional[Dict[str, Any]] = None,
-    model_call: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    usage: dict[str, Any] | None = None,
+    model_call: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Build the canonical record for a knowledge test result."""
     record = _base_record(test=test, test_type="knowledge", mode=mode, model_config=model_config)
     record["prompt_hash"] = prompt_hash
@@ -109,15 +109,15 @@ def build_execution_record(
     *,
     test: Any,
     mode: str,
-    model_config: Optional[ModelConfig],
-    prompt_hash: Optional[str],
-    raw_completion: Optional[str],
+    model_config: ModelConfig | None,
+    prompt_hash: str | None,
+    raw_completion: str | None,
     code: str,
     env_result: Any,
-    scores: Dict[str, Any],
-    usage: Optional[Dict[str, Any]] = None,
-    model_call: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+    scores: dict[str, Any],
+    usage: dict[str, Any] | None = None,
+    model_call: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Build the canonical record for an execution test result.
 
     Args:
@@ -147,10 +147,10 @@ def build_error_record(
     test: Any,
     test_type: str,
     mode: str,
-    model_config: Optional[ModelConfig],
+    model_config: ModelConfig | None,
     error_type: str,
     error_message: str,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Build the canonical record for a test that errored before grading.
 
     Used by ``run.continue_on_error``: the record fills the reserved
@@ -167,9 +167,9 @@ def build_exploit_audit_record(
     *,
     test: Any,
     candidates_tried: int,
-    passing_exploit: Optional[str],
-    exploit_code: Optional[str],
-) -> Dict[str, Any]:
+    passing_exploit: str | None,
+    exploit_code: str | None,
+) -> dict[str, Any]:
     """Build the record for one test in the adversarial assertion audit.
 
     Shares the canonical header (test_id/suite/type/category/difficulty)
@@ -192,7 +192,7 @@ def build_exploit_audit_record(
     }
 
 
-def execution_record_passed(record: Dict[str, Any]) -> bool:
+def execution_record_passed(record: dict[str, Any]) -> bool:
     """Whether an execution record represents a strict pass.
 
     Reads the primary execution_pass metric (SCORING_VERSION 2.0). Used by

--- a/python/wp_bench/scoring.py
+++ b/python/wp_bench/scoring.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from statistics import mean
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 #: Bump when the meaning of any aggregate or per-test score changes.
 SCORING_VERSION = "2.0"
@@ -19,18 +19,18 @@ SCORING_VERSION = "2.0"
 
 @dataclass
 class ScoreBreakdown:
-    knowledge: Optional[float] = None
+    knowledge: float | None = None
     #: Legacy compatibility score (see records: 1.0 on strict pass, else
     #: partial runtime credit). Kept one release for consumers of the old key.
-    correctness: Optional[float] = None
+    correctness: float | None = None
     #: Strict pass rate: fraction of execution tests with execution_pass=True.
     #: This is the primary execution ranking metric.
-    execution_pass_rate: Optional[float] = None
+    execution_pass_rate: float | None = None
     #: Mean partial runtime assertion score (0.0-1.0).
-    runtime: Optional[float] = None
+    runtime: float | None = None
     #: Fraction of execution tests without a hard static policy failure.
-    static_policy_pass_rate: Optional[float] = None
-    weights: Dict[str, float] = field(
+    static_policy_pass_rate: float | None = None
+    weights: dict[str, float] = field(
         default_factory=lambda: {"knowledge": 0.3, "execution_pass_rate": 0.7}
     )
 
@@ -49,7 +49,7 @@ class ScoreBreakdown:
         return round(total / total_weight, 4)
 
 
-def _percentile(values: List[float], fraction: float) -> float:
+def _percentile(values: list[float], fraction: float) -> float:
     """Nearest-rank percentile; values need not be pre-sorted."""
     ordered = sorted(values)
     index = min(len(ordered) - 1, max(0, round(fraction * (len(ordered) - 1))))
@@ -65,9 +65,9 @@ class UsageAggregator:
         self.total_tokens = 0
         self.cost_usd = 0.0
         self.has_cost = False
-        self.latencies_ms: List[float] = []
+        self.latencies_ms: list[float] = []
 
-    def add(self, usage: Optional[Dict[str, Any]]) -> None:
+    def add(self, usage: dict[str, Any] | None) -> None:
         if not isinstance(usage, dict):
             return
         for token_field in ("prompt_tokens", "completion_tokens", "total_tokens"):
@@ -82,7 +82,7 @@ class UsageAggregator:
         if isinstance(latency, (int, float)):
             self.latencies_ms.append(float(latency))
 
-    def summary(self) -> Dict[str, Any]:
+    def summary(self) -> dict[str, Any]:
         """Run-level usage summary; cost is an estimate, not billing truth."""
         return {
             "prompt_tokens": self.prompt_tokens,
@@ -100,13 +100,13 @@ class UsageAggregator:
 
 class ScoreAggregator:
     def __init__(self) -> None:
-        self.knowledge_scores: List[float] = []
-        self.correctness_scores: List[float] = []
-        self.execution_passes: List[bool] = []
-        self.runtime_scores: List[float] = []
-        self.static_policy_passes: List[bool] = []
+        self.knowledge_scores: list[float] = []
+        self.correctness_scores: list[float] = []
+        self.execution_passes: list[bool] = []
+        self.runtime_scores: list[float] = []
+        self.static_policy_passes: list[bool] = []
 
-    def add_execution(self, scores: Dict[str, Any]) -> None:
+    def add_execution(self, scores: dict[str, Any]) -> None:
         """Record an execution test's scores object (canonical record shape)."""
         correctness = scores.get("correctness")
         if isinstance(correctness, (int, float)):

--- a/python/wp_bench/selection.py
+++ b/python/wp_bench/selection.py
@@ -12,16 +12,16 @@ from __future__ import annotations
 
 import random
 from collections import defaultdict
-from typing import Any, Dict, List
+from typing import Any
 
 
 def select_tests(
-    tests: List[Any],
+    tests: list[Any],
     *,
     limit: int | None,
-    test_ids: List[str],
+    test_ids: list[str],
     seed: int,
-) -> List[Any]:
+) -> list[Any]:
     """Select tests for a run, deterministically.
 
     Rules:
@@ -40,7 +40,7 @@ def select_tests(
     if limit is None or limit >= len(tests):
         return tests
 
-    groups: Dict[Any, List[Any]] = defaultdict(list)
+    groups: dict[Any, list[Any]] = defaultdict(list)
     for test in tests:
         key = (getattr(test, "category", ""), getattr(test, "difficulty", ""))
         groups[key].append(test)
@@ -50,7 +50,7 @@ def select_tests(
     for key in ordered_keys:
         rng.shuffle(groups[key])
 
-    selected: List[Any] = []
+    selected: list[Any] = []
     while len(selected) < limit:
         progressed = False
         for key in ordered_keys:
@@ -65,6 +65,6 @@ def select_tests(
     return sorted(selected, key=lambda test: test.id)
 
 
-def selected_test_ids(tests: List[Any]) -> List[str]:
+def selected_test_ids(tests: list[Any]) -> list[str]:
     """IDs of a selection, for dry-run output and result metadata."""
     return [test.id for test in tests]


### PR DESCRIPTION
## What

CI's "Python lint, types, tests" job went red on **every open PR** (#45, #46) over files those PRs never touched. Cause: the dev extra declares `ruff>=0.6` unpinned, CI installs latest on each run, and ruff 0.16 changed its default rule set.

## Fix

- **Pin `ruff>=0.16,<0.17`** so lint results are deterministic; future default-set changes land as deliberate bumps, not surprise CI breakage.
- **Apply the 0.16 autofixes** (import sorting, modern typing syntax) across the harness — mechanical, no behavior change (26 files, all green under pytest/mypy).
- **Exempt `typer.Option` from B008** (`flake8-bugbear.extend-immutable-calls`): typer's call-in-default pattern is its documented API.
- **Fix the four genuine findings** the new rules caught: useless conditional in `cli.py`, `dict()` call → literal in a test, result-file timestamps now explicitly UTC (timezone-independent artifact names), and an intentional broad `except` in cost estimation annotated with its rationale.

## Verification

`ruff check python` clean under 0.16.1, `mypy python` clean, 152 tests pass.

Once merged, #45 and #46 just need a CI re-run (the lint job runs on the merge ref) — no rebase strictly required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)