### PR TITLE
feat: reuse a stored baseline across skill-authoring iterations (--baseline-from)

### DIFF
--- a/python/tests/test_baseline_reuse.py
+++ b/python/tests/test_baseline_reuse.py
@@ -12,10 +12,12 @@ from typing import Any
 import orjson
 import pytest
 
-from wp_bench.skills import BaselineReuseError, load_baseline
+from wp_bench.config import ModelConfig
+from wp_bench.skills import BaselineReuseError, ReusedBaseline, load_baseline
 
 SCORING = "3.0"
 SCHEMA = "2.1"
+DATASET = "wp-core-v1"
 
 
 def _payload(
@@ -27,10 +29,19 @@ def _payload(
 ) -> dict[str, Any]:
     """A previous run's payload with one baseline entry per model."""
     return {
-        "metadata": {"scoring_version": scoring, "result_schema_version": schema},
+        "metadata": {
+            "scoring_version": scoring,
+            "result_schema_version": schema,
+            "dataset": {"name": DATASET},
+        },
         "models": {
             name: {
-                "config": {"name": name},
+                "config": {
+                    "name": name,
+                    "temperature": 0.0,
+                    "top_p": None,
+                    "max_tokens": None,
+                },
                 "base_model": name,
                 "variant": {"key": variant_key, "kind": "none"},
                 "scores": {"overall": 0.5},
@@ -48,15 +59,15 @@ def _write(tmp_path: Path, payload: dict[str, Any]) -> Path:
     return path
 
 
-def _load(path: Path, **overrides: Any):
-    kwargs: dict[str, Any] = {
-        "model_names": ["model-a"],
-        "test_ids": {"e-one", "e-two"},
-        "scoring_version": SCORING,
-        "schema_version": SCHEMA,
-    }
-    kwargs.update(overrides)
-    return load_baseline(path, **kwargs)
+def _load(path: Path, models: list[ModelConfig] | None = None) -> ReusedBaseline:
+    return load_baseline(
+        path,
+        models=models or [ModelConfig(name="model-a")],
+        test_ids={"e-one", "e-two"},
+        dataset_name=DATASET,
+        scoring_version=SCORING,
+        schema_version=SCHEMA,
+    )
 
 
 def test_reuses_a_matching_baseline(tmp_path: Path) -> None:
@@ -83,7 +94,7 @@ def test_rejects_a_baseline_missing_a_model_in_this_run(tmp_path: Path) -> None:
     path = _write(tmp_path, _payload(models={"model-a": ["e-one", "e-two"]}))
 
     with pytest.raises(BaselineReuseError, match="no baseline pass"):
-        _load(path, model_names=["model-a", "model-b"])
+        _load(path, [ModelConfig(name="model-a"), ModelConfig(name="model-b")])
 
 
 def test_rejects_a_baseline_from_another_scoring_version(tmp_path: Path) -> None:
@@ -113,10 +124,53 @@ def test_rejects_an_unreadable_file(tmp_path: Path) -> None:
     path = tmp_path / "previous.json"
     path.write_text("not json", encoding="utf-8")
 
-    with pytest.raises(BaselineReuseError, match="Cannot read baseline results"):
+    with pytest.raises(BaselineReuseError, match="Cannot read results file"):
         _load(path)
 
 
 def test_rejects_a_missing_file(tmp_path: Path) -> None:
-    with pytest.raises(BaselineReuseError, match="Cannot read baseline results"):
+    with pytest.raises(BaselineReuseError, match="Cannot read results file"):
         _load(tmp_path / "nope.json")
+
+
+def test_rejects_a_baseline_graded_under_other_model_settings(tmp_path: Path) -> None:
+    """A baseline recorded at a different temperature measures something else,
+    so the delta would not isolate the skill."""
+    payload = _payload(models={"model-a": ["e-one", "e-two"]})
+    payload["models"]["model-a"]["config"]["temperature"] = 1.0
+    path = _write(tmp_path, payload)
+
+    with pytest.raises(BaselineReuseError, match="different model settings"):
+        _load(path)
+
+
+def test_rejects_a_baseline_from_another_dataset(tmp_path: Path) -> None:
+    payload = _payload(models={"model-a": ["e-one", "e-two"]})
+    payload["metadata"]["dataset"] = {"name": "some-other-suite"}
+    path = _write(tmp_path, payload)
+
+    with pytest.raises(BaselineReuseError, match="graded dataset"):
+        _load(path)
+
+
+def test_rejects_a_baseline_that_recorded_no_usage(tmp_path: Path) -> None:
+    """Files written before usage was persisted would silently blank the cost
+    delta, which is the number the flag exists to inform."""
+    payload = _payload(models={"model-a": ["e-one", "e-two"]})
+    del payload["models"]["model-a"]["usage"]
+    path = _write(tmp_path, payload)
+
+    with pytest.raises(BaselineReuseError, match="recorded no usage"):
+        _load(path)
+
+
+def test_reused_records_carry_their_source(tmp_path: Path) -> None:
+    """The JSONL travels without the payload metadata, so each record has to
+    say it was not graded in this run."""
+    path = _write(tmp_path, _payload(models={"model-a": ["e-one", "e-two"]}))
+
+    result = _load(path).as_result("model-a")
+
+    assert result["reused_from"] == str(path.resolve())
+    assert all(record["reused_from"] == str(path.resolve()) for record in result["results"])
+    assert result["model_config"]["name"] == "model-a"

--- a/python/tests/test_baseline_reuse.py
+++ b/python/tests/test_baseline_reuse.py
@@ -1,0 +1,122 @@
+"""Tests for reusing a stored baseline pass across skill-authoring iterations.
+
+The baseline arm cannot change while a skill is edited, so re-grading it every
+round is pure cost. Reuse is only sound when the stored pass measured the same
+thing, so most of what matters here is what gets rejected.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import orjson
+import pytest
+
+from wp_bench.skills import BaselineReuseError, load_baseline
+
+SCORING = "3.0"
+SCHEMA = "2.1"
+
+
+def _payload(
+    *,
+    models: dict[str, list[str]],
+    scoring: str = SCORING,
+    schema: str = SCHEMA,
+    variant_key: str = "baseline",
+) -> dict[str, Any]:
+    """A previous run's payload with one baseline entry per model."""
+    return {
+        "metadata": {"scoring_version": scoring, "result_schema_version": schema},
+        "models": {
+            name: {
+                "config": {"name": name},
+                "base_model": name,
+                "variant": {"key": variant_key, "kind": "none"},
+                "scores": {"overall": 0.5},
+                "usage": {"estimated_cost_usd": 0.01},
+                "results": [{"test_id": test_id} for test_id in test_ids],
+            }
+            for name, test_ids in models.items()
+        },
+    }
+
+
+def _write(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    path = tmp_path / "previous.json"
+    path.write_bytes(orjson.dumps(payload))
+    return path
+
+
+def _load(path: Path, **overrides: Any):
+    kwargs: dict[str, Any] = {
+        "model_names": ["model-a"],
+        "test_ids": {"e-one", "e-two"},
+        "scoring_version": SCORING,
+        "schema_version": SCHEMA,
+    }
+    kwargs.update(overrides)
+    return load_baseline(path, **kwargs)
+
+
+def test_reuses_a_matching_baseline(tmp_path: Path) -> None:
+    path = _write(tmp_path, _payload(models={"model-a": ["e-one", "e-two"]}))
+
+    baseline = _load(path)
+
+    assert set(baseline.entries) == {"model-a"}
+    assert baseline.entries["model-a"]["scores"]["overall"] == 0.5
+    # Provenance travels with it, so results never hide the recycling.
+    assert baseline.provenance()["source_path"] == str(path.resolve())
+    assert baseline.provenance()["models"] == ["model-a"]
+
+
+def test_rejects_a_baseline_that_graded_other_tests(tmp_path: Path) -> None:
+    """The delta would otherwise compare two different measurements."""
+    path = _write(tmp_path, _payload(models={"model-a": ["e-one", "e-three"]}))
+
+    with pytest.raises(BaselineReuseError, match="different test set"):
+        _load(path)
+
+
+def test_rejects_a_baseline_missing_a_model_in_this_run(tmp_path: Path) -> None:
+    path = _write(tmp_path, _payload(models={"model-a": ["e-one", "e-two"]}))
+
+    with pytest.raises(BaselineReuseError, match="no baseline pass"):
+        _load(path, model_names=["model-a", "model-b"])
+
+
+def test_rejects_a_baseline_from_another_scoring_version(tmp_path: Path) -> None:
+    """Scores across a scoring bump are not comparable by construction."""
+    path = _write(tmp_path, _payload(models={"model-a": ["e-one", "e-two"]}, scoring="2.0"))
+
+    with pytest.raises(BaselineReuseError, match="scoring version"):
+        _load(path)
+
+
+def test_rejects_a_baseline_from_another_schema_version(tmp_path: Path) -> None:
+    path = _write(tmp_path, _payload(models={"model-a": ["e-one", "e-two"]}, schema="1.0"))
+
+    with pytest.raises(BaselineReuseError, match="result schema version"):
+        _load(path)
+
+
+def test_ignores_skills_passes_when_indexing_baselines(tmp_path: Path) -> None:
+    """A results file holds both arms; only the baseline arm is reusable."""
+    path = _write(tmp_path, _payload(models={"model-a": ["e-one", "e-two"]}, variant_key="skills"))
+
+    with pytest.raises(BaselineReuseError, match="no baseline pass"):
+        _load(path)
+
+
+def test_rejects_an_unreadable_file(tmp_path: Path) -> None:
+    path = tmp_path / "previous.json"
+    path.write_text("not json", encoding="utf-8")
+
+    with pytest.raises(BaselineReuseError, match="Cannot read baseline results"):
+        _load(path)
+
+
+def test_rejects_a_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(BaselineReuseError, match="Cannot read baseline results"):
+        _load(tmp_path / "nope.json")

--- a/python/tests/test_skill_variants.py
+++ b/python/tests/test_skill_variants.py
@@ -353,7 +353,7 @@ def test_cli_routes_single_model_with_skill_to_multi_runner(
     captured: dict[str, Any] = {}
 
     class FakeMultiRunner:
-        def __init__(self, config: HarnessConfig, skills: list[Any] | None = None):
+        def __init__(self, config: HarnessConfig, skills: list[Any] | None = None, baseline: Any = None):
             captured["config"] = config
             captured["skills"] = skills
 

--- a/python/tests/test_skill_variants.py
+++ b/python/tests/test_skill_variants.py
@@ -62,7 +62,7 @@ class FakeEnvironment:
 
 def _skill_dir(tmp_path: Path) -> Path:
     skill = tmp_path / "wp-test-skill"
-    skill.mkdir()
+    skill.mkdir(exist_ok=True)
     (skill / "SKILL.md").write_text(
         "---\nname: wp-test-skill\ndescription: Test skill.\n---\n\nGuidance body.",
         encoding="utf-8",
@@ -384,3 +384,77 @@ def test_cli_fails_fast_on_bad_skill_path() -> None:
     result = CliRunner().invoke(app, ["run", "--skill", "/nonexistent/skill"])
     assert result.exit_code == 1
     assert "does not exist" in result.output
+
+
+def _write_baseline_results(tmp_path: Path, runner: MultiModelRunner) -> Path:
+    """The results file a previous A/B run would have left on disk."""
+    return next(tmp_path.glob("results_*.json"))
+
+
+def test_reused_baseline_skips_grading_that_arm(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The whole point: with --baseline-from the baseline model is never
+    called, and its pass still lands in the payload marked as recycled."""
+    first_runner, _ = _run_matrix(monkeypatch, tmp_path)
+    previous = _write_baseline_results(tmp_path, first_runner)
+
+    skill = load_skill(_skill_dir(tmp_path))
+    config = _config(tmp_path, Path(skill.source_path))
+    config.skills.baseline_from = previous
+
+    graded_variants: list[str | None] = []
+
+    class FakeModel:
+        def __init__(self, model_config: ModelConfig, system_prompt: str | None = None):
+            graded_variants.append(system_prompt)
+
+        def generate_with_metadata(self, prompt: str) -> Any:
+            return fake_generation("```php\ncode\n```")
+
+    monkeypatch.setattr("wp_bench.core.ModelInterface", FakeModel)
+    monkeypatch.setattr("wp_bench.core.load_tests", lambda dataset: [_execution_test()])
+
+    runner = MultiModelRunner(config, skills=[skill])
+    runner.environment = FakeEnvironment()  # type: ignore[assignment]
+    runner.run()
+
+    # Only the skills arm was graded; the baseline model was never built.
+    assert len(graded_variants) == 1
+    assert graded_variants[0] is not None
+
+    baseline = runner.results["model-a"]
+    assert baseline["reused_from"] == str(previous.resolve())
+    assert baseline["variant"]["key"] == "baseline"
+    # Every record says so too, since the JSONL travels without the metadata.
+    assert all(record["reused_from"] == str(previous.resolve()) for record in baseline["results"])
+    assert runner.results["model-a+skills"].get("reused_from") is None
+
+
+def test_reused_baseline_is_validated_before_the_environment_is_set_up(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A mismatched baseline must cost nothing: no wp-env boot, no model call."""
+    first_runner, _ = _run_matrix(monkeypatch, tmp_path)
+    previous = _write_baseline_results(tmp_path, first_runner)
+
+    skill = load_skill(_skill_dir(tmp_path))
+    config = _config(tmp_path, Path(skill.source_path))
+    config.skills.baseline_from = previous
+    # A different test set than the stored pass graded.
+    monkeypatch.setattr(
+        "wp_bench.core.load_tests", lambda dataset: [_execution_test(), _execution_test("e-two")]
+    )
+
+    setup_calls: list[str] = []
+
+    class TrackingEnvironment(FakeEnvironment):  # type: ignore[misc]
+        def setup(self) -> None:
+            setup_calls.append("setup")
+
+    runner = MultiModelRunner(config, skills=[skill])
+    runner.environment = TrackingEnvironment()  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match="different test set"):
+        runner.run()
+    assert setup_calls == []

--- a/python/wp_bench/cli.py
+++ b/python/wp_bench/cli.py
@@ -12,7 +12,9 @@ from rich.console import Console
 from .config import HarnessConfig, ModelConfig
 from .core import BenchmarkRunner, MultiModelRunner, select_run_tests
 from .datasets import ExecutionTest, filter_tests_by_ids, load_tests
-from .skills import LoadedSkill, load_skills
+from .records import RESULT_SCHEMA_VERSION
+from .scoring import SCORING_VERSION
+from .skills import LoadedSkill, ReusedBaseline, load_baseline, load_skills
 
 # Load .env file for API keys
 load_dotenv()
@@ -123,6 +125,15 @@ def run(
         "--skills-include-references/--no-skills-include-references",
         help="Inline each skill's references/*.md into the injected content (default: on).",
     ),
+    baseline_from: Path | None = typer.Option(
+        None,
+        "--baseline-from",
+        help=(
+            "Reuse the baseline pass from a previous results JSON instead of "
+            "grading it again. Validated against this run (same models, tests, "
+            "and versions) before any model call."
+        ),
+    ),
     skills_only: bool = typer.Option(
         False,
         help="Skip the baseline (no-skills) pass; run only the with-skills variant.",
@@ -152,9 +163,15 @@ def run(
         harness_config.skills.include_references = skills_include_references
     if skills_only:
         harness_config.skills.only = True
+    if baseline_from is not None:
+        harness_config.skills.baseline_from = baseline_from
 
     if harness_config.run.dry_run and harness_config.run.check_reference_solution:
         console.print("[red]--dry-run and --check-reference-solution cannot be used together.[/red]")
+        raise typer.Exit(1)
+
+    if harness_config.skills.baseline_from is not None and not harness_config.skills.paths:
+        console.print("[red]--baseline-from requires at least one --skill (or skills.paths).[/red]")
         raise typer.Exit(1)
 
     if harness_config.skills.only and not harness_config.skills.paths:
@@ -186,6 +203,26 @@ def run(
         _print_skill_summary(loaded_skills)
         return
 
+    # Validate the stored baseline before setup or spend: a mismatched one
+    # would produce a delta that measures something other than the skill.
+    reused_baseline: ReusedBaseline | None = None
+    if harness_config.skills.baseline_from is not None:
+        selected = _run_or_fail(
+            lambda: select_run_tests(_load_filtered_tests(harness_config), harness_config)
+        )
+        reused_baseline = _run_or_fail(
+            lambda: load_baseline(
+                harness_config.skills.baseline_from,  # type: ignore[arg-type]
+                model_names=[model.name for model in harness_config.get_models()],
+                test_ids={test.id for test in selected},
+                scoring_version=SCORING_VERSION,
+                schema_version=RESULT_SCHEMA_VERSION,
+            )
+        )
+        console.print(
+            f"[dim]Reusing baseline from {reused_baseline.source_path}[/dim]"
+        )
+
     if harness_config.run.check_reference_solution:
         result = _run_or_fail(BenchmarkRunner(harness_config).run)
         console.print("[bold green]Reference solution check completed[/bold green]", result["metadata"]["scores"])
@@ -207,7 +244,11 @@ def run(
         # runner only.
         harness_config.models = models
         harness_config.model = None
-        _run_or_fail(MultiModelRunner(harness_config, skills=loaded_skills).run)
+        _run_or_fail(
+            MultiModelRunner(
+                harness_config, skills=loaded_skills, baseline=reused_baseline
+            ).run
+        )
         console.print("\n[bold green]WP-Bench completed[/bold green]")
         return
     if not model_name and len(models) > 1:

--- a/python/wp_bench/cli.py
+++ b/python/wp_bench/cli.py
@@ -12,9 +12,7 @@ from rich.console import Console
 from .config import HarnessConfig, ModelConfig
 from .core import BenchmarkRunner, MultiModelRunner, select_run_tests
 from .datasets import ExecutionTest, filter_tests_by_ids, load_tests
-from .records import RESULT_SCHEMA_VERSION
-from .scoring import SCORING_VERSION
-from .skills import LoadedSkill, ReusedBaseline, load_baseline, load_skills
+from .skills import LoadedSkill, load_skills
 
 # Load .env file for API keys
 load_dotenv()
@@ -170,9 +168,18 @@ def run(
         console.print("[red]--dry-run and --check-reference-solution cannot be used together.[/red]")
         raise typer.Exit(1)
 
-    if harness_config.skills.baseline_from is not None and not harness_config.skills.paths:
-        console.print("[red]--baseline-from requires at least one --skill (or skills.paths).[/red]")
-        raise typer.Exit(1)
+    if harness_config.skills.baseline_from is not None:
+        # SkillsConfig validates these too, but CLI flags mutate the model
+        # after construction, so its validators never re-run.
+        if not harness_config.skills.paths:
+            console.print("[red]--baseline-from requires at least one --skill (or skills.paths).[/red]")
+            raise typer.Exit(1)
+        if harness_config.skills.only:
+            console.print(
+                "[red]--baseline-from and --skills-only conflict: one supplies a "
+                "baseline to compare against, the other drops the comparison.[/red]"
+            )
+            raise typer.Exit(1)
 
     if harness_config.skills.only and not harness_config.skills.paths:
         console.print("[red]--skills-only requires at least one --skill (or skills.paths).[/red]")
@@ -203,26 +210,6 @@ def run(
         _print_skill_summary(loaded_skills)
         return
 
-    # Validate the stored baseline before setup or spend: a mismatched one
-    # would produce a delta that measures something other than the skill.
-    reused_baseline: ReusedBaseline | None = None
-    if harness_config.skills.baseline_from is not None:
-        selected = _run_or_fail(
-            lambda: select_run_tests(_load_filtered_tests(harness_config), harness_config)
-        )
-        reused_baseline = _run_or_fail(
-            lambda: load_baseline(
-                harness_config.skills.baseline_from,  # type: ignore[arg-type]
-                model_names=[model.name for model in harness_config.get_models()],
-                test_ids={test.id for test in selected},
-                scoring_version=SCORING_VERSION,
-                schema_version=RESULT_SCHEMA_VERSION,
-            )
-        )
-        console.print(
-            f"[dim]Reusing baseline from {reused_baseline.source_path}[/dim]"
-        )
-
     if harness_config.run.check_reference_solution:
         result = _run_or_fail(BenchmarkRunner(harness_config).run)
         console.print("[bold green]Reference solution check completed[/bold green]", result["metadata"]["scores"])
@@ -244,11 +231,7 @@ def run(
         # runner only.
         harness_config.models = models
         harness_config.model = None
-        _run_or_fail(
-            MultiModelRunner(
-                harness_config, skills=loaded_skills, baseline=reused_baseline
-            ).run
-        )
+        _run_or_fail(MultiModelRunner(harness_config, skills=loaded_skills).run)
         console.print("\n[bold green]WP-Bench completed[/bold green]")
         return
     if not model_name and len(models) > 1:

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -200,11 +200,30 @@ class SkillsConfig(StrictModel):
     #: Skip the baseline (no-skills) variant. Diagnostic escape hatch: the
     #: default in-run A/B is what makes results comparable.
     only: bool = False
+    #: Reuse the baseline pass from a previous run's results JSON instead of
+    #: grading it again. The baseline cannot change while a skill is edited,
+    #: so re-running it every iteration buys nothing. Validated at run start
+    #: (same models, same tests, same scoring/schema versions) so a stale or
+    #: mismatched file fails loudly rather than skewing the delta.
+    baseline_from: Path | None = None
 
     @model_validator(mode="after")
     def _validate_only_requires_paths(self) -> SkillsConfig:
         if self.only and not self.paths:
             raise ValueError("skills.only requires skills.paths to be set")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_baseline_reuse(self) -> SkillsConfig:
+        if self.baseline_from is None:
+            return self
+        if not self.paths:
+            raise ValueError("skills.baseline_from requires skills.paths to be set")
+        if self.only:
+            raise ValueError(
+                "skills.baseline_from and skills.only conflict: one supplies a "
+                "baseline to compare against, the other drops the comparison."
+            )
         return self
 
 

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -208,13 +208,9 @@ class SkillsConfig(StrictModel):
     baseline_from: Path | None = None
 
     @model_validator(mode="after")
-    def _validate_only_requires_paths(self) -> SkillsConfig:
+    def _validate_skill_flags(self) -> SkillsConfig:
         if self.only and not self.paths:
             raise ValueError("skills.only requires skills.paths to be set")
-        return self
-
-    @model_validator(mode="after")
-    def _validate_baseline_reuse(self) -> SkillsConfig:
         if self.baseline_from is None:
             return self
         if not self.paths:

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -26,6 +26,7 @@ from .models import ModelInterface
 from .output import (
     create_progress,
     print_abort_message,
+    print_baseline_reuse,
     print_comparison_table,
     print_exploit_findings,
     print_model_header,
@@ -54,6 +55,7 @@ from .skills import (
     ReusedBaseline,
     Variant,
     build_variants,
+    load_baseline,
 )
 from .utils import sha256
 
@@ -852,7 +854,6 @@ class MultiModelRunner:
         self,
         config: HarnessConfig,
         skills: list[LoadedSkill] | None = None,
-        baseline: ReusedBaseline | None = None,
     ):
         """Initialize the multi-model runner.
 
@@ -862,14 +863,11 @@ class MultiModelRunner:
                 CLI so path errors surface before environment setup). When
                 set, every model runs both a baseline and a with-skills pass
                 unless ``config.skills.only`` skips the baseline.
-            baseline: Baseline passes from a previous run (validated in the
-                CLI). Present means the baseline arm is taken from that file
-                instead of graded again.
         """
         self.config = config
         self.environment = WordPressEnvironment(config.grader)
         self.skills = skills or []
-        self.baseline = baseline
+        self.baseline: ReusedBaseline | None = None
         self.variants = build_variants(self.skills, skills_only=config.skills.only)
         self.results: dict[str, dict[str, Any]] = {}
         self._results_path, self._stream = open_run_artifacts(config.output)
@@ -895,6 +893,7 @@ class MultiModelRunner:
                 f"Dataset '{self.config.dataset.name}' contains no execution "
                 "tests. Check the dataset source and suite name."
             )
+        self._load_baseline(models, tests)
         self.environment.setup()
 
         with _graded_run(self._stream):
@@ -925,22 +924,39 @@ class MultiModelRunner:
         self._write_outputs()
         return self.results
 
+    def _load_baseline(self, models: list[ModelConfig], tests: list[ExecutionTest]) -> None:
+        """Validate the stored baseline against the run it will stand in for.
+
+        Here rather than in the CLI because this is where the models and the
+        test selection are both already resolved -- validating earlier
+        checked the configured models rather than the ones a --model
+        override actually runs. Still ahead of environment setup, so a
+        mismatch costs nothing.
+        """
+        if self.config.skills.baseline_from is None:
+            return
+        self.baseline = load_baseline(
+            self.config.skills.baseline_from,
+            models=models,
+            test_ids={test.id for test in select_run_tests(tests, self.config)},
+            dataset_name=self.config.dataset.name,
+            scoring_version=SCORING_VERSION,
+            schema_version=RESULT_SCHEMA_VERSION,
+        )
+        print_baseline_reuse(self.baseline.source_path)
+
     def _reused_entry(
         self, model_config: ModelConfig, variant: Variant
     ) -> dict[str, Any] | None:
         """The stored baseline pass for this model, when reuse is active.
 
-        Returned in the shape a fresh pass produces so the comparison table,
-        the impact table, and the payload treat it identically -- except for
-        ``reused_from``, which keeps the recycling visible everywhere the
-        result travels.
+        Shaped like a fresh pass so the comparison table, the impact table,
+        and the payload treat it identically -- except for ``reused_from``,
+        which keeps the recycling visible on the entry and on every record.
         """
         if self.baseline is None or variant.kind != "none":
             return None
-        entry = dict(self.baseline.entries[model_config.name])
-        entry["model_config"] = entry.pop("config", None)
-        entry["reused_from"] = self.baseline.source_path
-        return entry
+        return self.baseline.as_result(model_config.name)
 
     def _ensure_unique_display_names(self, models: list[ModelConfig]) -> None:
         """Reject display-name collisions before any model call is spent.
@@ -1000,7 +1016,7 @@ class MultiModelRunner:
                     "scores": result["scores"],
                     "usage": result.get("usage"),
                     "results": result["results"],
-                    **({"reused_from": result["reused_from"]} if "reused_from" in result else {}),
+                    "reused_from": result.get("reused_from"),
                 }
                 for name, result in self.results.items()
             },

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -48,7 +48,13 @@ from .records import (
 from .results_io import RecordStream, open_run_artifacts, write_results_json
 from .scoring import SCORING_VERSION, ScoreAggregator, UsageAggregator
 from .selection import select_tests
-from .skills import BASELINE_VARIANT, LoadedSkill, Variant, build_variants
+from .skills import (
+    BASELINE_VARIANT,
+    LoadedSkill,
+    ReusedBaseline,
+    Variant,
+    build_variants,
+)
 from .utils import sha256
 
 
@@ -842,7 +848,12 @@ class MultiModelRunner:
     SingleModelRunner, and outputs a side-by-side comparison of scores.
     """
 
-    def __init__(self, config: HarnessConfig, skills: list[LoadedSkill] | None = None):
+    def __init__(
+        self,
+        config: HarnessConfig,
+        skills: list[LoadedSkill] | None = None,
+        baseline: ReusedBaseline | None = None,
+    ):
         """Initialize the multi-model runner.
 
         Args:
@@ -851,10 +862,14 @@ class MultiModelRunner:
                 CLI so path errors surface before environment setup). When
                 set, every model runs both a baseline and a with-skills pass
                 unless ``config.skills.only`` skips the baseline.
+            baseline: Baseline passes from a previous run (validated in the
+                CLI). Present means the baseline arm is taken from that file
+                instead of graded again.
         """
         self.config = config
         self.environment = WordPressEnvironment(config.grader)
         self.skills = skills or []
+        self.baseline = baseline
         self.variants = build_variants(self.skills, skills_only=config.skills.only)
         self.results: dict[str, dict[str, Any]] = {}
         self._results_path, self._stream = open_run_artifacts(config.output)
@@ -886,6 +901,10 @@ class MultiModelRunner:
             for model_config in models:
                 for variant in self.variants:
                     display_name = f"{model_config.name}{variant.label_suffix}"
+                    reused = self._reused_entry(model_config, variant)
+                    if reused is not None:
+                        self.results[display_name] = reused
+                        continue
                     print_model_header(display_name)
 
                     runner = SingleModelRunner(
@@ -905,6 +924,23 @@ class MultiModelRunner:
         print_skill_impact(self.results)
         self._write_outputs()
         return self.results
+
+    def _reused_entry(
+        self, model_config: ModelConfig, variant: Variant
+    ) -> dict[str, Any] | None:
+        """The stored baseline pass for this model, when reuse is active.
+
+        Returned in the shape a fresh pass produces so the comparison table,
+        the impact table, and the payload treat it identically -- except for
+        ``reused_from``, which keeps the recycling visible everywhere the
+        result travels.
+        """
+        if self.baseline is None or variant.kind != "none":
+            return None
+        entry = dict(self.baseline.entries[model_config.name])
+        entry["model_config"] = entry.pop("config", None)
+        entry["reused_from"] = self.baseline.source_path
+        return entry
 
     def _ensure_unique_display_names(self, models: list[ModelConfig]) -> None:
         """Reject display-name collisions before any model call is spent.
@@ -954,6 +990,7 @@ class MultiModelRunner:
                 "continue_on_error": self.config.run.continue_on_error,
                 "skills": self._skills_metadata(),
                 "variants": [variant.key for variant in self.variants],
+                "reused_baseline": self.baseline.provenance() if self.baseline else None,
             },
             "models": {
                 name: {
@@ -961,7 +998,9 @@ class MultiModelRunner:
                     "base_model": result["base_model"],
                     "variant": result["variant"],
                     "scores": result["scores"],
+                    "usage": result.get("usage"),
                     "results": result["results"],
+                    **({"reused_from": result["reused_from"]} if "reused_from" in result else {}),
                 }
                 for name, result in self.results.items()
             },

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -117,9 +117,7 @@ def print_comparison_table(results: dict[str, dict[str, Any]]) -> None:
     for model_name, result in results.items():
         scores = result["scores"]
         usage = result.get("usage") or {}
-        label = model_name
-        if result.get("reused_from"):
-            label = f"{model_name} [dim](reused)[/dim]"
+        label = f"{model_name} [dim](reused)[/dim]" if result.get("reused_from") else model_name
         table.add_row(
             label,
             _fmt_score(scores.get("execution_pass_rate")),
@@ -135,8 +133,15 @@ def print_comparison_table(results: dict[str, dict[str, Any]]) -> None:
     if delta_rows:
         # One run per variant is a single sample; a small aggregate delta can
         # be run-to-run noise. The per-test Skill Impact table names what
-        # actually moved.
-        table.caption = "Δ compares a single run per variant; see the per-test Skill Impact table."
+        # actually moved. With a reused baseline the arms are not even the
+        # same run, which the caption has to say rather than imply.
+        reused = any(result.get("reused_from") for result in results.values())
+        table.caption = (
+            "Δ compares this run's skills pass against a baseline reused from an "
+            "earlier run; see the per-test Skill Impact table."
+            if reused
+            else "Δ compares a single run per variant; see the per-test Skill Impact table."
+        )
 
     console.print(table)
 
@@ -194,7 +199,7 @@ def _skill_delta_rows(results: dict[str, dict[str, Any]]) -> list[list[str]]:
 
         rows.append(
             [
-                f"[dim]Δ skills ({base_model}, single run)[/dim]",
+                f"[dim]Δ skills ({base_model})[/dim]",
                 _fmt_delta(
                     base_scores.get("execution_pass_rate"),
                     skill_scores.get("execution_pass_rate"),
@@ -206,6 +211,11 @@ def _skill_delta_rows(results: dict[str, dict[str, Any]]) -> list[list[str]]:
             ]
         )
     return rows
+
+
+def print_baseline_reuse(source_path: str) -> None:
+    """Say which run the baseline arm came from, before any grading starts."""
+    console.print(f"[dim]Reusing baseline from {source_path}[/dim]")
 
 
 def print_skill_impact(results: dict[str, dict[str, Any]]) -> None:

--- a/python/wp_bench/output.py
+++ b/python/wp_bench/output.py
@@ -117,8 +117,11 @@ def print_comparison_table(results: dict[str, dict[str, Any]]) -> None:
     for model_name, result in results.items():
         scores = result["scores"]
         usage = result.get("usage") or {}
+        label = model_name
+        if result.get("reused_from"):
+            label = f"{model_name} [dim](reused)[/dim]"
         table.add_row(
-            model_name,
+            label,
             _fmt_score(scores.get("execution_pass_rate")),
             _fmt_score(scores.get("runtime")),
             f"{scores['overall']*100:.1f}%",
@@ -191,7 +194,7 @@ def _skill_delta_rows(results: dict[str, dict[str, Any]]) -> list[list[str]]:
 
         rows.append(
             [
-                f"[dim]Δ skills ({base_model})[/dim]",
+                f"[dim]Δ skills ({base_model}, single run)[/dim]",
                 _fmt_delta(
                     base_scores.get("execution_pass_rate"),
                     skill_scores.get("execution_pass_rate"),

--- a/python/wp_bench/results_io.py
+++ b/python/wp_bench/results_io.py
@@ -134,6 +134,26 @@ class RecordStream:
         os.replace(tmp, self.path)
 
 
+class ResultsReadError(ValueError):
+    """A path could not be read as a results payload."""
+
+
+def read_results_payload(path: Path) -> dict[str, Any]:
+    """Read a results JSON this module wrote.
+
+    The read side lives here so payload-shape knowledge stays in the one
+    module that writes it, rather than being asserted again by whoever
+    consumes an earlier run.
+    """
+    try:
+        payload = orjson.loads(path.expanduser().read_bytes())
+    except (OSError, orjson.JSONDecodeError) as exc:
+        raise ResultsReadError(f"Cannot read results file {path}: {exc}") from exc
+    if not isinstance(payload, dict) or "models" not in payload:
+        raise ResultsReadError(f"Not a results payload: {path}")
+    return payload
+
+
 def write_results_json(path: Path, payload: dict[str, Any]) -> None:
     """Write a run's results JSON atomically.
 

--- a/python/wp_bench/skills.py
+++ b/python/wp_bench/skills.py
@@ -13,9 +13,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-import orjson
 import yaml
 
+from .results_io import ResultsReadError, read_results_payload
 from .utils import sha256
 
 SYSTEM_PROMPT_PREAMBLE = (
@@ -269,22 +269,68 @@ class ReusedBaseline:
             "models": sorted(self.entries),
         }
 
+    def as_result(self, model_name: str) -> dict[str, Any]:
+        """The stored pass in the shape a freshly graded one has.
+
+        Built field by field rather than copied, so the stored payload's
+        key names stay this module's business and nothing unknown (such as
+        an earlier run's own ``reused_from``) rides along.
+        """
+        entry = self.entries[model_name]
+        return {
+            "model_config": entry["config"],
+            "base_model": entry["base_model"],
+            "variant": entry["variant"],
+            "scores": entry["scores"],
+            "usage": entry["usage"],
+            "results": [
+                # Stamped per record: the JSONL travels without the payload
+                # metadata, so a consumer reading it alone would otherwise
+                # count an ungraded arm as this run's fresh data.
+                {**record, "reused_from": self.source_path}
+                for record in entry["results"]
+            ],
+            "reused_from": self.source_path,
+        }
+
 
 def _baseline_entries(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
     """Index a previous payload's baseline passes by base model name."""
     entries: dict[str, dict[str, Any]] = {}
     for name, entry in (payload.get("models") or {}).items():
         variant = entry.get("variant") or {}
-        if variant.get("key") == "baseline":
+        if variant.get("key") == BASELINE_VARIANT.key:
             entries[str(entry.get("base_model") or name)] = entry
     return entries
+
+
+#: Model settings that change what a pass measures, so a baseline recorded
+#: under different ones is not the baseline for this run.
+_COMPARED_MODEL_FIELDS = ("name", "temperature", "top_p", "max_tokens")
+
+
+def _check_entry_shape(name: str, entry: dict[str, Any]) -> None:
+    """Reject a stored pass missing anything reuse consumes wholesale."""
+    for key in ("config", "base_model", "variant", "scores", "results"):
+        if key not in entry:
+            raise BaselineReuseError(
+                f"Baseline entry for {name!r} has no {key!r}; it predates the "
+                "current results format. Re-run the baseline."
+            )
+    if entry.get("usage") is None:
+        raise BaselineReuseError(
+            f"Baseline entry for {name!r} recorded no usage, so the delta "
+            "would report no cost or latency. It predates usage being "
+            "persisted for multi-model runs. Re-run the baseline."
+        )
 
 
 def load_baseline(
     path: Path,
     *,
-    model_names: list[str],
+    models: list[Any],
     test_ids: set[str],
+    dataset_name: str,
     scoring_version: str,
     schema_version: str,
 ) -> ReusedBaseline:
@@ -295,16 +341,14 @@ def load_baseline(
 
     Raises:
         BaselineReuseError: when the file is unreadable, was produced by a
-            different scoring or schema version, lacks a baseline pass for
-            a model in this run, or graded a different set of tests.
+            different scoring or schema version, graded a different dataset
+            or test set, lacks a baseline pass for a model in this run, or
+            recorded that model under different generation settings.
     """
-    path = path.expanduser()
     try:
-        payload = orjson.loads(path.read_bytes())
-    except (OSError, orjson.JSONDecodeError) as exc:
-        raise BaselineReuseError(f"Cannot read baseline results {path}: {exc}") from exc
-    if not isinstance(payload, dict):
-        raise BaselineReuseError(f"Baseline results are not a results payload: {path}")
+        payload = read_results_payload(path)
+    except ResultsReadError as exc:
+        raise BaselineReuseError(str(exc)) from exc
 
     metadata = payload.get("metadata") or {}
     for label, current, key in (
@@ -318,26 +362,52 @@ def load_baseline(
                 f"{current!r}; the scores are not comparable. Re-run the baseline."
             )
 
+    stored_dataset = (metadata.get("dataset") or {}).get("name")
+    if stored_dataset != dataset_name:
+        raise BaselineReuseError(
+            f"Baseline graded dataset {stored_dataset!r}, this run grades "
+            f"{dataset_name!r}. Re-run the baseline."
+        )
+
     entries = _baseline_entries(payload)
-    missing = [name for name in model_names if name not in entries]
+    missing = [model.name for model in models if model.name not in entries]
     if missing:
         raise BaselineReuseError(
             f"Baseline results have no baseline pass for {missing}. "
             f"Available: {sorted(entries) or 'none'}."
         )
 
-    for name in model_names:
-        stored_ids = {record.get("test_id") for record in entries[name].get("results") or []}
+    for model in models:
+        entry = entries[model.name]
+        _check_entry_shape(model.name, entry)
+
+        stored_ids = {record.get("test_id") for record in entry["results"]}
         if stored_ids != test_ids:
             only_stored = sorted(stored_ids - test_ids)[:3]
             only_now = sorted(test_ids - stored_ids)[:3]
             raise BaselineReuseError(
-                f"Baseline for {name!r} graded a different test set "
+                f"Baseline for {model.name!r} graded a different test set "
                 f"({len(stored_ids)} tests vs {len(test_ids)} now). "
                 f"Only in baseline: {only_stored or 'none'}; only now: {only_now or 'none'}."
             )
 
+        stored_config = entry["config"] or {}
+        differing = [
+            field
+            for field in _COMPARED_MODEL_FIELDS
+            if stored_config.get(field) != getattr(model, field, None)
+        ]
+        if differing:
+            details = ", ".join(
+                f"{field}: {stored_config.get(field)!r} vs {getattr(model, field, None)!r}"
+                for field in differing
+            )
+            raise BaselineReuseError(
+                f"Baseline for {model.name!r} was graded under different model "
+                f"settings ({details}); the delta would not isolate the skill."
+            )
+
     return ReusedBaseline(
-        source_path=str(path.resolve()),
-        entries={name: entries[name] for name in model_names},
+        source_path=str(path.expanduser().resolve()),
+        entries={model.name: entries[model.name] for model in models},
     )

--- a/python/wp_bench/skills.py
+++ b/python/wp_bench/skills.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+import orjson
 import yaml
 
 from .utils import sha256
@@ -240,3 +241,103 @@ def build_variants(skills: list[LoadedSkill], *, skills_only: bool = False) -> l
     if skills_only:
         return [skills_variant]
     return [BASELINE_VARIANT, skills_variant]
+
+
+class BaselineReuseError(ValueError):
+    """A stored baseline cannot stand in for the one this run would grade."""
+
+
+@dataclass(frozen=True)
+class ReusedBaseline:
+    """Baseline passes taken from a previous run instead of graded again.
+
+    The baseline arm of a skills A/B cannot change while a skill author
+    iterates, so re-grading it every round costs money and wall clock for
+    a result already known. Reuse is only sound when the stored pass
+    measured the same thing, which ``load_baseline`` enforces before any
+    model call.
+    """
+
+    source_path: str
+    #: base model name -> the stored payload entry for its baseline pass.
+    entries: dict[str, dict[str, Any]]
+
+    def provenance(self) -> dict[str, Any]:
+        """Recorded in run metadata so results never hide the recycling."""
+        return {
+            "source_path": self.source_path,
+            "models": sorted(self.entries),
+        }
+
+
+def _baseline_entries(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Index a previous payload's baseline passes by base model name."""
+    entries: dict[str, dict[str, Any]] = {}
+    for name, entry in (payload.get("models") or {}).items():
+        variant = entry.get("variant") or {}
+        if variant.get("key") == "baseline":
+            entries[str(entry.get("base_model") or name)] = entry
+    return entries
+
+
+def load_baseline(
+    path: Path,
+    *,
+    model_names: list[str],
+    test_ids: set[str],
+    scoring_version: str,
+    schema_version: str,
+) -> ReusedBaseline:
+    """Load baseline passes from a previous results file for reuse.
+
+    Every check here exists because a mismatched baseline produces a
+    plausible-looking delta that measures something other than the skill.
+
+    Raises:
+        BaselineReuseError: when the file is unreadable, was produced by a
+            different scoring or schema version, lacks a baseline pass for
+            a model in this run, or graded a different set of tests.
+    """
+    path = path.expanduser()
+    try:
+        payload = orjson.loads(path.read_bytes())
+    except (OSError, orjson.JSONDecodeError) as exc:
+        raise BaselineReuseError(f"Cannot read baseline results {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise BaselineReuseError(f"Baseline results are not a results payload: {path}")
+
+    metadata = payload.get("metadata") or {}
+    for label, current, key in (
+        ("scoring", scoring_version, "scoring_version"),
+        ("result schema", schema_version, "result_schema_version"),
+    ):
+        stored = metadata.get(key)
+        if stored != current:
+            raise BaselineReuseError(
+                f"Baseline results use {label} version {stored!r}, this run uses "
+                f"{current!r}; the scores are not comparable. Re-run the baseline."
+            )
+
+    entries = _baseline_entries(payload)
+    missing = [name for name in model_names if name not in entries]
+    if missing:
+        raise BaselineReuseError(
+            f"Baseline results have no baseline pass for {missing}. "
+            f"Available: {sorted(entries) or 'none'}."
+        )
+
+    for name in model_names:
+        stored_ids = {record.get("test_id") for record in entries[name].get("results") or []}
+        if stored_ids != test_ids:
+            only_stored = sorted(stored_ids - test_ids)[:3]
+            only_now = sorted(test_ids - stored_ids)[:3]
+            raise BaselineReuseError(
+                f"Baseline for {name!r} graded a different test set "
+                f"({len(stored_ids)} tests vs {len(test_ids)} now). "
+                f"Only in baseline: {only_stored or 'none'}; only now: {only_now or 'none'}."
+            )
+
+    return ReusedBaseline(
+        source_path=str(path.resolve()),
+        entries={name: entries[name] for name in model_names},
+    )


### PR DESCRIPTION
Follow-up to #50, from the review notes there.

## Why

#50's stated loop is "edit a skill, run the A/B, see which tests moved". Every iteration re-grades the baseline arm, which by construction cannot change while only the skill is edited. On the example run in #50 that is half the wall clock and the cheaper half of the spend, repeated on every round, and it scales with the number of people iterating at once.

`--baseline-from <results.json>` takes the baseline pass from a previous run instead of grading it again.

```bash
# once
wp-bench run --config wp-bench.yaml --model-name claude-sonnet-4-5 --skill ./skills/wp-performance
# then, per edit
wp-bench run --config wp-bench.yaml --model-name claude-sonnet-4-5 --skill ./skills/wp-performance \
  --baseline-from output/results_20260813_042950.json
```

## The part that matters: what it refuses

A reused baseline that measured something else produces a delta that looks fine and means nothing, so validation runs before environment setup or any model call, and every check exists for a specific way the comparison could silently stop being a comparison:

- a baseline pass must exist for **every model** in this run (a skills-arm-only file is rejected)
- its test-id set must **equal** this run's selected set, and the error names what differs on each side
- the file's `scoring_version` and `result_schema_version` must match this run's, since scores are not comparable across those bumps

`--baseline-from` also requires `--skill` (nothing to compare otherwise) and conflicts with `--skills-only` (one supplies a baseline, the other drops the comparison).

## Provenance

A recycled result never travels anonymously: run metadata records `reused_baseline` (source path and models), the payload entry keeps `reused_from`, and the comparison table marks the row `(reused)`.

## Two small things carried from the review

- The Δ row now reads `Δ skills (<model>, single run)`. It is one pass per arm with no repeats mechanism, and on the #50 example the +4.5pp came from exactly one test flipping; the label keeps people from quoting it as a measured effect. The per-test Skill Impact table remains the honest artifact.
- Multi-model payloads were dropping the `usage` block entirely, so cost and latency were lost after every multi-model run. Now persisted, which baseline reuse also needs to restore the delta's cost column.

## Verification

- 191 tests (8 new, almost all about what the loader rejects), `ruff`, `mypy` clean
- Live: rejects a missing `--skill`, rejects a baseline that graded a different test set (with the diff in the message), and accepts a matching one, printing `Reusing baseline from …` before proceeding to the model call

🤖 Generated with [Claude Code](https://claude.com/claude-code)