### PR TITLE
feat: add skill-injection A/B runs (--skill) with in-run baseline comparison

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This guide is the fastest path to contributing to WP-Bench. Keep changes minimal
 - Create a venv and install the harness: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ./python`.
 - Install dev tooling: `pip install -e ./python[dev]` (adds `pytest`, `ruff`, `mypy`).
 - Run the benchmark locally: `wp-bench run --config python/wp-bench.example.yaml`.
+- Skills A/B run (baseline vs with-skills, see README): `wp-bench run --skill <path-to-skill>`.
 - Lint: `ruff python`.
 - Type check: `mypy python`.
 - Unit tests: `pytest python` (use `-k <pattern>` to scope).

--- a/README.md
+++ b/README.md
@@ -110,7 +110,31 @@ wp-bench run --test-id e-abilities-api-001 --test-id e-rest-api-001
 wp-bench run --config wp-bench.yaml --dry-run # validate config without calling models
 wp-bench run --check-reference-solution      # verify reference solutions pass
 wp-bench run --check-exploits                # adversarial assertion audit (see below)
+wp-bench run --skill /path/to/skill          # skills A/B run (see below)
 ```
+
+### Skills A/B comparison
+
+To measure how much an agent skill improves model scores, pass one or more
+skills with `--skill` (a directory containing `SKILL.md`, or a bare `.md`
+file — e.g. from [WordPress/agent-skills](https://github.com/WordPress/agent-skills)).
+Every model then runs **both** a baseline pass and a with-skills pass over the
+identical seeded test subset; the skill content is injected as a system
+message, the user prompt stays byte-identical, and the comparison table gains
+a `Δ skills` row per model showing the score, cost, and latency deltas.
+
+```bash
+wp-bench run --config wp-bench.yaml --limit 10 \
+  --skill ../agent-skills/skills/wp-plugin-development
+```
+
+By default each skill's `references/*.md` files are inlined into the injected
+content (the run is single-shot, so the model cannot follow SKILL.md's file
+pointers on its own); disable with `--no-skills-include-references`.
+`--skills-only` skips the baseline pass. The equivalent config block is
+`skills:` (see `wp-bench.example.yaml`). Run metadata records each skill's
+name, source path, and content hash so results stay attributable to the exact
+skill version measured.
 
 ### Adversarial assertion audit
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Every model then runs **both** a baseline pass and a with-skills pass over the
 identical seeded test subset; the skill content is injected as a system
 message, the user prompt stays byte-identical, and the comparison table gains
 a `Δ skills` row per model showing the score, cost, and latency deltas.
+A per-test "Skill Impact" table follows, listing every test the skill fixed,
+broke, or moved (runtime-score shifts on still-failing tests), plus the tests
+still failing in both variants — the skill's next targets.
 
 ```bash
 wp-bench run --config wp-bench.yaml --limit 10 \

--- a/python/tests/test_config_validation.py
+++ b/python/tests/test_config_validation.py
@@ -7,7 +7,13 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from wp_bench.config import GraderConfig, HarnessConfig, ModelConfig, RunConfig, SkillsConfig
+from wp_bench.config import (
+    GraderConfig,
+    HarnessConfig,
+    ModelConfig,
+    RunConfig,
+    SkillsConfig,
+)
 
 
 def test_model_config_rejects_temperature_below_zero() -> None:

--- a/python/tests/test_config_validation.py
+++ b/python/tests/test_config_validation.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 import warnings
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
 
-from wp_bench.config import GraderConfig, HarnessConfig, ModelConfig, RunConfig
+from wp_bench.config import GraderConfig, HarnessConfig, ModelConfig, RunConfig, SkillsConfig
 
 
 def test_model_config_rejects_temperature_below_zero() -> None:
@@ -54,6 +55,36 @@ def test_grader_config_rejects_nonpositive_timeouts() -> None:
         GraderConfig(timeout_seconds=0)
     with pytest.raises(ValidationError):
         GraderConfig(setup_timeout_seconds=-1)
+
+
+def test_skills_config_defaults() -> None:
+    skills = HarnessConfig().skills
+    assert skills.paths == []
+    assert skills.include_references is True
+    assert skills.only is False
+
+
+def test_skills_config_rejects_only_without_paths() -> None:
+    with pytest.raises(ValidationError, match="skills.only requires skills.paths"):
+        SkillsConfig(only=True)
+
+
+def test_skills_config_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        SkillsConfig(mode="agentic")  # type: ignore[call-arg]
+
+
+def test_from_file_resolves_relative_skill_paths(tmp_path: Path) -> None:
+    config_path = tmp_path / "wp-bench.yaml"
+    config_path.write_text(
+        "skills:\n  paths:\n    - skills/example\n    - /abs/skill\n",
+        encoding="utf-8",
+    )
+    config = HarnessConfig.from_file(config_path)
+    assert config.skills.paths == [
+        (tmp_path / "skills/example").resolve(),
+        Path("/abs/skill"),
+    ]
 
 
 def test_config_construction_emits_no_deprecation_warnings() -> None:

--- a/python/tests/test_execution_isolation.py
+++ b/python/tests/test_execution_isolation.py
@@ -143,7 +143,7 @@ def test_multi_model_runner_resets_between_models(
     runner.environment = spy  # type: ignore[assignment]
     monkeypatch.setattr(
         "wp_bench.core.ModelInterface",
-        lambda model_config: type(
+        lambda model_config, system_prompt=None: type(
             "FakeModel",
             (),
             {"generate_with_metadata": staticmethod(lambda prompt: fake_generation("```php\ncode\n```"))},

--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -45,6 +45,21 @@ def test_generate_normalizes_none_content_to_empty_string(monkeypatch) -> None:
     assert result.text == ""
 
 
+def test_completion_kwargs_omit_system_message_by_default() -> None:
+    model = ModelInterface(ModelConfig(name="gpt-4o-mini"))
+    messages = model._completion_kwargs("hello")["messages"]
+    assert messages == [{"role": "user", "content": "hello"}]
+
+
+def test_completion_kwargs_prepend_system_prompt_when_set() -> None:
+    model = ModelInterface(ModelConfig(name="gpt-4o-mini"), system_prompt="Skill content.")
+    messages = model._completion_kwargs("hello")["messages"]
+    assert messages == [
+        {"role": "system", "content": "Skill content."},
+        {"role": "user", "content": "hello"},
+    ]
+
+
 def test_generate_does_not_retry_other_bad_request_errors(monkeypatch) -> None:
     def fake_completion(**kwargs):
         raise BadRequestError(

--- a/python/tests/test_result_schema.py
+++ b/python/tests/test_result_schema.py
@@ -119,6 +119,19 @@ def test_single_and_multi_model_records_have_same_keys(
     )
 
 
+def test_all_records_carry_baseline_variant_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Non-skills runs stamp the baseline variant; variant.* paths never vary."""
+    for record in _single_model_records(monkeypatch, tmp_path):
+        assert record["variant"] == {
+            "key": "baseline",
+            "kind": "none",
+            "system_prompt_hash": None,
+        }
+
+
 def test_multi_model_execution_records_include_audit_fields(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/python/tests/test_skill_variants.py
+++ b/python/tests/test_skill_variants.py
@@ -139,7 +139,7 @@ def test_matrix_payload_contains_skills_metadata(
 ) -> None:
     _run_matrix(monkeypatch, tmp_path)
 
-    payload_path = sorted(tmp_path.glob("results_*.json"))[-1]
+    payload_path = max(tmp_path.glob("results_*.json"))
     payload = json.loads(payload_path.read_text())
 
     metadata = payload["metadata"]
@@ -291,9 +291,11 @@ def test_skill_impact_lists_flipped_and_still_failing_tests(
     assert "e-broken" in output and "broken by skill" in output
     # Runtime movement on a still-failing test is surfaced too.
     assert "e-partial" in output and "runtime 25% → 75%" in output
-    # Unchanged tests are summarized, naming the still-failing ones.
+    # Tests failing in both variants are rows, marked as still failing.
     assert "e-stuck" in output
-    assert "1 passing" in output
+    assert "still failing" in output
+    # Tests passing in both variants are only counted, never listed.
+    assert "Passing in both variants (not shown): 1" in output
     assert "e-fine" not in output
 
 

--- a/python/tests/test_skill_variants.py
+++ b/python/tests/test_skill_variants.py
@@ -1,0 +1,289 @@
+"""Integration tests for skill-injection A/B variant runs."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from conftest import fake_generation
+from typer.testing import CliRunner
+
+from wp_bench.cli import app
+from wp_bench.config import (
+    DatasetConfig,
+    GraderConfig,
+    HarnessConfig,
+    ModelConfig,
+    OutputConfig,
+    RunConfig,
+    SkillsConfig,
+)
+from wp_bench.core import MultiModelRunner
+from wp_bench.datasets import ExecutionTest
+from wp_bench.environment import ExecutionResult
+from wp_bench.output import print_comparison_table
+from wp_bench.skills import build_variants, load_skill
+
+
+def _execution_test(test_id: str = "e-one") -> ExecutionTest:
+    return ExecutionTest(
+        id=test_id,
+        suite="wp-core-v1",
+        prompt="Prompt",
+        expected_behavior="expected",
+        category="hooks",
+        difficulty="basic",
+        requirements=["Requirement"],
+        test_function=None,
+        static_checks={"required_patterns": [{"pattern": "code", "weight": 1}]},
+        runtime_checks={"assertions": [{"type": "custom_assertion", "code": "return true;", "weight": 1}]},
+        reference_solution="function ref() { return true; }",
+        metadata={},
+    )
+
+
+def _passing_result() -> ExecutionResult:
+    raw = {
+        "success": True,
+        "static": {"score": 1.0, "details": {"total_weight": 1}},
+        "runtime": {"score": 1.0, "details": {"total_weight": 1}},
+    }
+    return ExecutionResult(success=True, raw=raw, stdout="out", stderr="")
+
+
+class FakeEnvironment:
+    def setup(self) -> None: ...
+    def reset(self) -> None: ...
+
+    def execute_artifact(self, artifact: object, spec: dict) -> ExecutionResult:
+        return _passing_result()
+
+
+def _skill_dir(tmp_path: Path) -> Path:
+    skill = tmp_path / "wp-test-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: wp-test-skill\ndescription: Test skill.\n---\n\nGuidance body.",
+        encoding="utf-8",
+    )
+    return skill
+
+
+def _config(tmp_path: Path, skill_path: Path) -> HarnessConfig:
+    return HarnessConfig(
+        dataset=DatasetConfig(source="local", name="wp-core-v1"),
+        models=[ModelConfig(name="model-a")],
+        grader=GraderConfig(kind="cli"),
+        run=RunConfig(),
+        output=OutputConfig(path=tmp_path / "results.json", jsonl_path=None),
+        skills=SkillsConfig(paths=[skill_path]),
+    )
+
+
+def _run_matrix(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> tuple[MultiModelRunner, list[str | None]]:
+    """Run a 1-model skills A/B matrix; returns runner + captured system prompts."""
+    skill = load_skill(_skill_dir(tmp_path))
+    config = _config(tmp_path, Path(skill.source_path))
+
+    system_prompts: list[str | None] = []
+
+    class FakeModel:
+        def __init__(self, model_config: ModelConfig, system_prompt: str | None = None):
+            system_prompts.append(system_prompt)
+
+        def generate_with_metadata(self, prompt: str) -> Any:
+            return fake_generation("```php\ncode\n```")
+
+    monkeypatch.setattr("wp_bench.core.ModelInterface", FakeModel)
+    monkeypatch.setattr("wp_bench.core.load_tests", lambda dataset: [_execution_test()])
+
+    runner = MultiModelRunner(config, skills=[skill])
+    runner.environment = FakeEnvironment()  # type: ignore[assignment]
+    runner.run()
+    return runner, system_prompts
+
+
+def test_matrix_runs_baseline_and_skills_variants(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner, system_prompts = _run_matrix(monkeypatch, tmp_path)
+
+    assert list(runner.results.keys()) == ["model-a", "model-a+skills"]
+    # Baseline pass has no system prompt; skills pass injects the skill.
+    assert system_prompts[0] is None
+    assert system_prompts[1] is not None
+    assert "# Skill: wp-test-skill" in system_prompts[1]
+
+    baseline = runner.results["model-a"]
+    skilled = runner.results["model-a+skills"]
+    assert baseline["base_model"] == skilled["base_model"] == "model-a"
+    assert baseline["variant"]["key"] == "baseline"
+    assert skilled["variant"]["key"] == "skills"
+    assert skilled["variant"]["skills"] == ["wp-test-skill"]
+
+    # Same test, same user prompt: prompt_hash identical across variants.
+    base_record = baseline["results"][0]
+    skill_record = skilled["results"][0]
+    assert base_record["prompt_hash"] == skill_record["prompt_hash"]
+    assert base_record["variant"]["key"] == "baseline"
+    assert skill_record["variant"]["key"] == "skills"
+    assert skill_record["variant"]["system_prompt_hash"]
+    assert base_record["variant"].keys() == skill_record["variant"].keys()
+
+
+def test_matrix_payload_contains_skills_metadata(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _run_matrix(monkeypatch, tmp_path)
+
+    payload_path = sorted(tmp_path.glob("results_*.json"))[-1]
+    payload = json.loads(payload_path.read_text())
+
+    metadata = payload["metadata"]
+    assert metadata["variants"] == ["baseline", "skills"]
+    assert metadata["skills"]["enabled"] is True
+    assert metadata["skills"]["include_references"] is True
+    assert metadata["skills"]["system_prompt_sha256"]
+    (provenance,) = metadata["skills"]["skills"]
+    assert provenance["name"] == "wp-test-skill"
+    assert provenance["content_sha256"]
+
+    assert set(payload["models"]) == {"model-a", "model-a+skills"}
+    entry = payload["models"]["model-a+skills"]
+    assert entry["base_model"] == "model-a"
+    assert entry["variant"]["kind"] == "inject"
+
+
+def test_skills_only_skips_baseline(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    skill = load_skill(_skill_dir(tmp_path))
+    config = _config(tmp_path, Path(skill.source_path))
+    config.skills.only = True
+
+    monkeypatch.setattr(
+        "wp_bench.core.ModelInterface",
+        lambda model_config, system_prompt=None: type(
+            "FakeModel",
+            (),
+            {"generate_with_metadata": staticmethod(lambda prompt: fake_generation("```php\ncode\n```"))},
+        )(),
+    )
+    monkeypatch.setattr("wp_bench.core.load_tests", lambda dataset: [_execution_test()])
+
+    runner = MultiModelRunner(config, skills=[skill])
+    runner.environment = FakeEnvironment()  # type: ignore[assignment]
+    runner.run()
+
+    assert list(runner.results.keys()) == ["model-a+skills"]
+
+
+def test_duplicate_display_names_rejected(tmp_path: Path) -> None:
+    skill = load_skill(_skill_dir(tmp_path))
+    config = _config(tmp_path, Path(skill.source_path))
+    config.models = [ModelConfig(name="model-a"), ModelConfig(name="model-a")]
+
+    runner = MultiModelRunner(config, skills=[skill])
+    with pytest.raises(ValueError, match="Duplicate result keys"):
+        runner._ensure_unique_display_names(config.get_models())
+
+
+def test_comparison_table_renders_delta_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _entry(variant_key: str, pass_rate: float, cost: float) -> dict[str, Any]:
+        return {
+            "base_model": "model-a",
+            "variant": {"key": variant_key},
+            "scores": {
+                "execution_pass_rate": pass_rate,
+                "runtime": pass_rate,
+                "overall": pass_rate,
+            },
+            "usage": {"estimated_cost_usd": cost, "median_latency_ms": 100.0},
+        }
+
+    from rich.console import Console
+
+    recording_console = Console(record=True, width=200)
+    monkeypatch.setattr("wp_bench.output.console", recording_console)
+    print_comparison_table(
+        {
+            "model-a": _entry("baseline", 0.5, 0.01),
+            "model-a+skills": _entry("skills", 0.75, 0.03),
+        }
+    )
+    output = recording_console.export_text()
+    assert "model-a+skills" in output
+    assert "Δ skills" in output
+    assert "+25.0pp" in output
+
+
+def test_comparison_table_without_variants_unchanged(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    print_comparison_table(
+        {
+            "model-a": {
+                "scores": {"execution_pass_rate": 0.5, "runtime": 0.5, "overall": 0.5},
+                "usage": {},
+            }
+        }
+    )
+    output = capsys.readouterr().out
+    assert "model-a" in output
+    assert "Δ" not in output
+
+
+def test_build_variants_shares_selection_config(tmp_path: Path) -> None:
+    """Both variants come from one config: selection (seed/limit) is identical."""
+    skill = load_skill(_skill_dir(tmp_path))
+    variants = build_variants([skill])
+    assert [variant.key for variant in variants] == ["baseline", "skills"]
+    # Variants carry no test-selection state at all — only injection state.
+    assert {field for field in variants[0].__dataclass_fields__} == {
+        "key",
+        "kind",
+        "label_suffix",
+        "skills",
+        "system_prompt",
+    }
+
+
+def test_cli_routes_single_model_with_skill_to_multi_runner(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    skill_dir = _skill_dir(tmp_path)
+    captured: dict[str, Any] = {}
+
+    class FakeMultiRunner:
+        def __init__(self, config: HarnessConfig, skills: list[Any] | None = None):
+            captured["config"] = config
+            captured["skills"] = skills
+
+        def run(self) -> dict[str, Any]:
+            return {}
+
+    monkeypatch.setattr("wp_bench.cli.MultiModelRunner", FakeMultiRunner)
+
+    result = CliRunner().invoke(
+        app, ["run", "--model-name", "model-a", "--skill", str(skill_dir)]
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["config"].models == [ModelConfig(name="model-a")]
+    assert captured["config"].model is None
+    assert [loaded.name for loaded in captured["skills"]] == ["wp-test-skill"]
+
+
+def test_cli_rejects_skills_with_audit_modes(tmp_path: Path) -> None:
+    skill_dir = _skill_dir(tmp_path)
+    result = CliRunner().invoke(
+        app, ["run", "--skill", str(skill_dir), "--check-exploits"]
+    )
+    assert result.exit_code == 1
+    assert "audit modes" in result.output
+
+
+def test_cli_fails_fast_on_bad_skill_path() -> None:
+    result = CliRunner().invoke(app, ["run", "--skill", "/nonexistent/skill"])
+    assert result.exit_code == 1
+    assert "does not exist" in result.output

--- a/python/tests/test_skill_variants.py
+++ b/python/tests/test_skill_variants.py
@@ -216,6 +216,7 @@ def test_comparison_table_renders_delta_row(monkeypatch: pytest.MonkeyPatch) -> 
     assert "model-a+skills" in output
     assert "Δ skills" in output
     assert "+25.0pp" in output
+    assert "single run per variant" in output
 
 
 def test_comparison_table_without_variants_unchanged(

--- a/python/tests/test_skill_variants.py
+++ b/python/tests/test_skill_variants.py
@@ -22,7 +22,7 @@ from wp_bench.config import (
 from wp_bench.core import MultiModelRunner
 from wp_bench.datasets import ExecutionTest
 from wp_bench.environment import ExecutionResult
-from wp_bench.output import print_comparison_table
+from wp_bench.output import print_comparison_table, print_skill_impact
 from wp_bench.skills import build_variants, load_skill
 
 
@@ -232,6 +232,100 @@ def test_comparison_table_without_variants_unchanged(
     output = capsys.readouterr().out
     assert "model-a" in output
     assert "Δ" not in output
+
+
+def _impact_record(
+    test_id: str, *, execution_pass: bool, runtime: float | None = None, error: bool = False
+) -> dict[str, Any]:
+    return {
+        "test_id": test_id,
+        "scores": {"execution_pass": execution_pass, "runtime": runtime},
+        "error": {"type": "Timeout", "message": "boom"} if error else None,
+    }
+
+
+def _render_skill_impact(
+    monkeypatch: pytest.MonkeyPatch, results: dict[str, dict[str, Any]]
+) -> str:
+    from rich.console import Console
+
+    recording_console = Console(record=True, width=200)
+    monkeypatch.setattr("wp_bench.output.console", recording_console)
+    print_skill_impact(results)
+    return recording_console.export_text()
+
+
+def test_skill_impact_lists_flipped_and_still_failing_tests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    results = {
+        "model-a": {
+            "base_model": "model-a",
+            "variant": {"key": "baseline"},
+            "scores": {},
+            "results": [
+                _impact_record("e-fixed", execution_pass=False, runtime=0.5),
+                _impact_record("e-broken", execution_pass=True, runtime=1.0),
+                _impact_record("e-stuck", execution_pass=False, runtime=0.0),
+                _impact_record("e-fine", execution_pass=True, runtime=1.0),
+                _impact_record("e-partial", execution_pass=False, runtime=0.25),
+            ],
+        },
+        "model-a+skills": {
+            "base_model": "model-a",
+            "variant": {"key": "skills"},
+            "scores": {},
+            "results": [
+                _impact_record("e-fixed", execution_pass=True, runtime=1.0),
+                _impact_record("e-broken", execution_pass=False, runtime=0.5),
+                _impact_record("e-stuck", execution_pass=False, runtime=0.0),
+                _impact_record("e-fine", execution_pass=True, runtime=1.0),
+                _impact_record("e-partial", execution_pass=False, runtime=0.75),
+            ],
+        },
+    }
+    output = _render_skill_impact(monkeypatch, results)
+
+    assert "Skill Impact per Test (model-a)" in output
+    assert "e-fixed" in output and "fixed by skill" in output
+    assert "e-broken" in output and "broken by skill" in output
+    # Runtime movement on a still-failing test is surfaced too.
+    assert "e-partial" in output and "runtime 25% → 75%" in output
+    # Unchanged tests are summarized, naming the still-failing ones.
+    assert "e-stuck" in output
+    assert "1 passing" in output
+    assert "e-fine" not in output
+
+
+def test_skill_impact_silent_without_variant_pair(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    output = _render_skill_impact(
+        monkeypatch,
+        {"model-a": {"scores": {}, "results": [_impact_record("e-1", execution_pass=True)]}},
+    )
+    assert output.strip() == ""
+
+
+def test_skill_impact_handles_errored_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    results = {
+        "model-a": {
+            "base_model": "model-a",
+            "variant": {"key": "baseline"},
+            "scores": {},
+            "results": [_impact_record("e-err", execution_pass=False, error=True)],
+        },
+        "model-a+skills": {
+            "base_model": "model-a",
+            "variant": {"key": "skills"},
+            "scores": {},
+            "results": [_impact_record("e-err", execution_pass=True, runtime=1.0)],
+        },
+    }
+    output = _render_skill_impact(monkeypatch, results)
+    assert "e-err" in output
+    assert "error" in output
+    assert "fixed by skill" in output
 
 
 def test_build_variants_shares_selection_config(tmp_path: Path) -> None:

--- a/python/tests/test_skills.py
+++ b/python/tests/test_skills.py
@@ -1,0 +1,167 @@
+"""Tests for skill loading and variant construction."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from wp_bench.skills import (
+    BASELINE_VARIANT,
+    SkillError,
+    build_variants,
+    load_skill,
+    load_skills,
+    render_skills_system_prompt,
+)
+
+SKILL_MD = """---
+name: wp-example
+description: "Example skill for tests."
+---
+
+# WP Example
+
+## Procedure
+1. Read: references/details.md
+"""
+
+
+def _write_skill(root: Path, *, references: bool = True) -> Path:
+    skill_dir = root / "wp-example"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(SKILL_MD, encoding="utf-8")
+    if references:
+        refs = skill_dir / "references"
+        refs.mkdir()
+        (refs / "details.md").write_text("Deep details.", encoding="utf-8")
+        (refs / "advanced.md").write_text("Advanced notes.", encoding="utf-8")
+    return skill_dir
+
+
+def test_load_skill_parses_frontmatter_and_inlines_references(tmp_path: Path) -> None:
+    skill = load_skill(_write_skill(tmp_path))
+    assert skill.name == "wp-example"
+    assert skill.description == "Example skill for tests."
+    assert skill.body.startswith("# WP Example")
+    assert "---" not in skill.body
+    # References sorted by filename and inlined under path headings.
+    assert [rel for rel, _ in skill.references] == [
+        "references/advanced.md",
+        "references/details.md",
+    ]
+    assert "## Reference: references/details.md" in skill.rendered
+    assert "Deep details." in skill.rendered
+    assert skill.token_estimate == len(skill.rendered) // 4
+
+
+def test_load_skill_without_references(tmp_path: Path) -> None:
+    skill = load_skill(_write_skill(tmp_path), include_references=False)
+    assert skill.references == ()
+    assert "## Reference:" not in skill.rendered
+
+
+def test_load_skill_bare_markdown_file(tmp_path: Path) -> None:
+    md = tmp_path / "notes.md"
+    md.write_text("Just guidance, no frontmatter.", encoding="utf-8")
+    skill = load_skill(md)
+    assert skill.name == "notes"
+    assert skill.description is None
+    assert "Just guidance" in skill.rendered
+
+
+def test_load_skill_name_falls_back_to_directory(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("Body only.", encoding="utf-8")
+    assert load_skill(skill_dir).name == "my-skill"
+
+
+@pytest.mark.parametrize(
+    ("setup", "message"),
+    [
+        (lambda p: p / "missing", "does not exist"),
+        (lambda p: _empty_dir(p), "no SKILL.md"),
+        (lambda p: _skill_with(p, "---\nname: [broken\n---\nBody"), "frontmatter"),
+        (lambda p: _skill_with(p, "---\nname: x\n---\n\n"), "empty"),
+        (lambda p: _text_file(p, "notes.txt"), "markdown"),
+    ],
+)
+def test_load_skill_errors(tmp_path: Path, setup, message) -> None:
+    with pytest.raises(SkillError, match=message):
+        load_skill(setup(tmp_path))
+
+
+def _empty_dir(root: Path) -> Path:
+    path = root / "empty"
+    path.mkdir()
+    return path
+
+
+def _skill_with(root: Path, text: str) -> Path:
+    path = root / "bad"
+    path.mkdir()
+    (path / "SKILL.md").write_text(text, encoding="utf-8")
+    return path
+
+
+def _text_file(root: Path, name: str) -> Path:
+    path = root / name
+    path.write_text("text", encoding="utf-8")
+    return path
+
+
+def test_load_skills_dedupes_paths(tmp_path: Path) -> None:
+    skill_dir = _write_skill(tmp_path)
+    skills = load_skills([skill_dir, skill_dir])
+    assert len(skills) == 1
+
+
+def test_content_hash_changes_with_reference_content(tmp_path: Path) -> None:
+    skill_dir = _write_skill(tmp_path)
+    before = load_skill(skill_dir).content_sha256
+    (skill_dir / "references" / "details.md").write_text("Changed.", encoding="utf-8")
+    after = load_skill(skill_dir).content_sha256
+    assert before != after
+
+
+def test_build_variants_matrix(tmp_path: Path) -> None:
+    assert build_variants([]) == [BASELINE_VARIANT]
+
+    skill = load_skill(_write_skill(tmp_path))
+    both = build_variants([skill])
+    assert [variant.key for variant in both] == ["baseline", "skills"]
+    assert both[1].kind == "inject"
+    assert both[1].label_suffix == "+skills"
+    assert both[1].system_prompt is not None
+    assert skill.rendered in both[1].system_prompt
+
+    only = build_variants([skill], skills_only=True)
+    assert [variant.key for variant in only] == ["skills"]
+
+
+def test_variant_record_and_payload_info(tmp_path: Path) -> None:
+    assert BASELINE_VARIANT.record_info() == {
+        "key": "baseline",
+        "kind": "none",
+        "system_prompt_hash": None,
+    }
+    skill = load_skill(_write_skill(tmp_path))
+    variant = build_variants([skill])[1]
+    info = variant.record_info()
+    assert info["key"] == "skills"
+    assert info["system_prompt_hash"]
+    payload = variant.payload_info()
+    assert payload["skills"] == ["wp-example"]
+    assert payload["system_prompt_sha256"] == info["system_prompt_hash"]
+
+
+def test_render_skills_system_prompt_contains_preamble_and_all_skills(tmp_path: Path) -> None:
+    first = load_skill(_write_skill(tmp_path))
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    (other_dir / "SKILL.md").write_text("Other body.", encoding="utf-8")
+    second = load_skill(other_dir)
+
+    prompt = render_skills_system_prompt([first, second])
+    assert prompt.index("skill documents") < prompt.index("# Skill: wp-example")
+    assert "# Skill: other" in prompt

--- a/python/wp_bench/cli.py
+++ b/python/wp_bench/cli.py
@@ -12,6 +12,7 @@ from rich.console import Console
 from .config import HarnessConfig, ModelConfig
 from .core import BenchmarkRunner, MultiModelRunner, select_run_tests
 from .datasets import ExecutionTest, filter_tests_by_ids, load_tests
+from .skills import LoadedSkill, load_skills
 
 # Load .env file for API keys
 load_dotenv()
@@ -75,6 +76,18 @@ def _print_dry_run_counts(
         console.print(f"Selected test ids: {ids}")
 
 
+def _print_skill_summary(skills: list[LoadedSkill]) -> None:
+    """Print which skills would be injected (dry run)."""
+    if not skills:
+        return
+    console.print("Skills to inject:")
+    for loaded in skills:
+        console.print(
+            f"  {loaded.name} (~{loaded.token_estimate} tokens, "
+            f"{len(loaded.references)} reference file(s))"
+        )
+
+
 @app.command()
 def run(
     config: Path | None = typer.Option(None, help="Path to wp-bench YAML config"),
@@ -96,6 +109,24 @@ def run(
         "--test-id",
         help="Run only the given dataset test ID. May be repeated or comma-separated.",
     ),
+    skill: list[Path] | None = typer.Option(
+        None,
+        "--skill",
+        help=(
+            "Skill to inject (directory containing SKILL.md, or a bare .md file). "
+            "May be repeated. Each model then runs both a baseline pass and a "
+            "with-skills pass over the identical test subset."
+        ),
+    ),
+    skills_include_references: bool | None = typer.Option(
+        None,
+        "--skills-include-references/--no-skills-include-references",
+        help="Inline each skill's references/*.md into the injected content (default: on).",
+    ),
+    skills_only: bool = typer.Option(
+        False,
+        help="Skip the baseline (no-skills) pass; run only the with-skills variant.",
+    ),
 ) -> None:
     """Run the benchmark end-to-end."""
     harness_config = HarnessConfig.from_file(config) if config else HarnessConfig()
@@ -115,15 +146,44 @@ def run(
     normalized_test_ids = _normalize_test_ids(test_id)
     if normalized_test_ids:
         harness_config.run.test_ids = normalized_test_ids
+    if skill:
+        harness_config.skills.paths = list(skill)
+    if skills_include_references is not None:
+        harness_config.skills.include_references = skills_include_references
+    if skills_only:
+        harness_config.skills.only = True
 
     if harness_config.run.dry_run and harness_config.run.check_reference_solution:
         console.print("[red]--dry-run and --check-reference-solution cannot be used together.[/red]")
         raise typer.Exit(1)
 
+    if harness_config.skills.only and not harness_config.skills.paths:
+        console.print("[red]--skills-only requires at least one --skill (or skills.paths).[/red]")
+        raise typer.Exit(1)
+
+    skills_active = bool(harness_config.skills.paths)
+    if skills_active and (
+        harness_config.run.check_reference_solution or harness_config.run.check_exploits
+    ):
+        console.print(
+            "[red]Skills cannot be combined with --check-reference-solution or "
+            "--check-exploits: audit modes never call a model.[/red]"
+        )
+        raise typer.Exit(1)
+
+    # Load skills before anything expensive so bad paths fail fast.
+    loaded_skills: list[LoadedSkill] = _run_or_fail(
+        lambda: load_skills(
+            harness_config.skills.paths,
+            include_references=harness_config.skills.include_references,
+        )
+    )
+
     if harness_config.run.dry_run:
         _run_or_fail(
             lambda: _print_dry_run_counts(_load_filtered_tests(harness_config), harness_config)
         )
+        _print_skill_summary(loaded_skills)
         return
 
     if harness_config.run.check_reference_solution:
@@ -140,11 +200,21 @@ def run(
     if model_name:
         harness_config.model = ModelConfig(name=model_name)
         harness_config.models = None
-    elif len(models) > 1:
+        models = harness_config.get_models()
+    if skills_active:
+        # Skills always run the (model x variant) matrix, even for one
+        # model: the A/B payload shape and delta table live in the multi
+        # runner only.
+        harness_config.models = models
+        harness_config.model = None
+        _run_or_fail(MultiModelRunner(harness_config, skills=loaded_skills).run)
+        console.print("\n[bold green]WP-Bench completed[/bold green]")
+        return
+    if not model_name and len(models) > 1:
         _run_or_fail(MultiModelRunner(harness_config).run)
         console.print("\n[bold green]WP-Bench completed[/bold green]")
         return
-    elif not harness_config.model:
+    if not harness_config.model:
         harness_config.model = models[0]
     result = _run_or_fail(BenchmarkRunner(harness_config).run)
     console.print("[bold green]WP-Bench completed[/bold green]", result["metadata"]["scores"])

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -183,6 +183,31 @@ class OutputConfig(StrictModel):
     jsonl_path: Path | None = Field(default=Path("results.jsonl"))
 
 
+class SkillsConfig(StrictModel):
+    """Skill-injection A/B runs. When ``paths`` is set, every model runs a
+    baseline pass and a with-skills pass over the identical seeded test
+    subset, and the comparison table shows deltas.
+    """
+
+    #: Skill sources: a directory containing SKILL.md, or a bare .md file.
+    #: Path existence and content are validated at run start (load_skills),
+    #: not here — config construction stays IO-free.
+    paths: list[Path] = Field(default_factory=list)
+    #: Inline each skill's references/*.md into the injected content. The
+    #: harness is single-shot, so the model cannot follow SKILL.md's file
+    #: pointers on its own; disabling this is a diagnostic mode.
+    include_references: bool = True
+    #: Skip the baseline (no-skills) variant. Diagnostic escape hatch: the
+    #: default in-run A/B is what makes results comparable.
+    only: bool = False
+
+    @model_validator(mode="after")
+    def _validate_only_requires_paths(self) -> SkillsConfig:
+        if self.only and not self.paths:
+            raise ValueError("skills.only requires skills.paths to be set")
+        return self
+
+
 class HarnessConfig(StrictModel):
     dataset: DatasetConfig = DatasetConfig()
     model: ModelConfig | None = None  # Single model (legacy)
@@ -190,6 +215,7 @@ class HarnessConfig(StrictModel):
     grader: GraderConfig = GraderConfig()
     run: RunConfig = RunConfig()
     output: OutputConfig = OutputConfig()
+    skills: SkillsConfig = SkillsConfig()
 
     def get_models(self) -> list[ModelConfig]:
         """Return list of models to evaluate."""
@@ -229,5 +255,10 @@ class HarnessConfig(StrictModel):
             for key in ("path", "jsonl_path"):
                 if key in data["output"] and data["output"][key]:
                     data["output"][key] = resolve_path(data["output"][key])
+
+        if "skills" in data and isinstance(data["skills"], dict):
+            paths = data["skills"].get("paths")
+            if isinstance(paths, list):
+                data["skills"]["paths"] = [resolve_path(item) for item in paths if item]
 
         return cls(**data)

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -48,6 +48,7 @@ from .records import (
 )
 from .scoring import SCORING_VERSION, ScoreAggregator, UsageAggregator
 from .selection import select_tests
+from .skills import BASELINE_VARIANT, LoadedSkill, Variant, build_variants
 from .utils import ensure_dir, sha256
 
 
@@ -169,6 +170,7 @@ def _error_record(
     *,
     mode: str,
     model_config: ModelConfig | None,
+    variant: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Canonical record for a test the runner caught erroring.
 
@@ -181,6 +183,7 @@ def _error_record(
         model_config=model_config,
         error_type=type(error.original_error).__name__,
         error_message=str(error.original_error),
+        variant=variant,
     )
 
 
@@ -834,29 +837,37 @@ class MultiModelRunner:
     SingleModelRunner, and outputs a side-by-side comparison of scores.
     """
 
-    def __init__(self, config: HarnessConfig):
+    def __init__(self, config: HarnessConfig, skills: list[LoadedSkill] | None = None):
         """Initialize the multi-model runner.
 
         Args:
             config: Harness configuration with multiple models defined.
+            skills: Pre-loaded skills for A/B variant runs (loaded in the
+                CLI so path errors surface before environment setup). When
+                set, every model runs both a baseline and a with-skills pass
+                unless ``config.skills.only`` skips the baseline.
         """
         self.config = config
         self.environment = WordPressEnvironment(config.grader)
+        self.skills = skills or []
+        self.variants = build_variants(self.skills, skills_only=config.skills.only)
         self.results: dict[str, dict[str, Any]] = {}
 
     def run(self) -> dict[str, Any]:
-        """Execute benchmarks for all configured models.
+        """Execute benchmarks for all configured (model x variant) passes.
 
-        Sets up the WordPress environment once, then runs each model sequentially.
-        Prints a comparison table and writes combined results.
+        Sets up the WordPress environment once, then runs each pass
+        sequentially. Prints a comparison table and writes combined results.
 
         Returns:
-            Dict mapping model names to their individual results.
+            Dict mapping display names (model name plus variant suffix,
+            e.g. "gpt-4o" / "gpt-4o+skills") to their individual results.
 
         Raises:
             SystemExit: If a test fails, prints error details and exits with code 1.
         """
         models = self.config.get_models()
+        self._ensure_unique_display_names(models)
         tests = filter_tests_by_ids(load_tests(self.config.dataset), self.config.run.test_ids)
         if not tests:
             raise ValueError(
@@ -867,17 +878,21 @@ class MultiModelRunner:
 
         try:
             for model_config in models:
-                model_name = model_config.name
-                print_model_header(model_name)
+                for variant in self.variants:
+                    display_name = f"{model_config.name}{variant.label_suffix}"
+                    print_model_header(display_name)
 
-                runner = SingleModelRunner(
-                    config=self.config,
-                    model_config=model_config,
-                    environment=self.environment,
-                    tests=tests,
-                )
-                result = runner.run()
-                self.results[model_name] = result
+                    runner = SingleModelRunner(
+                        config=self.config,
+                        model_config=model_config,
+                        environment=self.environment,
+                        tests=tests,
+                        variant=variant,
+                    )
+                    result = runner.run()
+                    result["base_model"] = model_config.name
+                    result["variant"] = variant.payload_info()
+                    self.results[display_name] = result
         except TestError as e:
             print_test_error(e)
             raise SystemExit(1) from e
@@ -888,6 +903,41 @@ class MultiModelRunner:
         print_comparison_table(self.results)
         self._write_outputs()
         return self.results
+
+    def _ensure_unique_display_names(self, models: list[ModelConfig]) -> None:
+        """Reject display-name collisions before any model call is spent.
+
+        A duplicated model entry, or a model literally named "x+skills"
+        alongside model "x" in a skills run, would silently overwrite a
+        results key.
+        """
+        display_names = [
+            f"{model.name}{variant.label_suffix}"
+            for model in models
+            for variant in self.variants
+        ]
+        duplicates = {name for name in display_names if display_names.count(name) > 1}
+        if duplicates:
+            raise ValueError(
+                f"Duplicate result keys {sorted(duplicates)}: model names plus "
+                "variant suffixes must be unique."
+            )
+
+    def _skills_metadata(self) -> dict[str, Any]:
+        """The skills provenance block recorded in payload metadata."""
+        skills_variant = next(
+            (variant for variant in self.variants if variant.kind != "none"), None
+        )
+        return {
+            "enabled": bool(self.skills),
+            "include_references": self.config.skills.include_references,
+            "system_prompt_sha256": (
+                sha256(skills_variant.system_prompt)
+                if skills_variant and skills_variant.system_prompt
+                else None
+            ),
+            "skills": [skill.provenance() for skill in self.skills],
+        }
 
     def _write_outputs(self) -> None:
         """Write combined results to output files."""
@@ -900,10 +950,14 @@ class MultiModelRunner:
                 "dataset": self.config.dataset.model_dump(mode="json"),
                 "runtime_isolation": self.config.run.execution_isolation,
                 "continue_on_error": self.config.run.continue_on_error,
+                "skills": self._skills_metadata(),
+                "variants": [variant.key for variant in self.variants],
             },
             "models": {
                 name: {
                     "config": result["model_config"],
+                    "base_model": result["base_model"],
+                    "variant": result["variant"],
                     "scores": result["scores"],
                     "results": result["results"],
                 }
@@ -929,6 +983,7 @@ class SingleModelRunner:
         model_config: ModelConfig,
         environment: WordPressEnvironment,
         tests: list[ExecutionTest],
+        variant: Variant = BASELINE_VARIANT,
     ):
         """Initialize runner for a specific model.
 
@@ -937,10 +992,13 @@ class SingleModelRunner:
             model_config: Configuration for the specific model to evaluate.
             environment: Shared WordPress environment instance.
             tests: Pre-loaded execution tests.
+            variant: Which pass of the run matrix this is (baseline or
+                skills); carries the system prompt to inject, if any.
         """
         self.config = config
         self.model_config = model_config
-        self.model = ModelInterface(model_config)
+        self.variant = variant
+        self.model = ModelInterface(model_config, system_prompt=variant.system_prompt)
         self.environment = environment
         self.tests = tests
         self.aggregator = ScoreAggregator()
@@ -968,6 +1026,7 @@ class SingleModelRunner:
     def _run_execution_tests(self, tests: list[ExecutionTest]) -> None:
         """Run execution tests with isolation. See BenchmarkRunner._run_execution_tests."""
         tests_to_run = select_run_tests(tests, self.config)
+        variant_info = self.variant.record_info()
 
         def process_test(test: ExecutionTest) -> dict[str, Any]:
             try:
@@ -988,6 +1047,7 @@ class SingleModelRunner:
                         scores=_artifact_failure_scores(),
                         usage=generation.usage_dict(),
                         model_call=_model_call_info(generation),
+                        variant=variant_info,
                     )
                 verification_spec = _build_verification_spec(test, self.config)
                 env_result = self.environment.execute_artifact(artifact, verification_spec)
@@ -1008,6 +1068,7 @@ class SingleModelRunner:
                     scores=scores,
                     usage=generation.usage_dict(),
                     model_call=_model_call_info(generation),
+                    variant=variant_info,
                 )
             except Exception as e:
                 raise TestError(test.id, e) from e
@@ -1020,7 +1081,9 @@ class SingleModelRunner:
                 self.records.append(result)
 
         def on_error(test: ExecutionTest, error: TestError) -> dict[str, Any]:
-            return _error_record(test, error, mode="model", model_config=self.model_config)
+            return _error_record(
+                test, error, mode="model", model_config=self.model_config, variant=variant_info
+            )
 
         _run_isolated_execution_loop(
             tests_to_run=tests_to_run,

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -33,6 +33,7 @@ from .output import (
     print_model_header,
     print_reference_solution_failures,
     print_results_path,
+    print_skill_impact,
     print_systemic_abort,
     print_test_error,
     print_test_warning,
@@ -901,6 +902,7 @@ class MultiModelRunner:
             raise SystemExit(130) from None
 
         print_comparison_table(self.results)
+        print_skill_impact(self.results)
         self._write_outputs()
         return self.results
 

--- a/python/wp_bench/models.py
+++ b/python/wp_bench/models.py
@@ -72,8 +72,11 @@ class ModelGeneration:
 class ModelInterface:
     """Thin wrapper over LiteLLM to keep prompts consistent."""
 
-    def __init__(self, config: ModelConfig):
+    def __init__(self, config: ModelConfig, system_prompt: str | None = None):
         self.config = config
+        #: Variant state (e.g. injected skill content), deliberately not part
+        #: of ModelConfig so it never lands in serialized model config blocks.
+        self.system_prompt = system_prompt
 
     def generate(self, prompt: str) -> str:
         """Generate a completion for the given prompt (text only).
@@ -165,9 +168,13 @@ class ModelInterface:
         return completion_cost(response)
 
     def _completion_kwargs(self, prompt: str) -> dict[str, Any]:
+        messages: list[dict[str, str]] = []
+        if self.system_prompt:
+            messages.append({"role": "system", "content": self.system_prompt})
+        messages.append({"role": "user", "content": prompt})
         kwargs: dict[str, Any] = {
             "model": self.config.name,
-            "messages": [{"role": "user", "content": prompt}],
+            "messages": messages,
             "max_tokens": self.config.max_tokens,
             "top_p": self.config.top_p,
             "timeout": self.config.request_timeout,

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -132,8 +132,10 @@ def print_comparison_table(results: dict[str, dict[str, Any]]) -> None:
     console.print(table)
 
 
-def _skill_delta_rows(results: dict[str, dict[str, Any]]) -> list[list[str]]:
-    """Build a "Δ skills" row per base model that ran both variants."""
+def _variant_pairs(
+    results: dict[str, dict[str, Any]],
+) -> dict[str, tuple[dict[str, Any], dict[str, Any]]]:
+    """Map each base model to its (baseline, skills) result pair, when both ran."""
 
     def _variant_key(result: dict[str, Any]) -> str | None:
         variant = result.get("variant")
@@ -145,6 +147,16 @@ def _skill_delta_rows(results: dict[str, dict[str, Any]]) -> list[list[str]]:
         if key:
             by_base.setdefault(result.get("base_model", ""), {})[key] = result
 
+    return {
+        base_model: (variants["baseline"], variants["skills"])
+        for base_model, variants in by_base.items()
+        if "baseline" in variants and "skills" in variants
+    }
+
+
+def _skill_delta_rows(results: dict[str, dict[str, Any]]) -> list[list[str]]:
+    """Build a "Δ skills" row per base model that ran both variants."""
+
     def _fmt_delta(base: float | None, with_skills: float | None) -> str:
         if base is None or with_skills is None:
             return "N/A"
@@ -153,10 +165,7 @@ def _skill_delta_rows(results: dict[str, dict[str, Any]]) -> list[list[str]]:
         return f"[{color}]{delta*100:+.1f}pp[/{color}]"
 
     rows: list[list[str]] = []
-    for base_model, variants in by_base.items():
-        baseline, skilled = variants.get("baseline"), variants.get("skills")
-        if not baseline or not skilled:
-            continue
+    for base_model, (baseline, skilled) in _variant_pairs(results).items():
         base_scores, skill_scores = baseline["scores"], skilled["scores"]
         base_usage, skill_usage = baseline.get("usage") or {}, skilled.get("usage") or {}
 
@@ -182,6 +191,101 @@ def _skill_delta_rows(results: dict[str, dict[str, Any]]) -> list[list[str]]:
             ]
         )
     return rows
+
+
+def print_skill_impact(results: dict[str, dict[str, Any]]) -> None:
+    """Per-test breakdown of what the skills variant changed, per base model.
+
+    Skill authors iterate on one skill at a time; the aggregate delta hides
+    which tests actually moved. For every base model that ran both variants
+    this prints one row per test whose outcome changed (execution pass flip,
+    or a runtime-score shift on a still-failing test), then summarizes the
+    unchanged tests — naming the still-failing ones, since those are the
+    skill's next targets. No-op for runs without a baseline/skills pair.
+    """
+    for base_model, (baseline, skilled) in _variant_pairs(results).items():
+        base_records = {r["test_id"]: r for r in baseline.get("results", [])}
+        skill_records = {r["test_id"]: r for r in skilled.get("results", [])}
+
+        changed: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
+        unchanged_pass: list[str] = []
+        unchanged_fail: list[str] = []
+        for test_id in sorted(base_records.keys() | skill_records.keys()):
+            base, skill = base_records.get(test_id), skill_records.get(test_id)
+            if base is None or skill is None or _test_outcome(base) != _test_outcome(skill):
+                changed.append((test_id, base or {}, skill or {}))
+            elif _test_outcome(base)[0] == "pass":
+                unchanged_pass.append(test_id)
+            else:
+                unchanged_fail.append(test_id)
+
+        table = Table(title=f"Skill Impact per Test ({base_model})")
+        table.add_column("Test ID", style="cyan")
+        table.add_column("Baseline", justify="right")
+        table.add_column("+Skills", justify="right")
+        table.add_column("Change", justify="left")
+        for test_id, base, skill in changed:
+            table.add_row(
+                test_id,
+                _fmt_outcome(_test_outcome(base) if base else None),
+                _fmt_outcome(_test_outcome(skill) if skill else None),
+                _fmt_outcome_change(
+                    _test_outcome(base) if base else None,
+                    _test_outcome(skill) if skill else None,
+                ),
+            )
+        if not changed:
+            table.add_row("[dim]—[/dim]", "", "", "[dim]no per-test changes[/dim]")
+        console.print(table)
+
+        summary = f"Unchanged: {len(unchanged_pass)} passing"
+        if unchanged_fail:
+            summary += (
+                f", {len(unchanged_fail)} failing in both variants: "
+                f"{', '.join(unchanged_fail)}"
+            )
+        console.print(f"[dim]{summary}[/dim]")
+
+
+def _test_outcome(record: dict[str, Any]) -> tuple[str, float | None]:
+    """Reduce a record to a comparable (status, runtime score) outcome."""
+    if record.get("error") is not None:
+        return ("error", None)
+    scores = record.get("scores") or {}
+    status = "pass" if scores.get("execution_pass") else "fail"
+    return (status, scores.get("runtime"))
+
+
+def _fmt_outcome(outcome: tuple[str, float | None] | None) -> str:
+    if outcome is None:
+        return "[dim]missing[/dim]"
+    status, runtime = outcome
+    if status == "pass":
+        return "[green]pass[/green]"
+    if status == "error":
+        return "[yellow]error[/yellow]"
+    if runtime is not None and runtime > 0:
+        return f"[red]fail[/red] [dim]({runtime*100:.0f}% runtime)[/dim]"
+    return "[red]fail[/red]"
+
+
+def _fmt_outcome_change(
+    base: tuple[str, float | None] | None,
+    skill: tuple[str, float | None] | None,
+) -> str:
+    if base is None or skill is None:
+        return "[yellow]present in one variant only[/yellow]"
+    base_status, base_runtime = base
+    skill_status, skill_runtime = skill
+    if base_status != "pass" and skill_status == "pass":
+        return "[green]▲ fixed by skill[/green]"
+    if base_status == "pass" and skill_status != "pass":
+        return "[red]▼ broken by skill[/red]"
+    if base_runtime is not None and skill_runtime is not None:
+        direction = "▲" if skill_runtime > base_runtime else "▼"
+        color = "green" if skill_runtime > base_runtime else "red"
+        return f"[{color}]{direction} runtime {base_runtime*100:.0f}% → {skill_runtime*100:.0f}%[/{color}]"
+    return "[yellow]changed[/yellow]"
 
 
 def print_reference_solution_failures(records: list[dict[str, Any]]) -> None:

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -90,8 +90,12 @@ def print_results_path(path: Path) -> None:
 def print_comparison_table(results: dict[str, dict[str, Any]]) -> None:
     """Print a formatted table comparing scores across all models.
 
+    In a skills A/B run each base model has a baseline row and a "+skills"
+    row; a delta row follows each such pair. Results without variant keys
+    (plain multi-model runs) render exactly as before.
+
     Args:
-        results: Dict mapping model names to their result dicts containing scores.
+        results: Dict mapping display names to their result dicts containing scores.
     """
     table = Table(title="WP-Bench Results")
     table.add_column("Model", style="cyan")
@@ -122,7 +126,62 @@ def print_comparison_table(results: dict[str, dict[str, Any]]) -> None:
             _fmt_latency(usage.get("median_latency_ms")),
         )
 
+    for delta_row in _skill_delta_rows(results):
+        table.add_row(*delta_row)
+
     console.print(table)
+
+
+def _skill_delta_rows(results: dict[str, dict[str, Any]]) -> list[list[str]]:
+    """Build a "Δ skills" row per base model that ran both variants."""
+
+    def _variant_key(result: dict[str, Any]) -> str | None:
+        variant = result.get("variant")
+        return variant.get("key") if isinstance(variant, dict) else None
+
+    by_base: dict[str, dict[str, dict[str, Any]]] = {}
+    for result in results.values():
+        key = _variant_key(result)
+        if key:
+            by_base.setdefault(result.get("base_model", ""), {})[key] = result
+
+    def _fmt_delta(base: float | None, with_skills: float | None) -> str:
+        if base is None or with_skills is None:
+            return "N/A"
+        delta = with_skills - base
+        color = "green" if delta > 0 else "red" if delta < 0 else "dim"
+        return f"[{color}]{delta*100:+.1f}pp[/{color}]"
+
+    rows: list[list[str]] = []
+    for base_model, variants in by_base.items():
+        baseline, skilled = variants.get("baseline"), variants.get("skills")
+        if not baseline or not skilled:
+            continue
+        base_scores, skill_scores = baseline["scores"], skilled["scores"]
+        base_usage, skill_usage = baseline.get("usage") or {}, skilled.get("usage") or {}
+
+        def _usage_delta(field: str, prefix: str = "", suffix: str = "") -> str:
+            base_value, skill_value = base_usage.get(field), skill_usage.get(field)
+            if base_value is None or skill_value is None:
+                return "N/A"
+            delta = skill_value - base_value
+            precision = 4 if field == "estimated_cost_usd" else 0
+            return f"{prefix}{delta:+.{precision}f}{suffix}"
+
+        rows.append(
+            [
+                f"[dim]Δ skills ({base_model})[/dim]",
+                _fmt_delta(
+                    base_scores.get("execution_pass_rate"),
+                    skill_scores.get("execution_pass_rate"),
+                ),
+                _fmt_delta(base_scores.get("runtime"), skill_scores.get("runtime")),
+                _fmt_delta(base_scores.get("overall"), skill_scores.get("overall")),
+                _usage_delta("estimated_cost_usd", prefix="$"),
+                _usage_delta("median_latency_ms", suffix="ms"),
+            ]
+        )
+    return rows
 
 
 def print_reference_solution_failures(records: list[dict[str, Any]]) -> None:

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -126,8 +126,14 @@ def print_comparison_table(results: dict[str, dict[str, Any]]) -> None:
             _fmt_latency(usage.get("median_latency_ms")),
         )
 
-    for delta_row in _skill_delta_rows(results):
+    delta_rows = _skill_delta_rows(results)
+    for delta_row in delta_rows:
         table.add_row(*delta_row)
+    if delta_rows:
+        # One run per variant is a single sample; a small aggregate delta can
+        # be run-to-run noise. The per-test Skill Impact table names what
+        # actually moved.
+        table.caption = "Δ compares a single run per variant; see the per-test Skill Impact table."
 
     console.print(table)
 

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -164,18 +164,24 @@ def _skill_delta_rows(results: dict[str, dict[str, Any]]) -> list[list[str]]:
         color = "green" if delta > 0 else "red" if delta < 0 else "dim"
         return f"[{color}]{delta*100:+.1f}pp[/{color}]"
 
+    def _usage_delta(
+        base_usage: dict[str, Any],
+        skill_usage: dict[str, Any],
+        field: str,
+        prefix: str = "",
+        suffix: str = "",
+    ) -> str:
+        base_value, skill_value = base_usage.get(field), skill_usage.get(field)
+        if base_value is None or skill_value is None:
+            return "N/A"
+        delta = skill_value - base_value
+        precision = 4 if field == "estimated_cost_usd" else 0
+        return f"{prefix}{delta:+.{precision}f}{suffix}"
+
     rows: list[list[str]] = []
     for base_model, (baseline, skilled) in _variant_pairs(results).items():
         base_scores, skill_scores = baseline["scores"], skilled["scores"]
         base_usage, skill_usage = baseline.get("usage") or {}, skilled.get("usage") or {}
-
-        def _usage_delta(field: str, prefix: str = "", suffix: str = "") -> str:
-            base_value, skill_value = base_usage.get(field), skill_usage.get(field)
-            if base_value is None or skill_value is None:
-                return "N/A"
-            delta = skill_value - base_value
-            precision = 4 if field == "estimated_cost_usd" else 0
-            return f"{prefix}{delta:+.{precision}f}{suffix}"
 
         rows.append(
             [
@@ -186,8 +192,8 @@ def _skill_delta_rows(results: dict[str, dict[str, Any]]) -> list[list[str]]:
                 ),
                 _fmt_delta(base_scores.get("runtime"), skill_scores.get("runtime")),
                 _fmt_delta(base_scores.get("overall"), skill_scores.get("overall")),
-                _usage_delta("estimated_cost_usd", prefix="$"),
-                _usage_delta("median_latency_ms", suffix="ms"),
+                _usage_delta(base_usage, skill_usage, "estimated_cost_usd", prefix="$"),
+                _usage_delta(base_usage, skill_usage, "median_latency_ms", suffix="ms"),
             ]
         )
     return rows
@@ -198,53 +204,44 @@ def print_skill_impact(results: dict[str, dict[str, Any]]) -> None:
 
     Skill authors iterate on one skill at a time; the aggregate delta hides
     which tests actually moved. For every base model that ran both variants
-    this prints one row per test whose outcome changed (execution pass flip,
-    or a runtime-score shift on a still-failing test), then summarizes the
-    unchanged tests — naming the still-failing ones, since those are the
-    skill's next targets. No-op for runs without a baseline/skills pair.
+    this prints one row per test that changed (execution pass flip, or a
+    runtime-score shift) or is still failing in both variants — the latter
+    are the skill's next targets. Tests passing in both variants are only
+    counted. No-op for runs without a baseline/skills pair.
     """
     for base_model, (baseline, skilled) in _variant_pairs(results).items():
         base_records = {r["test_id"]: r for r in baseline.get("results", [])}
         skill_records = {r["test_id"]: r for r in skilled.get("results", [])}
 
-        changed: list[tuple[str, dict[str, Any], dict[str, Any]]] = []
-        unchanged_pass: list[str] = []
-        unchanged_fail: list[str] = []
+        rows: list[tuple[str, dict[str, Any] | None, dict[str, Any] | None, str | None]] = []
+        unchanged_pass = 0
         for test_id in sorted(base_records.keys() | skill_records.keys()):
             base, skill = base_records.get(test_id), skill_records.get(test_id)
             if base is None or skill is None or _test_outcome(base) != _test_outcome(skill):
-                changed.append((test_id, base or {}, skill or {}))
+                rows.append((test_id, base, skill, None))
             elif _test_outcome(base)[0] == "pass":
-                unchanged_pass.append(test_id)
+                unchanged_pass += 1
             else:
-                unchanged_fail.append(test_id)
+                rows.append((test_id, base, skill, "[dim]— still failing[/dim]"))
 
         table = Table(title=f"Skill Impact per Test ({base_model})")
         table.add_column("Test ID", style="cyan")
         table.add_column("Baseline", justify="right")
         table.add_column("+Skills", justify="right")
         table.add_column("Change", justify="left")
-        for test_id, base, skill in changed:
+        for test_id, base, skill, change in rows:
+            base_outcome = _test_outcome(base) if base else None
+            skill_outcome = _test_outcome(skill) if skill else None
             table.add_row(
                 test_id,
-                _fmt_outcome(_test_outcome(base) if base else None),
-                _fmt_outcome(_test_outcome(skill) if skill else None),
-                _fmt_outcome_change(
-                    _test_outcome(base) if base else None,
-                    _test_outcome(skill) if skill else None,
-                ),
+                _fmt_outcome(base_outcome),
+                _fmt_outcome(skill_outcome),
+                change if change is not None else _fmt_outcome_change(base_outcome, skill_outcome),
             )
-        if not changed:
-            table.add_row("[dim]—[/dim]", "", "", "[dim]no per-test changes[/dim]")
+        if not rows:
+            table.add_row("[dim]—[/dim]", "", "", "[dim]all tests passing in both variants[/dim]")
         console.print(table)
-
-        summary = f"Unchanged: {len(unchanged_pass)} passing"
-        if unchanged_fail:
-            summary += (
-                f", {len(unchanged_fail)} failing in both variants: "
-                f"{', '.join(unchanged_fail)}"
-            )
-        console.print(f"[dim]{summary}[/dim]")
+        console.print(f"[dim]Passing in both variants (not shown): {unchanged_pass}[/dim]")
 
 
 def _test_outcome(record: dict[str, Any]) -> tuple[str, float | None]:

--- a/python/wp_bench/records.py
+++ b/python/wp_bench/records.py
@@ -14,7 +14,17 @@ from .config import ModelConfig
 #: Bump when the per-test record shape changes. Recorded in payload metadata.
 #: 2.0: the "knowledge" score key and the knowledge-only "output.answer"
 #: field were removed (knowledge track removed).
-RESULT_SCHEMA_VERSION = "2.0"
+#: 2.1: added the "variant" block for skill-injection A/B runs.
+RESULT_SCHEMA_VERSION = "2.1"
+
+
+def _baseline_variant_info() -> dict[str, Any]:
+    """The no-skills variant identity every record carries by default.
+
+    Kept structurally identical to skills.Variant.record_info() so the
+    variant key paths never diverge between baseline and skills records.
+    """
+    return {"key": "baseline", "kind": "none", "system_prompt_hash": None}
 
 
 def _model_info(model_config: ModelConfig | None) -> dict[str, Any] | None:
@@ -57,6 +67,7 @@ def _base_record(
     test: Any,
     mode: str,
     model_config: ModelConfig | None,
+    variant: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """The canonical per-test record skeleton shared by every builder.
 
@@ -74,6 +85,7 @@ def _base_record(
         "mode": mode,
         "prompt_hash": None,
         "model": _model_info(model_config),
+        "variant": variant if variant is not None else _baseline_variant_info(),
         "output": {"raw_completion": None, "code": None},
         "scores": _null_scores(),
         "grader": None,
@@ -95,6 +107,7 @@ def build_execution_record(
     scores: dict[str, Any],
     usage: dict[str, Any] | None = None,
     model_call: dict[str, Any] | None = None,
+    variant: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the canonical record for an execution test result.
 
@@ -102,9 +115,11 @@ def build_execution_record(
         scores: Scores object from BenchmarkRunner._score_execution, carrying
             correctness (legacy), execution_pass (primary), runtime, static,
             and static_policy_pass.
+        variant: Variant identity from skills.Variant.record_info();
+            defaults to the baseline (no-skills) variant.
     """
     raw = env_result.raw or {}
-    record = _base_record(test=test, mode=mode, model_config=model_config)
+    record = _base_record(test=test, mode=mode, model_config=model_config, variant=variant)
     record["prompt_hash"] = prompt_hash
     record["output"] = {"raw_completion": raw_completion, "code": code}
     record["scores"] = scores
@@ -127,6 +142,7 @@ def build_error_record(
     model_config: ModelConfig | None,
     error_type: str,
     error_message: str,
+    variant: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the canonical record for a test that errored before grading.
 
@@ -135,7 +151,7 @@ def build_error_record(
     pass or fail), and keeps the exact canonical key structure so consumers
     never need a separate parser for errored tests.
     """
-    record = _base_record(test=test, mode=mode, model_config=model_config)
+    record = _base_record(test=test, mode=mode, model_config=model_config, variant=variant)
     record["error"] = {"type": error_type, "message": error_message}
     return record
 

--- a/python/wp_bench/skills.py
+++ b/python/wp_bench/skills.py
@@ -1,0 +1,242 @@
+"""Skill loading and run-variant modeling for skill-injection A/B runs.
+
+A "skill" follows the SKILL.md convention (a directory containing a
+``SKILL.md`` with YAML frontmatter plus optional ``references/*.md``, or a
+bare markdown file). The harness is single-shot, so a skill is "used" by
+injecting its rendered content as a system message; ``Variant`` models the
+baseline-vs-skills axis so every model can run both passes in one run.
+``Variant.kind`` is the extension seam for a future agentic mode.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+from .utils import sha256
+
+SYSTEM_PROMPT_PREAMBLE = (
+    "You are assisting with WordPress development tasks. The following "
+    "skill documents provide domain knowledge; apply them when relevant."
+)
+
+
+class SkillError(ValueError):
+    """A skill path could not be loaded into an injectable skill."""
+
+
+@dataclass(frozen=True)
+class LoadedSkill:
+    """One skill loaded from disk, rendered for prompt injection."""
+
+    name: str
+    description: str | None
+    source_path: str
+    body: str
+    #: (relative path, file content) pairs, sorted by path.
+    references: tuple[tuple[str, str], ...]
+    #: The exact injection block for this skill; hashed for provenance.
+    rendered: str
+    content_sha256: str
+    token_estimate: int
+
+    def provenance(self) -> dict[str, Any]:
+        """Identity block recorded in run metadata."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "source_path": self.source_path,
+            "content_sha256": self.content_sha256,
+            "token_estimate": self.token_estimate,
+            "reference_count": len(self.references),
+        }
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Split optional ``---`` YAML frontmatter from a markdown body."""
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---", 4)
+    if end == -1:
+        return {}, text
+    raw = text[4:end]
+    body = text[end + 4 :].lstrip("\n")
+    try:
+        parsed = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise SkillError(f"Invalid YAML frontmatter: {exc}") from exc
+    if parsed is None:
+        return {}, body
+    if not isinstance(parsed, dict):
+        raise SkillError("SKILL.md frontmatter must be a YAML mapping.")
+    return parsed, body
+
+
+def _load_references(skill_dir: Path) -> tuple[tuple[str, str], ...]:
+    references_dir = skill_dir / "references"
+    if not references_dir.is_dir():
+        return ()
+    pairs = []
+    for ref_path in sorted(references_dir.glob("*.md")):
+        pairs.append((f"references/{ref_path.name}", ref_path.read_text(encoding="utf-8")))
+    return tuple(pairs)
+
+
+def _render_skill(name: str, description: str | None, body: str, references: tuple[tuple[str, str], ...]) -> str:
+    """Render one skill's injection block.
+
+    References are inlined under headings matching their relative paths so
+    the body's pointers ("Read: references/foo.md") resolve in-context
+    without rewriting the body itself.
+    """
+    parts = [f"# Skill: {name}"]
+    if description:
+        parts.append(description)
+    parts.append(body.strip())
+    for rel_path, content in references:
+        parts.append(f"## Reference: {rel_path}")
+        parts.append(content.strip())
+    return "\n\n".join(part for part in parts if part)
+
+
+def load_skill(path: Path, *, include_references: bool = True) -> LoadedSkill:
+    """Load a skill from a directory containing SKILL.md or a bare .md file.
+
+    Raises:
+        SkillError: if the path is missing, SKILL.md is absent, frontmatter
+            is invalid, or the body is empty.
+    """
+    path = path.expanduser()
+    if path.is_dir():
+        skill_file = path / "SKILL.md"
+        if not skill_file.is_file():
+            raise SkillError(f"Skill directory has no SKILL.md: {path}")
+        fallback_name = path.name
+        references_dir: Path | None = path
+    elif path.is_file():
+        if path.suffix.lower() != ".md":
+            raise SkillError(f"Skill file must be markdown (.md): {path}")
+        skill_file = path
+        fallback_name = path.stem
+        references_dir = None
+    else:
+        raise SkillError(f"Skill path does not exist: {path}")
+
+    try:
+        text = skill_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SkillError(f"Cannot read skill file {skill_file}: {exc}") from exc
+
+    try:
+        frontmatter, body = _split_frontmatter(text)
+    except SkillError as exc:
+        raise SkillError(f"{skill_file}: {exc}") from exc
+    if not body.strip():
+        raise SkillError(f"Skill body is empty: {skill_file}")
+
+    name = str(frontmatter.get("name") or fallback_name)
+    raw_description = frontmatter.get("description")
+    description = str(raw_description) if raw_description else None
+
+    references: tuple[tuple[str, str], ...] = ()
+    if include_references and references_dir is not None:
+        references = _load_references(references_dir)
+
+    rendered = _render_skill(name, description, body, references)
+    return LoadedSkill(
+        name=name,
+        description=description,
+        source_path=str(path.resolve()),
+        body=body,
+        references=references,
+        rendered=rendered,
+        content_sha256=sha256(rendered),
+        token_estimate=len(rendered) // 4,
+    )
+
+
+def load_skills(paths: list[Path], *, include_references: bool = True) -> list[LoadedSkill]:
+    """Load skills from paths, deduplicating repeats (order-preserving)."""
+    skills: list[LoadedSkill] = []
+    seen: set[str] = set()
+    for path in paths:
+        resolved = str(path.expanduser().resolve())
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        skills.append(load_skill(path, include_references=include_references))
+    return skills
+
+
+def render_skills_system_prompt(skills: list[LoadedSkill]) -> str:
+    """Render the full system prompt injected in the skills variant."""
+    blocks = [SYSTEM_PROMPT_PREAMBLE]
+    blocks.extend(skill.rendered for skill in skills)
+    return "\n\n".join(blocks)
+
+
+#: How a variant applies skills. "none" = baseline; "inject" = skill content
+#: injected as a system message. A future agentic mode adds "agentic" here
+#: and selects a different runner strategy on it.
+VariantKind = Literal["none", "inject"]
+
+
+@dataclass(frozen=True)
+class Variant:
+    """One pass of the (model x variant) run matrix."""
+
+    key: str
+    kind: VariantKind
+    #: Appended to the model name for display/payload keys (e.g. "+skills").
+    label_suffix: str
+    skills: tuple[LoadedSkill, ...]
+    system_prompt: str | None
+
+    def record_info(self) -> dict[str, Any]:
+        """Compact per-record provenance (full skill list lives in metadata)."""
+        return {
+            "key": self.key,
+            "kind": self.kind,
+            "system_prompt_hash": sha256(self.system_prompt) if self.system_prompt else None,
+        }
+
+    def payload_info(self) -> dict[str, Any]:
+        """Per-model payload entry provenance."""
+        return {
+            "key": self.key,
+            "kind": self.kind,
+            "skills": [skill.name for skill in self.skills],
+            "system_prompt_sha256": sha256(self.system_prompt) if self.system_prompt else None,
+        }
+
+
+BASELINE_VARIANT = Variant(
+    key="baseline",
+    kind="none",
+    label_suffix="",
+    skills=(),
+    system_prompt=None,
+)
+
+
+def build_variants(skills: list[LoadedSkill], *, skills_only: bool = False) -> list[Variant]:
+    """Build the variant axis of the run matrix.
+
+    No skills -> just the baseline. Skills -> baseline plus the injected
+    variant (both passes grade the identical seeded test subset), unless
+    ``skills_only`` skips the baseline.
+    """
+    if not skills:
+        return [BASELINE_VARIANT]
+    skills_variant = Variant(
+        key="skills",
+        kind="inject",
+        label_suffix="+skills",
+        skills=tuple(skills),
+        system_prompt=render_skills_system_prompt(skills),
+    )
+    if skills_only:
+        return [skills_variant]
+    return [BASELINE_VARIANT, skills_variant]

--- a/wp-bench.example.yaml
+++ b/wp-bench.example.yaml
@@ -63,6 +63,18 @@ run:
   # leaderboard runs must grade every selected test.
   # continue_on_error: false
 
+# Agent skills (A/B comparison). When paths are set, every model runs BOTH
+# a baseline pass and a with-skills pass over the identical seeded test
+# subset, and the comparison table shows deltas. A skill is a directory
+# containing SKILL.md (optionally with references/*.md), or a bare .md file;
+# skills typically live outside this repo. CLI: --skill <path> (repeatable),
+# --skills-include-references / --no-skills-include-references, --skills-only.
+# skills:
+#   paths:
+#     - /path/to/agent-skills/skills/wp-plugin-development
+#   include_references: true  # inline references/*.md into the injection
+#   only: false               # true = skip the baseline pass (diagnostic)
+
 # Output paths
 output:
   path: output/results.json


### PR DESCRIPTION
## Intent

Measure how much an agent skill (the [WordPress/agent-skills](https://github.com/WordPress/agent-skills) `SKILL.md` convention) improves model scores. Passing `--skill <path>` makes every configured model run **twice** over the identical seeded test subset — a baseline pass and a with-skills pass — and the output gains a `Δ skills` aggregate row plus a per-test **Skill Impact** table. This gives skill authors a quantified iteration loop: edit a skill, run the A/B, see exactly which tests moved.

## How it works

- New `python/wp_bench/skills.py` loads a skill (directory with `SKILL.md`, or a bare `.md` file), parses frontmatter, and by default inlines `references/*.md` under `## Reference:` headings so the body's file pointers resolve in-context (the harness is single-shot; `--no-skills-include-references` disables). `scripts/` are never included.
- Skill content is injected as a **system message** (`ModelInterface(config, system_prompt=...)`), so the user prompt stays byte-identical across variants and `prompt_hash` remains comparable.
- `MultiModelRunner` now runs a (model × variant) matrix; payload `models` stays a flat dict keyed `"<model>"` / `"<model>+skills"` (the results notebook keeps working), with additive `base_model` and `variant` keys per entry.
- Provenance: `RESULT_SCHEMA_VERSION` 2.0 → 2.1. Every record carries a `variant` block; run metadata records each skill's name, source path, content sha256, and token estimate, so results stay attributable to the exact skill version measured.
- The `Variant.kind` field (`none` / `inject`) is the extension seam for a future agentic mode where the model navigates skill files itself.

## Config changes

New optional `skills:` block (documented in `wp-bench.example.yaml`), mirrored by CLI flags `--skill` (repeatable), `--skills-include-references/--no-skills-include-references`, and `--skills-only`. Default remains no skills. Guards: bad skill paths fail before environment setup or API spend; skills are rejected in audit modes (`--check-exploits`, `--check-reference-solution`); duplicate display keys error before any model call.

## Example run

Random skill (`wp-performance`) against the 22 execution tests in the categories its references cover (caching, cron, settings-options, database):

```bash
wp-bench run --config wp-bench.yaml --model-name claude-sonnet-4-5 \
  --skill /path/to/agent-skills/skills/wp-performance \
  --test-id e-caching-001,e-caching-002,e-caching-003,e-caching-004,e-caching-005,e-caching-006,e-cron-001,e-cron-002,e-cron-003,e-cron-004,e-cron-005,e-settings-options-001,e-settings-options-002,e-settings-options-003,e-settings-options-004,e-settings-options-005,e-database-001,e-database-002,e-database-003,e-database-004,e-database-005,e-database-006
```

```text
Execution ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
                                WP-Bench Results
┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃             ┃   Execution ┃      Runtime ┃         ┃           ┃      Median ┃
┃ Model       ┃        Pass ┃      Partial ┃ Overall ┃ Est. Cost ┃     Latency ┃
┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ claude-son… │       81.8% │        81.8% │   81.8% │   $0.0520 │      2531ms │
│ claude-son… │       86.4% │        86.4% │   86.4% │   $0.3168 │      3190ms │
│ Δ skills    │      +4.5pp │       +4.5pp │  +4.5pp │  $+0.2649 │      +659ms │
│ (claude-so… │             │              │         │           │             │
└─────────────┴─────────────┴──────────────┴─────────┴───────────┴─────────────┘
        Skill Impact per Test (claude-sonnet-4-5)
┏━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
┃ Test ID        ┃ Baseline ┃ +Skills ┃ Change           ┃
┡━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
│ e-caching-003  │     fail │    fail │ — still failing  │
│ e-caching-006  │     fail │    fail │ — still failing  │
│ e-cron-005     │     fail │    fail │ — still failing  │
│ e-database-006 │     fail │    pass │ ▲ fixed by skill │
└────────────────┴──────────┴─────────┴──────────────────┘
Passing in both variants (not shown): 18
Results written to:
/Users/jason/coding/wp-bench/output/results_20260813_042950.json

WP-Bench completed
```

(Model names are ellipsized in the aggregate table because the run was captured through an 80-column pipe; interactive terminals show `claude-sonnet-4-5`, `claude-sonnet-4-5+skills`, and `Δ skills (claude-sonnet-4-5)` in full. The Skill Impact section was rendered from this run's results file after the feature landed; subsequent runs print it inline exactly as shown.)

The Skill Impact table is the skill author's iteration loop made visible: every test that changed or is still failing gets a row — the +4.5pp aggregate came from exactly one test, `e-database-006` (dbDelta schema-upgrade task), fixed by the skill's `database.md` reference — while the `— still failing` rows are the skill's next targets. The table also flags regressions (`▼ broken by skill`) and runtime-score movement on still-failing tests; tests passing in both variants are only counted, keeping the table scannable.

## Commands run

- `ruff check python` — clean
- `mypy python` — clean (38 files)
- `pytest python` — 183 passed (14 new loader tests, 13 new variant/CLI/impact-table integration tests, plus schema-parity and model-kwargs additions)
- Runtime smoke: the example run above end-to-end against the wp-env grader (44 graded executions), plus `--dry-run` skill summaries and fail-fast checks for bad paths / audit-mode combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
