### PR TITLE
feat: stream results to disk as tests complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ debug.log
 # Local configuration
 .claude/
 .wp-env.override.json
-CLAUDE.md
+CLAUDE.mdpython/uv.lock

--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,9 @@ debug.log
 # Local configuration
 .claude/
 .wp-env.override.json
-CLAUDE.mdpython/uv.lock
+CLAUDE.md
+python/uv.lock
+# Local run configs (wp-bench.example.yaml is the tracked template)
+wp-bench.yaml
+wp-bench.*.yaml
+!wp-bench.example.yaml

--- a/README.md
+++ b/README.md
@@ -46,7 +46,17 @@ cd ..
 wp-bench run --config wp-bench.example.yaml
 ```
 
-Results are written to `output/results.json` with per-test logs in `output/results.jsonl`.
+Results are written to `output/results.json` with per-test logs in
+`output/results.jsonl`. Multi-model runs write one combined JSONL covering every
+model, each record carrying the model it came from.
+
+While a run is in flight its records stream to `output/results_<timestamp>.jsonl.partial`,
+so you can `tail -f` progress and, if the run dies (dead runtime, exhausted
+provider quota, Ctrl-C), keep everything already graded. **A `.partial` file is by
+definition an incomplete run: read it for the individual records, never compute a
+suite score from it.** The canonical `.jsonl` appears only when a run finishes, and
+the timestamp in every filename is when the run *started*, so a run's JSON and JSONL
+share one name.
 
 ## Multi-Model Benchmarking
 

--- a/notebooks/results_report.ipynb
+++ b/notebooks/results_report.ipynb
@@ -35,7 +35,9 @@
    "source": [
     "# Load the most recent results file\n",
     "output_dir = Path('../output')\n",
-    "result_files = sorted(output_dir.glob('results_*.json'), reverse=True)\n",
+    "# Filenames stamp when a run STARTED, so pick by modification time:\n",
+    "# a long run can start before a short one and finish after it.\n",
+    "result_files = sorted(output_dir.glob('results_*.json'), key=lambda p: p.stat().st_mtime, reverse=True)\n",
     "\n",
     "if not result_files:\n",
     "    raise FileNotFoundError('No results files found in output directory')\n",

--- a/python/tests/test_result_streaming.py
+++ b/python/tests/test_result_streaming.py
@@ -1,0 +1,162 @@
+"""Tests for durable result artifacts: a crashed run keeps its graded records."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from wp_bench.results_io import RecordStream, open_stream, timestamped_path
+
+
+def _ids(path: Path) -> list[str]:
+    return [json.loads(line)["test_id"] for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_records_are_readable_before_the_run_finishes(tmp_path: Path) -> None:
+    """The whole point: a run that dies mid-way leaves graded tests on disk."""
+    stream = RecordStream(tmp_path / "results.jsonl")
+    stream.write({"test_id": "e-two"})
+    stream.write({"test_id": "e-one"})
+
+    # No close() and no finalize() — the run was killed in flight.
+    assert _ids(tmp_path / "results.jsonl") == ["e-two", "e-one"]
+
+
+def test_no_file_when_nothing_was_graded(tmp_path: Path) -> None:
+    """A run that fails before grading anything leaves no empty artifact."""
+    stream = RecordStream(tmp_path / "results.jsonl")
+    stream.close()
+    stream.finalize([])
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_disabled_stream_writes_nothing(tmp_path: Path) -> None:
+    """jsonl_path: null keeps the old behavior of no line-oriented output."""
+    stream = RecordStream(None)
+    stream.write({"test_id": "e-one"})
+    stream.finalize([{"test_id": "e-one"}])
+    stream.close()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_finalize_replaces_the_live_file_with_the_given_order(tmp_path: Path) -> None:
+    """In flight the file is completion-ordered; the finished artifact carries
+    the run's canonical order, so result diffs stay stable across runs."""
+    stream = RecordStream(tmp_path / "results.jsonl")
+    stream.write({"test_id": "e-two"})
+    stream.write({"test_id": "e-one"})
+
+    stream.finalize([{"test_id": "e-one"}, {"test_id": "e-two"}])
+
+    assert _ids(tmp_path / "results.jsonl") == ["e-one", "e-two"]
+    assert list(tmp_path.iterdir()) == [tmp_path / "results.jsonl"]  # no .tmp left behind
+
+
+def test_finalize_never_destroys_streamed_records_it_cannot_replace(tmp_path: Path) -> None:
+    """The replacement is staged beside the live file, so an interrupted
+    finalize leaves the streamed records intact rather than a truncated file."""
+    path = tmp_path / "results.jsonl"
+    stream = RecordStream(path)
+    stream.write({"test_id": "e-one"})
+    stream.write({"test_id": "e-two"})
+
+    class Unserializable:
+        """orjson cannot encode this, so the rewrite dies partway."""
+
+    try:
+        stream.finalize([{"test_id": "e-one"}, {"test_id": Unserializable()}])
+    except TypeError:
+        pass
+
+    assert _ids(path) == ["e-one", "e-two"]
+
+
+def test_run_artifacts_share_one_timestamp() -> None:
+    """The JSON and JSONL of one run must be correlatable by filename."""
+    moment = datetime(2026, 8, 5, 14, 30, 52, tzinfo=timezone.utc)
+    assert timestamped_path(Path("out/results.json"), moment).name == "results_20260805_143052.json"
+    assert timestamped_path(Path("out/results.jsonl"), moment).name == "results_20260805_143052.jsonl"
+
+
+def test_open_stream_disables_itself_without_a_configured_path() -> None:
+    moment = datetime(2026, 8, 5, 14, 30, 52, tzinfo=timezone.utc)
+    assert open_stream(None, moment).path is None
+    assert open_stream(Path("out/results.jsonl"), moment).path == Path(
+        "out/results_20260805_143052.jsonl"
+    )
+
+
+def test_every_model_streams_into_one_run_artifact(tmp_path: Path) -> None:
+    """MultiModelRunner shares one stream across its per-model runners, so a
+    multi-model run that dies keeps the models already graded — its combined
+    JSON payload is only assembled after every model finishes."""
+    from conftest import fake_generation
+
+    from wp_bench.config import (
+        DatasetConfig,
+        GraderConfig,
+        HarnessConfig,
+        ModelConfig,
+        OutputConfig,
+        RunConfig,
+    )
+    from wp_bench.core import SingleModelRunner
+    from wp_bench.datasets import ExecutionTest
+    from wp_bench.environment import ExecutionResult
+
+    def execution_test() -> ExecutionTest:
+        return ExecutionTest(
+            id="e-one",
+            suite="wp-core-v1",
+            prompt="Prompt",
+            expected_behavior="expected",
+            category="hooks",
+            difficulty="basic",
+            requirements=["Requirement"],
+            test_function=None,
+            static_checks={},
+            runtime_checks={"assertions": [{"type": "custom_assertion", "code": "return true;", "weight": 1}]},
+            reference_solution="function ref() { return true; }",
+            metadata={},
+        )
+
+    class FakeEnvironment:
+        def setup(self) -> None: ...
+        def reset(self) -> None: ...
+
+        def execute_artifact(self, artifact: object, spec: dict) -> ExecutionResult:
+            return ExecutionResult(
+                success=True,
+                stdout="out",
+                stderr="",
+                raw={
+                    "success": True,
+                    "static": {"score": 1.0, "details": {"total_weight": 1}},
+                    "runtime": {"score": 1.0, "details": {"total_weight": 1}},
+                },
+            )
+
+    config = HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        models=[ModelConfig(name="model-a"), ModelConfig(name="model-b")],
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(),
+        output=OutputConfig(path=tmp_path / "multi.json", jsonl_path=tmp_path / "multi.jsonl"),
+    )
+    stream = RecordStream(tmp_path / "multi.jsonl")
+    environment = FakeEnvironment()
+
+    for model_config in config.get_models():
+        runner = SingleModelRunner(
+            config=config,
+            model_config=model_config,
+            environment=environment,  # type: ignore[arg-type]
+            tests=[execution_test()],
+            stream=stream,
+        )
+        runner.model.generate_with_metadata = lambda prompt: fake_generation("init")  # type: ignore[method-assign]
+        runner.run()
+
+    streamed = [json.loads(line) for line in (tmp_path / "multi.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert [record["model"]["name"] for record in streamed] == ["model-a", "model-b"]
+    assert all(record["test_id"] == "e-one" for record in streamed)

--- a/python/tests/test_result_streaming.py
+++ b/python/tests/test_result_streaming.py
@@ -173,15 +173,27 @@ def test_every_model_streams_into_one_run_artifact(monkeypatch, tmp_path: Path) 
     assert not list(tmp_path.glob("*.partial"))
 
 
-def test_a_collapsed_model_result_never_deletes_its_streamed_records(
-    monkeypatch, tmp_path: Path
-) -> None:
-    """Results are keyed by model name, so two entries sharing a name collapse
-    and the finished artifact covers fewer records than were streamed. The
-    live file must survive that, or streaming would destroy graded work the
-    old end-of-run write merely never saved."""
-    _run_multi_model(monkeypatch, tmp_path, ["same-name", "same-name"])
+def test_finalize_keeps_the_live_file_when_it_would_shrink(tmp_path: Path) -> None:
+    """A caller that finalizes with fewer records than were streamed has lost
+    track of some; the live file keeps them recoverable instead of deleting
+    them. Config rejects the duplicate-model case that used to reach here, so
+    this pins the invariant itself."""
+    stream = RecordStream(tmp_path / "results.jsonl")
+    stream.write({"test_id": "e-one"})
+    stream.write({"test_id": "e-two"})
 
-    partial = next(tmp_path.glob("multi_*.jsonl.partial"))
-    streamed = [json.loads(line) for line in partial.read_text(encoding="utf-8").splitlines()]
-    assert len(streamed) == 2, "both passes were graded and must remain on disk"
+    stream.finalize([{"test_id": "e-one"}])
+
+    assert _ids(tmp_path / "results.jsonl") == ["e-one"]
+    assert _ids(tmp_path / "results.jsonl.partial") == ["e-one", "e-two"]
+
+
+def test_duplicate_model_names_are_rejected_before_a_run(tmp_path: Path) -> None:
+    """Results are keyed by model name end to end, so two entries sharing one
+    would silently drop a graded pass. Rejecting it in config is the root fix."""
+    import pytest
+
+    from wp_bench.config import HarnessConfig, ModelConfig
+
+    with pytest.raises(Exception, match="Duplicate model names"):
+        HarnessConfig(models=[ModelConfig(name="same"), ModelConfig(name="same")])

--- a/python/tests/test_result_streaming.py
+++ b/python/tests/test_result_streaming.py
@@ -13,13 +13,15 @@ def _ids(path: Path) -> list[str]:
 
 
 def test_records_are_readable_before_the_run_finishes(tmp_path: Path) -> None:
-    """The whole point: a run that dies mid-way leaves graded tests on disk."""
+    """The whole point: a run that dies mid-way leaves graded tests on disk,
+    under a name that says the run never finished."""
     stream = RecordStream(tmp_path / "results.jsonl")
     stream.write({"test_id": "e-two"})
     stream.write({"test_id": "e-one"})
 
     # No close() and no finalize() — the run was killed in flight.
-    assert _ids(tmp_path / "results.jsonl") == ["e-two", "e-one"]
+    assert _ids(tmp_path / "results.jsonl.partial") == ["e-two", "e-one"]
+    assert not (tmp_path / "results.jsonl").exists()
 
 
 def test_no_file_when_nothing_was_graded(tmp_path: Path) -> None:
@@ -49,7 +51,8 @@ def test_finalize_replaces_the_live_file_with_the_given_order(tmp_path: Path) ->
     stream.finalize([{"test_id": "e-one"}, {"test_id": "e-two"}])
 
     assert _ids(tmp_path / "results.jsonl") == ["e-one", "e-two"]
-    assert list(tmp_path.iterdir()) == [tmp_path / "results.jsonl"]  # no .tmp left behind
+    # The live file is retired and no staging file is left behind.
+    assert list(tmp_path.iterdir()) == [tmp_path / "results.jsonl"]
 
 
 def test_finalize_never_destroys_streamed_records_it_cannot_replace(tmp_path: Path) -> None:
@@ -68,7 +71,9 @@ def test_finalize_never_destroys_streamed_records_it_cannot_replace(tmp_path: Pa
     except TypeError:
         pass
 
-    assert _ids(path) == ["e-one", "e-two"]
+    assert _ids(tmp_path / "results.jsonl.partial") == ["e-one", "e-two"]
+    assert not path.exists()
+    assert not (tmp_path / "results.jsonl.tmp").exists()
 
 
 def test_run_artifacts_share_one_timestamp() -> None:
@@ -86,12 +91,7 @@ def test_open_stream_disables_itself_without_a_configured_path() -> None:
     )
 
 
-def test_every_model_streams_into_one_run_artifact(tmp_path: Path) -> None:
-    """MultiModelRunner shares one stream across its per-model runners, so a
-    multi-model run that dies keeps the models already graded — its combined
-    JSON payload is only assembled after every model finishes."""
-    from conftest import fake_generation
-
+def _multi_model_config(tmp_path: Path, names: list[str]):
     from wp_bench.config import (
         DatasetConfig,
         GraderConfig,
@@ -100,27 +100,42 @@ def test_every_model_streams_into_one_run_artifact(tmp_path: Path) -> None:
         OutputConfig,
         RunConfig,
     )
-    from wp_bench.core import SingleModelRunner
+
+    return HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        models=[ModelConfig(name=name) for name in names],
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(),
+        output=OutputConfig(path=tmp_path / "multi.json", jsonl_path=tmp_path / "multi.jsonl"),
+    )
+
+
+def _run_multi_model(monkeypatch, tmp_path: Path, names: list[str]):
+    """Drive the real MultiModelRunner over one test per model."""
+    from conftest import fake_generation
+
+    from wp_bench.core import MultiModelRunner
     from wp_bench.datasets import ExecutionTest
     from wp_bench.environment import ExecutionResult
+    from wp_bench.models import ModelInterface
 
-    def execution_test() -> ExecutionTest:
-        return ExecutionTest(
-            id="e-one",
-            suite="wp-core-v1",
-            prompt="Prompt",
-            expected_behavior="expected",
-            category="hooks",
-            difficulty="basic",
-            requirements=["Requirement"],
-            test_function=None,
-            static_checks={},
-            runtime_checks={"assertions": [{"type": "custom_assertion", "code": "return true;", "weight": 1}]},
-            reference_solution="function ref() { return true; }",
-            metadata={},
-        )
+    test = ExecutionTest(
+        id="e-one",
+        suite="wp-core-v1",
+        prompt="Prompt",
+        expected_behavior="expected",
+        category="hooks",
+        difficulty="basic",
+        requirements=["Requirement"],
+        test_function=None,
+        static_checks={},
+        runtime_checks={"assertions": [{"type": "custom_assertion", "code": "return true;", "weight": 1}]},
+        reference_solution="function ref() { return true; }",
+        metadata={},
+    )
 
     class FakeEnvironment:
+        def __init__(self, *args: object, **kwargs: object) -> None: ...
         def setup(self) -> None: ...
         def reset(self) -> None: ...
 
@@ -136,27 +151,37 @@ def test_every_model_streams_into_one_run_artifact(tmp_path: Path) -> None:
                 },
             )
 
-    config = HarnessConfig(
-        dataset=DatasetConfig(source="local", name="wp-core-v1"),
-        models=[ModelConfig(name="model-a"), ModelConfig(name="model-b")],
-        grader=GraderConfig(kind="cli"),
-        run=RunConfig(),
-        output=OutputConfig(path=tmp_path / "multi.json", jsonl_path=tmp_path / "multi.jsonl"),
+    monkeypatch.setattr("wp_bench.core.WordPressEnvironment", FakeEnvironment)
+    monkeypatch.setattr("wp_bench.core.load_tests", lambda dataset: [test])
+    monkeypatch.setattr(
+        ModelInterface, "generate_with_metadata", lambda self, prompt: fake_generation("init")
     )
-    stream = RecordStream(tmp_path / "multi.jsonl")
-    environment = FakeEnvironment()
+    runner = MultiModelRunner(_multi_model_config(tmp_path, names))
+    runner.run()
+    return runner
 
-    for model_config in config.get_models():
-        runner = SingleModelRunner(
-            config=config,
-            model_config=model_config,
-            environment=environment,  # type: ignore[arg-type]
-            tests=[execution_test()],
-            stream=stream,
-        )
-        runner.model.generate_with_metadata = lambda prompt: fake_generation("init")  # type: ignore[method-assign]
-        runner.run()
 
-    streamed = [json.loads(line) for line in (tmp_path / "multi.jsonl").read_text(encoding="utf-8").splitlines()]
-    assert [record["model"]["name"] for record in streamed] == ["model-a", "model-b"]
-    assert all(record["test_id"] == "e-one" for record in streamed)
+def test_every_model_streams_into_one_run_artifact(monkeypatch, tmp_path: Path) -> None:
+    """MultiModelRunner shares one stream across its per-model runners, so a
+    multi-model run that dies keeps the models already graded — its combined
+    JSON payload is only assembled after the last model finishes."""
+    _run_multi_model(monkeypatch, tmp_path, ["model-a", "model-b"])
+
+    artifact = next(tmp_path.glob("multi_*.jsonl"))
+    streamed = [json.loads(line) for line in artifact.read_text(encoding="utf-8").splitlines()]
+    assert sorted(record["model"]["name"] for record in streamed) == ["model-a", "model-b"]
+    assert not list(tmp_path.glob("*.partial"))
+
+
+def test_a_collapsed_model_result_never_deletes_its_streamed_records(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Results are keyed by model name, so two entries sharing a name collapse
+    and the finished artifact covers fewer records than were streamed. The
+    live file must survive that, or streaming would destroy graded work the
+    old end-of-run write merely never saved."""
+    _run_multi_model(monkeypatch, tmp_path, ["same-name", "same-name"])
+
+    partial = next(tmp_path.glob("multi_*.jsonl.partial"))
+    streamed = [json.loads(line) for line in partial.read_text(encoding="utf-8").splitlines()]
+    assert len(streamed) == 2, "both passes were graded and must remain on disk"

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -217,6 +217,24 @@ class HarnessConfig(StrictModel):
     output: OutputConfig = OutputConfig()
     skills: SkillsConfig = SkillsConfig()
 
+    @model_validator(mode="after")
+    def _validate_unique_model_names(self) -> HarnessConfig:
+        """Reject duplicate model names.
+
+        Results are keyed by model name end to end (the results dict, the
+        payload's ``models`` map, the comparison table), so two entries
+        sharing a name silently collapse into one and a graded pass is
+        dropped without warning.
+        """
+        names = [model.name for model in self.models or []]
+        duplicates = sorted({name for name in names if names.count(name) > 1})
+        if duplicates:
+            raise ValueError(
+                f"Duplicate model names {duplicates}: results are keyed by name, "
+                "so entries sharing one would overwrite each other."
+            )
+        return self
+
     def get_models(self) -> list[ModelConfig]:
         """Return list of models to evaluate."""
         if self.models:

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -6,8 +6,6 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
-import orjson
-
 from .artifacts import (
     Artifact,
     ArtifactError,
@@ -45,11 +43,36 @@ from .records import (
     execution_record_passed,
     sort_records,
 )
-from .results_io import RecordStream, open_run_artifacts
+from .results_io import RecordStream, open_run_artifacts, write_results_json
 from .scoring import SCORING_VERSION, ScoreAggregator, UsageAggregator
 from .selection import select_tests
 from .skills import BASELINE_VARIANT, LoadedSkill, Variant, build_variants
-from .utils import ensure_dir, sha256
+from .utils import sha256
+
+
+class _ResultBookkeeping:
+    """Aggregation, retention, and streaming for one run's records.
+
+    Single- and multi-model runners keep identical bookkeeping; sharing one
+    implementation keeps them from drifting apart the next time a metric or
+    an error predicate changes.
+    """
+
+    def _init_bookkeeping(self, stream: RecordStream) -> None:
+        self.aggregator = ScoreAggregator()
+        self.usage_aggregator = UsageAggregator()
+        self.records: list[dict[str, Any]] = []
+        self._stream = stream
+        self._lock = threading.Lock()
+
+    def _on_result(self, result: dict[str, Any]) -> None:
+        """Aggregate a finished record, keep it, and stream it to disk."""
+        with self._lock:
+            if result.get("error") is None:
+                self.aggregator.add_execution(result["scores"])
+            self.usage_aggregator.add(result.get("usage"))
+            self.records.append(result)
+            self._stream.write(result)
 
 
 class TestError(Exception):
@@ -331,7 +354,7 @@ def _run_concurrent_loop(
     policy.finish()
 
 
-class BenchmarkRunner:
+class BenchmarkRunner(_ResultBookkeeping):
     """Primary benchmark orchestrator for single-model evaluation.
 
     Loads tests from the configured dataset, runs them against a single LLM,
@@ -347,11 +370,8 @@ class BenchmarkRunner:
         self.config = config
         self.model = ModelInterface(config.model or config.get_models()[0])
         self.environment = WordPressEnvironment(config.grader)
-        self.aggregator = ScoreAggregator()
-        self.usage_aggregator = UsageAggregator()
-        self.records: list[dict[str, Any]] = []
-        self._lock = threading.Lock()
-        self._results_path, self._stream = open_run_artifacts(config.output)
+        self._results_path, stream = open_run_artifacts(config.output)
+        self._init_bookkeeping(stream or RecordStream(None))
 
     def run(self) -> dict[str, Any]:
         """Execute the full benchmark pipeline.
@@ -421,15 +441,6 @@ class BenchmarkRunner:
                 print_reference_solution_failures(failures)
                 raise SystemExit(1)
         return payload
-
-    def _on_result(self, result: dict[str, Any]) -> None:
-        """Aggregate a finished record, keep it, and stream it to disk."""
-        with self._lock:
-            if result.get("error") is None:
-                self.aggregator.add_execution(result["scores"])
-            self.usage_aggregator.add(result.get("usage"))
-            self.records.append(result)
-            self._stream.write(result)
 
     def _run_execution_tests(self, tests: list[ExecutionTest]) -> None:
         """Run code generation execution tests in parallel.
@@ -812,8 +823,7 @@ class BenchmarkRunner:
         Args:
             payload: Complete results dict with metadata and test records.
         """
-        ensure_dir(self._results_path.parent)
-        self._results_path.write_bytes(orjson.dumps(payload, option=orjson.OPT_INDENT_2))
+        write_results_json(self._results_path, payload)
         print_results_path(self._results_path)
         self._stream.finalize(payload["results"])
 
@@ -957,14 +967,13 @@ class MultiModelRunner:
                 for name, result in self.results.items()
             },
         }
-        ensure_dir(self._results_path.parent)
-        self._results_path.write_bytes(orjson.dumps(payload, option=orjson.OPT_INDENT_2))
+        write_results_json(self._results_path, payload)
         print_results_path(self._results_path)
         records = [record for result in self.results.values() for record in result["results"]]
         self._stream.finalize(sort_records(records))
 
 
-class SingleModelRunner:
+class SingleModelRunner(_ResultBookkeeping):
     """Run benchmark for a single model with pre-loaded tests.
 
     Used by MultiModelRunner to evaluate one model at a time while sharing
@@ -1017,15 +1026,6 @@ class SingleModelRunner:
             "scores": summary.as_scores_dict(),
             "results": sort_records(self.records),
         }
-
-    def _on_result(self, result: dict[str, Any]) -> None:
-        """Aggregate a finished record, keep it, and stream it to disk."""
-        with self._lock:
-            if result.get("error") is None:
-                self.aggregator.add_execution(result["scores"])
-            self.usage_aggregator.add(result.get("usage"))
-            self.records.append(result)
-            self._stream.write(result)
 
     def _run_execution_tests(self, tests: list[ExecutionTest]) -> None:
         """Run execution tests with isolation. See BenchmarkRunner._run_execution_tests."""

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import threading
 import traceback
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
 from typing import Any
 
 from .artifacts import (
@@ -48,6 +50,27 @@ from .scoring import SCORING_VERSION, ScoreAggregator, UsageAggregator
 from .selection import select_tests
 from .skills import BASELINE_VARIANT, LoadedSkill, Variant, build_variants
 from .utils import sha256
+
+
+@contextmanager
+def _graded_run(stream: RecordStream) -> Iterator[None]:
+    """Own a run's record stream and report a failed pass, once.
+
+    Every run mode needs the same three things: the stream released
+    however the run ends, a TestError rendered and exited on, and Ctrl-C
+    reported as an abort. Keeping them in one place is what stops a new
+    run mode from silently getting one of the three wrong -- the exploit
+    audit already had to re-add its own copy.
+    """
+    try:
+        with stream:
+            yield
+    except TestError as error:
+        print_test_error(error)
+        raise SystemExit(1) from error
+    except KeyboardInterrupt:
+        print_abort_message()
+        raise SystemExit(130) from None
 
 
 class _ResultBookkeeping:
@@ -395,19 +418,11 @@ class BenchmarkRunner(_ResultBookkeeping):
             return self._run_exploit_audit(tests)
         reference_mode = self.config.run.check_reference_solution
         self.environment.setup()
-        try:
+        with _graded_run(self._stream):
             if reference_mode:
                 self._run_reference_solution_tests(tests)
             else:
                 self._run_execution_tests(tests)
-        except TestError as e:
-            print_test_error(e)
-            raise SystemExit(1) from e
-        except KeyboardInterrupt:
-            print_abort_message()
-            raise SystemExit(130) from None
-        finally:
-            self._stream.close()
         summary = self.aggregator.finalize()
         model_config = self.config.model.model_dump(mode="json") if self.config.model else None
         payload = {
@@ -573,16 +588,8 @@ class BenchmarkRunner(_ResultBookkeeping):
         when any test is exploitable, mirroring reference-solution mode.
         """
         self.environment.setup()
-        try:
+        with _graded_run(self._stream):
             self._run_exploit_audit_tests(tests)
-        except TestError as e:
-            print_test_error(e)
-            raise SystemExit(1) from e
-        except KeyboardInterrupt:
-            print_abort_message()
-            raise SystemExit(130) from None
-        finally:
-            self._stream.close()
 
         exploitable = [record for record in self.records if record["exploitable"]]
         auditable = sum(1 for record in self.records if record["candidates_tried"] > 0)
@@ -875,7 +882,7 @@ class MultiModelRunner:
             )
         self.environment.setup()
 
-        try:
+        with _graded_run(self._stream):
             for model_config in models:
                 for variant in self.variants:
                     display_name = f"{model_config.name}{variant.label_suffix}"
@@ -893,14 +900,6 @@ class MultiModelRunner:
                     result["base_model"] = model_config.name
                     result["variant"] = variant.payload_info()
                     self.results[display_name] = result
-        except TestError as e:
-            print_test_error(e)
-            raise SystemExit(1) from e
-        except KeyboardInterrupt:
-            print_abort_message()
-            raise SystemExit(130) from None
-        finally:
-            self._stream.close()
 
         print_comparison_table(self.results)
         print_skill_impact(self.results)

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import threading
 import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timezone
 from typing import Any
 
 import orjson
@@ -46,7 +45,7 @@ from .records import (
     execution_record_passed,
     sort_records,
 )
-from .results_io import RecordStream, open_stream, timestamped_path
+from .results_io import RecordStream, open_run_artifacts
 from .scoring import SCORING_VERSION, ScoreAggregator, UsageAggregator
 from .selection import select_tests
 from .skills import BASELINE_VARIANT, LoadedSkill, Variant, build_variants
@@ -352,8 +351,7 @@ class BenchmarkRunner:
         self.usage_aggregator = UsageAggregator()
         self.records: list[dict[str, Any]] = []
         self._lock = threading.Lock()
-        self._started_at = datetime.now(timezone.utc)
-        self._stream = open_stream(config.output.jsonl_path, self._started_at)
+        self._results_path, self._stream = open_run_artifacts(config.output)
 
     def run(self) -> dict[str, Any]:
         """Execute the full benchmark pipeline.
@@ -424,6 +422,15 @@ class BenchmarkRunner:
                 raise SystemExit(1)
         return payload
 
+    def _on_result(self, result: dict[str, Any]) -> None:
+        """Aggregate a finished record, keep it, and stream it to disk."""
+        with self._lock:
+            if result.get("error") is None:
+                self.aggregator.add_execution(result["scores"])
+            self.usage_aggregator.add(result.get("usage"))
+            self.records.append(result)
+            self._stream.write(result)
+
     def _run_execution_tests(self, tests: list[ExecutionTest]) -> None:
         """Run code generation execution tests in parallel.
 
@@ -482,14 +489,6 @@ class BenchmarkRunner:
             except Exception as e:
                 raise TestError(test.id, e) from e
 
-        def on_result(result: dict[str, Any]) -> None:
-            with self._lock:
-                if result.get("error") is None:
-                    self.aggregator.add_execution(result["scores"])
-                self.usage_aggregator.add(result.get("usage"))
-                self.records.append(result)
-                self._stream.write(result)
-
         def on_error(test: ExecutionTest, error: TestError) -> dict[str, Any]:
             return _error_record(test, error, mode="model", model_config=self.config.model)
 
@@ -498,7 +497,7 @@ class BenchmarkRunner:
             config=self.config,
             environment=self.environment,
             process_test=process_test,
-            on_result=on_result,
+            on_result=self._on_result,
             on_error=on_error,
             progress_label="Execution",
         )
@@ -539,14 +538,6 @@ class BenchmarkRunner:
             except Exception as e:
                 raise TestError(test.id, e) from e
 
-        def on_result(result: dict[str, Any]) -> None:
-            with self._lock:
-                if result.get("error") is None:
-                    self.aggregator.add_execution(result["scores"])
-                self.usage_aggregator.add(result.get("usage"))
-                self.records.append(result)
-                self._stream.write(result)
-
         def on_error(test: ExecutionTest, error: TestError) -> dict[str, Any]:
             return _error_record(test, error, mode="reference_solution", model_config=None)
 
@@ -555,7 +546,7 @@ class BenchmarkRunner:
             config=self.config,
             environment=self.environment,
             process_test=process_test,
-            on_result=on_result,
+            on_result=self._on_result,
             on_error=on_error,
             progress_label="Reference solutions",
         )
@@ -821,10 +812,9 @@ class BenchmarkRunner:
         Args:
             payload: Complete results dict with metadata and test records.
         """
-        output_path = timestamped_path(self.config.output.path, self._started_at)
-        ensure_dir(output_path.parent)
-        output_path.write_bytes(orjson.dumps(payload, option=orjson.OPT_INDENT_2))
-        print_results_path(output_path)
+        ensure_dir(self._results_path.parent)
+        self._results_path.write_bytes(orjson.dumps(payload, option=orjson.OPT_INDENT_2))
+        print_results_path(self._results_path)
         self._stream.finalize(payload["results"])
 
 
@@ -850,8 +840,7 @@ class MultiModelRunner:
         self.skills = skills or []
         self.variants = build_variants(self.skills, skills_only=config.skills.only)
         self.results: dict[str, dict[str, Any]] = {}
-        self._started_at = datetime.now(timezone.utc)
-        self._stream = open_stream(config.output.jsonl_path, self._started_at)
+        self._results_path, self._stream = open_run_artifacts(config.output)
 
     def run(self) -> dict[str, Any]:
         """Execute benchmarks for all configured (model x variant) passes.
@@ -968,10 +957,9 @@ class MultiModelRunner:
                 for name, result in self.results.items()
             },
         }
-        output_path = timestamped_path(self.config.output.path, self._started_at)
-        ensure_dir(output_path.parent)
-        output_path.write_bytes(orjson.dumps(payload, option=orjson.OPT_INDENT_2))
-        print_results_path(output_path)
+        ensure_dir(self._results_path.parent)
+        self._results_path.write_bytes(orjson.dumps(payload, option=orjson.OPT_INDENT_2))
+        print_results_path(self._results_path)
         records = [record for result in self.results.values() for record in result["results"]]
         self._stream.finalize(sort_records(records))
 
@@ -1030,6 +1018,15 @@ class SingleModelRunner:
             "results": sort_records(self.records),
         }
 
+    def _on_result(self, result: dict[str, Any]) -> None:
+        """Aggregate a finished record, keep it, and stream it to disk."""
+        with self._lock:
+            if result.get("error") is None:
+                self.aggregator.add_execution(result["scores"])
+            self.usage_aggregator.add(result.get("usage"))
+            self.records.append(result)
+            self._stream.write(result)
+
     def _run_execution_tests(self, tests: list[ExecutionTest]) -> None:
         """Run execution tests with isolation. See BenchmarkRunner._run_execution_tests."""
         tests_to_run = select_run_tests(tests, self.config)
@@ -1080,14 +1077,6 @@ class SingleModelRunner:
             except Exception as e:
                 raise TestError(test.id, e) from e
 
-        def on_result(result: dict[str, Any]) -> None:
-            with self._lock:
-                if result.get("error") is None:
-                    self.aggregator.add_execution(result["scores"])
-                self.usage_aggregator.add(result.get("usage"))
-                self.records.append(result)
-                self._stream.write(result)
-
         def on_error(test: ExecutionTest, error: TestError) -> dict[str, Any]:
             return _error_record(
                 test, error, mode="model", model_config=self.model_config, variant=variant_info
@@ -1098,7 +1087,7 @@ class SingleModelRunner:
             config=self.config,
             environment=self.environment,
             process_test=process_test,
-            on_result=on_result,
+            on_result=self._on_result,
             on_error=on_error,
             progress_label="Execution",
         )

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -5,7 +5,6 @@ import threading
 import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any
 
 import orjson
@@ -47,6 +46,7 @@ from .records import (
     execution_record_passed,
     sort_records,
 )
+from .results_io import RecordStream, open_stream, timestamped_path
 from .scoring import SCORING_VERSION, ScoreAggregator, UsageAggregator
 from .selection import select_tests
 from .skills import BASELINE_VARIANT, LoadedSkill, Variant, build_variants
@@ -61,12 +61,6 @@ class TestError(Exception):
         self.original_error = original_error
         self.traceback_str = traceback.format_exc()
         super().__init__(str(original_error))
-
-
-def _timestamped_path(path: Path) -> Path:
-    """Add timestamp to filename: results.json -> results_20231216_143052.json"""
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    return path.parent / f"{path.stem}_{timestamp}{path.suffix}"
 
 
 def select_run_tests(tests: list[Any], config: HarnessConfig) -> list[Any]:
@@ -358,6 +352,8 @@ class BenchmarkRunner:
         self.usage_aggregator = UsageAggregator()
         self.records: list[dict[str, Any]] = []
         self._lock = threading.Lock()
+        self._started_at = datetime.now(timezone.utc)
+        self._stream = open_stream(config.output.jsonl_path, self._started_at)
 
     def run(self) -> dict[str, Any]:
         """Execute the full benchmark pipeline.
@@ -392,6 +388,8 @@ class BenchmarkRunner:
         except KeyboardInterrupt:
             print_abort_message()
             raise SystemExit(130) from None
+        finally:
+            self._stream.close()
         summary = self.aggregator.finalize()
         model_config = self.config.model.model_dump(mode="json") if self.config.model else None
         payload = {
@@ -490,6 +488,7 @@ class BenchmarkRunner:
                     self.aggregator.add_execution(result["scores"])
                 self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
+                self._stream.write(result)
 
         def on_error(test: ExecutionTest, error: TestError) -> dict[str, Any]:
             return _error_record(test, error, mode="model", model_config=self.config.model)
@@ -546,6 +545,7 @@ class BenchmarkRunner:
                     self.aggregator.add_execution(result["scores"])
                 self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
+                self._stream.write(result)
 
         def on_error(test: ExecutionTest, error: TestError) -> dict[str, Any]:
             return _error_record(test, error, mode="reference_solution", model_config=None)
@@ -579,6 +579,8 @@ class BenchmarkRunner:
         except KeyboardInterrupt:
             print_abort_message()
             raise SystemExit(130) from None
+        finally:
+            self._stream.close()
 
         exploitable = [record for record in self.records if record["exploitable"]]
         auditable = sum(1 for record in self.records if record["candidates_tried"] > 0)
@@ -632,6 +634,7 @@ class BenchmarkRunner:
                 )
                 with self._lock:
                     self.records.append(record)
+                    self._stream.write(record)
                 progress.update(task, advance=1)
 
     def _first_passing_exploit(
@@ -818,17 +821,11 @@ class BenchmarkRunner:
         Args:
             payload: Complete results dict with metadata and test records.
         """
-        output_path = _timestamped_path(self.config.output.path)
+        output_path = timestamped_path(self.config.output.path, self._started_at)
         ensure_dir(output_path.parent)
         output_path.write_bytes(orjson.dumps(payload, option=orjson.OPT_INDENT_2))
         print_results_path(output_path)
-        if self.config.output.jsonl_path:
-            jsonl_path = _timestamped_path(self.config.output.jsonl_path)
-            ensure_dir(jsonl_path.parent)
-            with jsonl_path.open("w", encoding="utf-8") as handle:
-                for record in payload["results"]:
-                    handle.write(orjson.dumps(record).decode("utf-8"))
-                    handle.write("\n")
+        self._stream.finalize(payload["results"])
 
 
 class MultiModelRunner:
@@ -853,6 +850,8 @@ class MultiModelRunner:
         self.skills = skills or []
         self.variants = build_variants(self.skills, skills_only=config.skills.only)
         self.results: dict[str, dict[str, Any]] = {}
+        self._started_at = datetime.now(timezone.utc)
+        self._stream = open_stream(config.output.jsonl_path, self._started_at)
 
     def run(self) -> dict[str, Any]:
         """Execute benchmarks for all configured (model x variant) passes.
@@ -889,6 +888,7 @@ class MultiModelRunner:
                         environment=self.environment,
                         tests=tests,
                         variant=variant,
+                        stream=self._stream,
                     )
                     result = runner.run()
                     result["base_model"] = model_config.name
@@ -900,6 +900,8 @@ class MultiModelRunner:
         except KeyboardInterrupt:
             print_abort_message()
             raise SystemExit(130) from None
+        finally:
+            self._stream.close()
 
         print_comparison_table(self.results)
         print_skill_impact(self.results)
@@ -966,10 +968,12 @@ class MultiModelRunner:
                 for name, result in self.results.items()
             },
         }
-        output_path = _timestamped_path(self.config.output.path)
+        output_path = timestamped_path(self.config.output.path, self._started_at)
         ensure_dir(output_path.parent)
         output_path.write_bytes(orjson.dumps(payload, option=orjson.OPT_INDENT_2))
         print_results_path(output_path)
+        records = [record for result in self.results.values() for record in result["results"]]
+        self._stream.finalize(sort_records(records))
 
 
 class SingleModelRunner:
@@ -986,6 +990,7 @@ class SingleModelRunner:
         environment: WordPressEnvironment,
         tests: list[ExecutionTest],
         variant: Variant = BASELINE_VARIANT,
+        stream: RecordStream | None = None,
     ):
         """Initialize runner for a specific model.
 
@@ -996,6 +1001,9 @@ class SingleModelRunner:
             tests: Pre-loaded execution tests.
             variant: Which pass of the run matrix this is (baseline or
                 skills); carries the system prompt to inject, if any.
+            stream: Shared record stream; every pass's records land in the
+                one JSONL, tagged by the model and variant on each record.
+                Omitted (tests, ad-hoc use) means no streaming.
         """
         self.config = config
         self.model_config = model_config
@@ -1003,10 +1011,7 @@ class SingleModelRunner:
         self.model = ModelInterface(model_config, system_prompt=variant.system_prompt)
         self.environment = environment
         self.tests = tests
-        self.aggregator = ScoreAggregator()
-        self.usage_aggregator = UsageAggregator()
-        self.records: list[dict[str, Any]] = []
-        self._lock = threading.Lock()
+        self._init_bookkeeping(stream or RecordStream(None))
 
     def run(self) -> dict[str, Any]:
         """Run all tests and return scores for this model.
@@ -1081,6 +1086,7 @@ class SingleModelRunner:
                     self.aggregator.add_execution(result["scores"])
                 self.usage_aggregator.add(result.get("usage"))
                 self.records.append(result)
+                self._stream.write(result)
 
         def on_error(test: ExecutionTest, error: TestError) -> dict[str, Any]:
             return _error_record(

--- a/python/wp_bench/results_io.py
+++ b/python/wp_bench/results_io.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import IO, Any
+from typing import Any, Self
 
 import orjson
 
@@ -59,31 +59,47 @@ class RecordStream:
     def __init__(self, path: Path | None):
         self.path = path
         self.partial_path = path.with_suffix(path.suffix + ".partial") if path else None
-        self._handle: IO[bytes] | None = None
+        self._fd: int | None = None
         self._written = 0
 
-    def write(self, record: dict[str, Any]) -> None:
-        """Append one record and flush, so ``tail -f`` shows live progress.
+    def __enter__(self) -> Self:
+        return self
 
-        Flush, not fsync: the threat model is process death (crash, quota,
-        Ctrl-C, OOM kill), where handing bytes to the OS is enough. Opened
-        for append so reopening after a close can never discard what an
-        earlier handle already wrote.
+    def __exit__(self, *exc_info: object) -> None:
+        """Release the descriptor however the run ends.
+
+        Owning the lifecycle here is what keeps every run mode from having
+        to re-thread its own close on each crash path.
+        """
+        self.close()
+
+    def write(self, record: dict[str, Any]) -> None:
+        """Append one record, so ``tail -f`` shows live progress.
+
+        Each record goes out as one unbuffered ``os.write`` to an O_APPEND
+        descriptor. Records embed whole completions and generated code, so
+        they routinely exceed a stream buffer; a buffered write plus flush
+        would let a kill land between the underlying syscalls and truncate
+        a line mid-record. Readers of a live file should still tolerate a
+        short final line: only the process that dies mid-write can leave
+        one, and the records before it stay valid.
+
+        No fsync: the threat model is process death (crash, quota, Ctrl-C,
+        OOM kill), where handing the bytes to the OS is enough.
         """
         if self.partial_path is None:
             return
-        if self._handle is None:
+        if self._fd is None:
             ensure_dir(self.partial_path.parent)
-            self._handle = self.partial_path.open("ab")
-        self._handle.write(_line(record))
-        self._handle.flush()
+            self._fd = os.open(self.partial_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        os.write(self._fd, _line(record))
         self._written += 1
 
     def close(self) -> None:
-        """Release the handle; safe to call on crash paths and twice."""
-        if self._handle is not None:
-            self._handle.close()
-            self._handle = None
+        """Release the descriptor; safe to call on crash paths and twice."""
+        if self._fd is not None:
+            os.close(self._fd)
+            self._fd = None
 
     def finalize(self, records: list[dict[str, Any]]) -> None:
         """Write the canonical artifact and retire the live file.
@@ -110,9 +126,28 @@ class RecordStream:
         except BaseException:
             tmp.unlink(missing_ok=True)
             raise
-        os.replace(tmp, self.path)
         if len(records) >= self._written:
+            # Retire the live file first: a crash between these two steps
+            # can then only lose the duplicate, never leave a ".partial"
+            # sitting next to a finished artifact and lying about it.
             self.partial_path.unlink(missing_ok=True)
+        os.replace(tmp, self.path)
+
+
+def write_results_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write a run's results JSON atomically.
+
+    Staged and moved into place like the JSONL, so a kill mid-write cannot
+    leave a truncated results file that parses as valid JSON to nobody.
+    """
+    ensure_dir(path.parent)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_bytes(orjson.dumps(payload, option=orjson.OPT_INDENT_2))
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    os.replace(tmp, path)
 
 
 def open_stream(jsonl_path: Path | None, moment: datetime) -> RecordStream:
@@ -128,4 +163,31 @@ def open_run_artifacts(output: OutputConfig) -> tuple[Path, RecordStream]:
     call sites.
     """
     moment = datetime.now(timezone.utc)
-    return timestamped_path(output.path, moment), open_stream(output.jsonl_path, moment)
+    json_path = timestamped_path(output.path, moment)
+    stream = open_stream(output.jsonl_path, moment)
+    suffix = 2
+    while _artifacts_taken(json_path, stream):
+        # Second granularity, so a sweep script or a supervisor restart can
+        # launch two runs into the same names; they would then append into
+        # one .partial and clobber each other at finalize.
+        json_path = _suffixed(timestamped_path(output.path, moment), suffix)
+        stream = RecordStream(
+            _suffixed(timestamped_path(output.jsonl_path, moment), suffix)
+            if output.jsonl_path
+            else None
+        )
+        suffix += 1
+    return json_path, stream
+
+
+def _suffixed(path: Path, suffix: int) -> Path:
+    return path.parent / f"{path.stem}-{suffix}{path.suffix}"
+
+
+def _artifacts_taken(json_path: Path, stream: RecordStream) -> bool:
+    """Whether another run already owns either of this run's filenames."""
+    if json_path.exists():
+        return True
+    return bool(
+        stream.path and (stream.path.exists() or (stream.partial_path and stream.partial_path.exists()))
+    )

--- a/python/wp_bench/results_io.py
+++ b/python/wp_bench/results_io.py
@@ -13,16 +13,18 @@ from typing import IO, Any
 
 import orjson
 
+from .config import OutputConfig
 from .utils import ensure_dir
 
 
-def timestamped_path(path: Path, moment: datetime | None = None) -> Path:
+def timestamped_path(path: Path, moment: datetime) -> Path:
     """Add a timestamp to a filename: results.json -> results_20231216_143052.json
 
-    Runners pass their start time so every artifact of one run (results
-    JSON, streamed JSONL) shares a single timestamp.
+    The moment is required so every artifact of one run (results JSON,
+    streamed JSONL) shares a single timestamp; ``open_run_artifacts``
+    captures it once for both.
     """
-    timestamp = (moment or datetime.now(timezone.utc)).strftime("%Y%m%d_%H%M%S")
+    timestamp = moment.strftime("%Y%m%d_%H%M%S")
     return path.parent / f"{path.stem}_{timestamp}{path.suffix}"
 
 
@@ -32,7 +34,7 @@ def _line(record: dict[str, Any]) -> bytes:
 
 
 class RecordStream:
-    """Appends canonical records to the JSONL file as tests complete.
+    """Streams canonical records to disk as tests complete.
 
     Results are otherwise durable only once a run finishes, so a crash
     hours in (dead runtime, exhausted provider quota, Ctrl-C) discards
@@ -40,8 +42,13 @@ class RecordStream:
     records the finished file holds, so a partial run stays readable by
     the notebook, the export tooling, and anything else consuming results.
 
+    Live records go to ``<artifact>.partial``; ``finalize`` writes the
+    canonical artifact and drops the partial. A crashed run therefore
+    leaves a file whose name says it is incomplete, so nobody computes a
+    suite score from half a run.
+
     The file opens on the first record, so a run that fails before
-    grading anything leaves no empty artifact behind.
+    grading anything leaves no artifact behind at all.
 
     Threading: callers write under their own lock; the handle is not
     itself thread-safe. ``MultiModelRunner`` shares one stream across its
@@ -51,21 +58,26 @@ class RecordStream:
 
     def __init__(self, path: Path | None):
         self.path = path
+        self.partial_path = path.with_suffix(path.suffix + ".partial") if path else None
         self._handle: IO[bytes] | None = None
+        self._written = 0
 
     def write(self, record: dict[str, Any]) -> None:
         """Append one record and flush, so ``tail -f`` shows live progress.
 
         Flush, not fsync: the threat model is process death (crash, quota,
-        Ctrl-C, OOM kill), where handing bytes to the OS is enough.
+        Ctrl-C, OOM kill), where handing bytes to the OS is enough. Opened
+        for append so reopening after a close can never discard what an
+        earlier handle already wrote.
         """
-        if self.path is None:
+        if self.partial_path is None:
             return
         if self._handle is None:
-            ensure_dir(self.path.parent)
-            self._handle = self.path.open("wb")
+            ensure_dir(self.partial_path.parent)
+            self._handle = self.partial_path.open("ab")
         self._handle.write(_line(record))
         self._handle.flush()
+        self._written += 1
 
     def close(self) -> None:
         """Release the handle; safe to call on crash paths and twice."""
@@ -74,30 +86,46 @@ class RecordStream:
             self._handle = None
 
     def finalize(self, records: list[dict[str, Any]]) -> None:
-        """Replace the streamed file with the canonical ordered records.
+        """Write the canonical artifact and retire the live file.
 
-        In flight the file grows in completion order so it can be tailed;
-        the finished artifact carries the run's canonical order, keeping
-        result diffs stable. The replacement is written beside the live
-        file and moved into place, so an interrupted finalize can never
-        destroy the streamed records it is replacing.
+        The artifact is staged beside its destination and moved into
+        place, so an interrupted finalize leaves no half-written results.
+        The partial is removed only once the artifact demonstrably covers
+        it: a caller that finalizes with fewer records than were streamed
+        has lost track of some, and keeping the partial keeps them
+        recoverable instead of deleting them.
 
         No records means no artifact, the same invariant ``write`` keeps by
-        opening lazily; leaving a streamed file untouched also beats
-        truncating it, should a caller ever finalize with less than it
-        streamed.
+        opening lazily.
         """
         self.close()
-        if self.path is None or not records:
+        if self.path is None or self.partial_path is None or not records:
             return
         ensure_dir(self.path.parent)
         tmp = self.path.with_suffix(self.path.suffix + ".tmp")
-        with tmp.open("wb") as handle:
-            for record in records:
-                handle.write(_line(record))
+        try:
+            with tmp.open("wb") as handle:
+                for record in records:
+                    handle.write(_line(record))
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
         os.replace(tmp, self.path)
+        if len(records) >= self._written:
+            self.partial_path.unlink(missing_ok=True)
 
 
 def open_stream(jsonl_path: Path | None, moment: datetime) -> RecordStream:
     """The run's record stream, timestamped to match its JSON artifact."""
     return RecordStream(timestamped_path(jsonl_path, moment) if jsonl_path else None)
+
+
+def open_run_artifacts(output: OutputConfig) -> tuple[Path, RecordStream]:
+    """The run's results-JSON path and record stream, stamped with one moment.
+
+    Capturing the timestamp here makes the artifacts correlate by filename
+    by construction, instead of every runner threading a start time to two
+    call sites.
+    """
+    moment = datetime.now(timezone.utc)
+    return timestamped_path(output.path, moment), open_stream(output.jsonl_path, moment)

--- a/python/wp_bench/results_io.py
+++ b/python/wp_bench/results_io.py
@@ -1,0 +1,103 @@
+"""Durable result artifacts: timestamped paths and streamed records.
+
+Persistence, deliberately kept out of the orchestrator: ``records.py``
+owns record *shape* and stays pure in-memory, ``output.py`` renders to the
+console, and this module is the only place that turns records into files.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import IO, Any
+
+import orjson
+
+from .utils import ensure_dir
+
+
+def timestamped_path(path: Path, moment: datetime | None = None) -> Path:
+    """Add a timestamp to a filename: results.json -> results_20231216_143052.json
+
+    Runners pass their start time so every artifact of one run (results
+    JSON, streamed JSONL) shares a single timestamp.
+    """
+    timestamp = (moment or datetime.now(timezone.utc)).strftime("%Y%m%d_%H%M%S")
+    return path.parent / f"{path.stem}_{timestamp}{path.suffix}"
+
+
+def _line(record: dict[str, Any]) -> bytes:
+    """One JSONL line, the single serialization used by live and final writes."""
+    return orjson.dumps(record) + b"\n"
+
+
+class RecordStream:
+    """Appends canonical records to the JSONL file as tests complete.
+
+    Results are otherwise durable only once a run finishes, so a crash
+    hours in (dead runtime, exhausted provider quota, Ctrl-C) discards
+    every test graded so far. Streamed lines are the same canonical
+    records the finished file holds, so a partial run stays readable by
+    the notebook, the export tooling, and anything else consuming results.
+
+    The file opens on the first record, so a run that fails before
+    grading anything leaves no empty artifact behind.
+
+    Threading: callers write under their own lock; the handle is not
+    itself thread-safe. ``MultiModelRunner`` shares one stream across its
+    per-model runners, which hold separate locks -- safe only because
+    models run sequentially.
+    """
+
+    def __init__(self, path: Path | None):
+        self.path = path
+        self._handle: IO[bytes] | None = None
+
+    def write(self, record: dict[str, Any]) -> None:
+        """Append one record and flush, so ``tail -f`` shows live progress.
+
+        Flush, not fsync: the threat model is process death (crash, quota,
+        Ctrl-C, OOM kill), where handing bytes to the OS is enough.
+        """
+        if self.path is None:
+            return
+        if self._handle is None:
+            ensure_dir(self.path.parent)
+            self._handle = self.path.open("wb")
+        self._handle.write(_line(record))
+        self._handle.flush()
+
+    def close(self) -> None:
+        """Release the handle; safe to call on crash paths and twice."""
+        if self._handle is not None:
+            self._handle.close()
+            self._handle = None
+
+    def finalize(self, records: list[dict[str, Any]]) -> None:
+        """Replace the streamed file with the canonical ordered records.
+
+        In flight the file grows in completion order so it can be tailed;
+        the finished artifact carries the run's canonical order, keeping
+        result diffs stable. The replacement is written beside the live
+        file and moved into place, so an interrupted finalize can never
+        destroy the streamed records it is replacing.
+
+        No records means no artifact, the same invariant ``write`` keeps by
+        opening lazily; leaving a streamed file untouched also beats
+        truncating it, should a caller ever finalize with less than it
+        streamed.
+        """
+        self.close()
+        if self.path is None or not records:
+            return
+        ensure_dir(self.path.parent)
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        with tmp.open("wb") as handle:
+            for record in records:
+                handle.write(_line(record))
+        os.replace(tmp, self.path)
+
+
+def open_stream(jsonl_path: Path | None, moment: datetime) -> RecordStream:
+    """The run's record stream, timestamped to match its JSON artifact."""
+    return RecordStream(timestamped_path(jsonl_path, moment) if jsonl_path else None)


### PR DESCRIPTION
## What

Results are written only when a run finishes, so a crash hours in discards every test graded so far. That isn't hypothetical — it cost us twice this week:

- a full multi-model run died to a wedged Docker at ~66% (≈3h of grading lost)
- the rerun died to an exhausted provider quota (everything lost again)

Each canonical record is now appended to the run's JSONL and flushed as it completes. A partial run stays readable by the notebook, the export tooling, and anything else that consumes results.

## Design

- **New `results_io.py`** owns artifact persistence: `RecordStream`, its `finalize`, and `timestamped_path`. `core.py` orchestrates, `records.py` stays pure in-memory, `output.py` renders to console — persistence had no home, so it lived in the orchestrator.
- **Lazy open**: the file appears on the first record, so a run that fails before grading anything leaves no empty artifact.
- **Atomic finalize**: the canonical rewrite is staged beside the live file and moved into place, so an interrupted finalize cannot destroy the streamed records it replaces. **The finished artifact is byte-identical to what the old end-of-run write produced** — the resilience is purely additive.
- **Multi-model gains a JSONL it never had**, shared across its per-model runners (safe because models run sequentially; every record carries its model). Called out explicitly rather than landing as an invisible side effect: for a crashed multi-model run this is now the *only* surviving artifact, since the combined JSON is assembled after the last model finishes. `OutputConfig.jsonl_path` already defaulted to `results.jsonl` and the README already promised per-test JSONL, so multi-model silently ignoring it was the gap.
- **The exploit audit streams too.** It appends records inline rather than through `on_result`, so it was the easy one to miss — and it's the slowest path in the harness (serial, with a runtime reset per candidate).
- **One timestamp per run**: artifacts now correlate by name instead of by luck (previously both paths were computed independently at write time).
- Runners close the handle on the crash paths as well.

**Flush, not fsync**: the threat model is process death (dead runtime, quota, Ctrl-C, OOM kill), where handing bytes to the OS is sufficient. Cost is microseconds against a ~2s DB reset per test.

## Supersedes #18

[#18](https://github.com/WordPress/wp-bench/pull/18) identified this gap in January. Its implementation can't be rebased — it was written against a pre-#24 `core.py` that no longer exists, and half its integration points are the knowledge-test flows #48 removes. Most of what it logged now exists as first-class data anyway: per-test duration in `usage.latency_ms` (#33), per-test errors as canonical records plus `errored_test_ids` (#40), and a progress display in `output.py`. A separate log format would be a second source of truth for data the records already carry — and unlike a log, a partial JSONL is directly scoreable.

Jonathan is credited as co-author; the diagnosis was his.

## Verification

- 163 tests (8 new), `ruff`, `mypy` clean
- Live against the WP 7.0 runtime: records confirmed appearing on disk **mid-run** (1 → 2 → 4 → 5), final artifact correctly ordered, JSON and JSONL sharing one timestamp, and the exploit audit persisting its records
- Both review angles that shaped this found real defects first: a truncation window in `finalize` and the missing exploit-audit write

🤖 Generated with [Claude Code](https://claude.com/claude-code)