### PR TITLE
fix(models)!: remove temperature and recover from rejected sampling params

### DIFF
--- a/python/tests/test_config_validation.py
+++ b/python/tests/test_config_validation.py
@@ -16,19 +16,10 @@ from wp_bench.config import (
 )
 
 
-def test_model_config_rejects_temperature_below_zero() -> None:
-    with pytest.raises(ValidationError, match="between 0 and 2"):
-        ModelConfig(temperature=-0.1)
-
-
-def test_model_config_rejects_temperature_above_two() -> None:
-    with pytest.raises(ValidationError, match="between 0 and 2"):
-        ModelConfig(temperature=2.1)
-
-
-def test_model_config_accepts_temperature_bounds() -> None:
-    assert ModelConfig(temperature=0.0).temperature == 0.0
-    assert ModelConfig(temperature=2.0).temperature == 2.0
+def test_model_config_rejects_temperature() -> None:
+    """Removed outright -- see test_sampling_param_fallback for the rationale."""
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ModelConfig(temperature=0.0)  # type: ignore[call-arg]
 
 
 def test_model_config_rejects_invalid_top_p() -> None:
@@ -98,6 +89,6 @@ def test_config_construction_emits_no_deprecation_warnings() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         HarnessConfig()
-        ModelConfig(temperature=1.0, top_p=0.5)
+        ModelConfig(top_p=0.5)
         RunConfig(limit=5)
         GraderConfig(kind="cli")

--- a/python/tests/test_model_retries.py
+++ b/python/tests/test_model_retries.py
@@ -148,7 +148,8 @@ def test_deprecated_temperature_fallback_is_flagged_not_counted(monkeypatch) -> 
         return _ok_response()
 
     monkeypatch.setattr(models_module, "completion", fake_completion)
-    model = ModelInterface(_fast_config())
+    # temperature is opt-in now; this fallback only applies when it is set.
+    model = ModelInterface(_fast_config(temperature=0.0))
 
     generation = model.generate_with_metadata("hello")
 

--- a/python/tests/test_model_retries.py
+++ b/python/tests/test_model_retries.py
@@ -134,31 +134,6 @@ def test_timeout_retry_can_be_disabled(monkeypatch) -> None:
     assert len(calls) == 1
 
 
-def test_deprecated_temperature_fallback_is_flagged_not_counted(monkeypatch) -> None:
-    calls: list[dict] = []
-
-    def fake_completion(**kwargs):
-        calls.append(kwargs)
-        if len(calls) == 1:
-            raise BadRequestError(
-                message="`temperature` is deprecated for this model.",
-                model="gpt-4o-mini",
-                llm_provider="openai",
-            )
-        return _ok_response()
-
-    monkeypatch.setattr(models_module, "completion", fake_completion)
-    # temperature is opt-in now; this fallback only applies when it is set.
-    model = ModelInterface(_fast_config(temperature=0.0))
-
-    generation = model.generate_with_metadata("hello")
-
-    assert generation.text == "ok"
-    assert generation.temperature_fallback is True
-    assert generation.retry_count == 0  # fallback is not a transient retry
-    assert "temperature" not in calls[1]
-
-
 def test_retry_config_from_values() -> None:
     config = ModelConfig(
         max_retries=5,

--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -24,7 +24,8 @@ def test_generate_retries_without_temperature_on_deprecated_error(monkeypatch) -
 
     monkeypatch.setattr(models_module, "completion", fake_completion)
 
-    model = ModelInterface(ModelConfig(name="anthropic/claude-opus-4-7"))
+    # temperature is opt-in now; this fallback only applies when it is set.
+    model = ModelInterface(ModelConfig(name="anthropic/claude-opus-4-7", temperature=0.0))
     result = model.generate("hello")
 
     assert result == "ok"

--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -9,31 +9,6 @@ from wp_bench.config import ModelConfig
 from wp_bench.models import ModelInterface
 
 
-def test_generate_retries_without_temperature_on_deprecated_error(monkeypatch) -> None:
-    calls: list[dict] = []
-
-    def fake_completion(**kwargs):
-        calls.append(kwargs)
-        if len(calls) == 1:
-            raise BadRequestError(
-                message="AnthropicException - `temperature` is deprecated for this model.",
-                model="anthropic/claude-opus-4-7",
-                llm_provider="anthropic",
-            )
-        return SimpleNamespace(choices=[SimpleNamespace(message={"content": "ok"})])
-
-    monkeypatch.setattr(models_module, "completion", fake_completion)
-
-    # temperature is opt-in now; this fallback only applies when it is set.
-    model = ModelInterface(ModelConfig(name="anthropic/claude-opus-4-7", temperature=0.0))
-    result = model.generate("hello")
-
-    assert result == "ok"
-    assert len(calls) == 2
-    assert calls[0]["temperature"] == 0.0
-    assert "temperature" not in calls[1]
-
-
 def test_generate_normalizes_none_content_to_empty_string(monkeypatch) -> None:
     def fake_completion(**kwargs):
         return SimpleNamespace(choices=[SimpleNamespace(message={"content": None})])

--- a/python/tests/test_sampling_param_fallback.py
+++ b/python/tests/test_sampling_param_fallback.py
@@ -1,9 +1,10 @@
-"""Durability of the unsupported-sampling-parameter fallback.
+"""Sampling parameters: opt-in, and survivable when a provider rejects one.
 
-Providers retire sampling parameters (``temperature``, ``top_p``, ``top_k``)
-on a per-model basis and describe the rejection in whatever prose they like.
-The harness must recover by dropping the offending parameter rather than
-aborting a suite, without matching on any single vendor's wording.
+No sampling parameter is sent unless a config asks for it, because every
+current frontier model rejects them. When one *is* asked for and rejected,
+the harness drops it and re-sends rather than aborting the suite -- without
+matching on any single vendor's wording, which is what made the previous
+implementation brittle.
 """
 from __future__ import annotations
 
@@ -30,7 +31,7 @@ def _bad_request(message: str) -> BadRequestError:
 
 
 def _fast_config(**overrides: object) -> ModelConfig:
-    """Sub-second backoff so tests stay fast; no temperature unless asked."""
+    """Sub-second backoff so tests stay fast; no sampling params by default."""
     defaults: dict = {
         "name": "test-model",
         "max_retries": 0,
@@ -41,46 +42,44 @@ def _fast_config(**overrides: object) -> ModelConfig:
     return ModelConfig.model_validate(defaults)
 
 
-# Wordings observed across providers and generations for the same underlying
-# condition: this model will not accept this sampling parameter.
+def test_no_sampling_parameters_are_sent_by_default() -> None:
+    """The default request cannot provoke the rejection in the first place."""
+    kwargs = ModelInterface(_fast_config())._completion_kwargs("hello")
+
+    assert "top_p" not in kwargs  # nor an explicit null, which differs from absent
+    assert "top_k" not in kwargs
+    assert set(kwargs) == {"model", "messages", "max_tokens", "timeout"}
+
+
+def test_temperature_is_not_a_config_option() -> None:
+    """Removed outright: every current frontier model rejects it, and a fixed
+    temperature never bought the reproducibility it appeared to."""
+    assert not hasattr(ModelConfig(), "temperature")
+    with pytest.raises(Exception):  # noqa: B017 - pydantic ValidationError
+        ModelConfig(temperature=0.0)  # type: ignore[call-arg]
+
+
+def test_top_p_is_sent_when_explicitly_configured() -> None:
+    kwargs = ModelInterface(_fast_config(top_p=0.9))._completion_kwargs("hello")
+
+    assert kwargs["top_p"] == 0.9
+
+
+# Wordings observed across providers and generations for one condition:
+# this model will not accept this sampling parameter.
 REJECTION_WORDINGS = [
-    pytest.param("`temperature` is deprecated for this model.", id="anthropic-deprecated"),
+    pytest.param("`top_p` is deprecated for this model.", id="deprecated"),
+    pytest.param("Exception - top_p: Extra inputs are not permitted", id="removed"),
     pytest.param(
-        "AnthropicException - temperature: Extra inputs are not permitted",
-        id="anthropic-removed",
+        "Unsupported value: 'top_p' does not support 0.9 with this model.",
+        id="unsupported-value",
     ),
-    pytest.param(
-        "Unsupported value: 'temperature' does not support 0.0 with this model. "
-        "Only the default (1) value is supported.",
-        id="openai-unsupported-value",
-    ),
-    pytest.param(
-        'Invalid request: parameter "temperature" is not supported.',
-        id="generic-not-supported",
-    ),
+    pytest.param('Invalid request: parameter "top_p" is not supported.', id="not-supported"),
 ]
 
 
-def test_temperature_is_not_sent_by_default() -> None:
-    """The default request carries no sampling parameter that a current
-    frontier model would reject -- no fallback round trip required."""
-    kwargs = ModelInterface(_fast_config())._completion_kwargs("hello")
-
-    assert "temperature" not in kwargs
-    # Nor an explicit null top_p, which is not the same thing as absent.
-    assert "top_p" not in kwargs
-    assert ModelConfig().temperature is None
-
-
-def test_temperature_is_sent_when_explicitly_configured() -> None:
-    """Local and older backends can still ask for it."""
-    kwargs = ModelInterface(_fast_config(temperature=0.2))._completion_kwargs("hello")
-
-    assert kwargs["temperature"] == 0.2
-
-
 @pytest.mark.parametrize("message", REJECTION_WORDINGS)
-def test_drops_temperature_regardless_of_provider_wording(monkeypatch, message: str) -> None:
+def test_drops_rejected_param_regardless_of_provider_wording(monkeypatch, message: str) -> None:
     calls: list[dict] = []
 
     def fake_completion(**kwargs):
@@ -90,53 +89,13 @@ def test_drops_temperature_regardless_of_provider_wording(monkeypatch, message: 
         return _ok_response()
 
     monkeypatch.setattr(models_module, "completion", fake_completion)
-    generation = ModelInterface(_fast_config(temperature=0.0)).generate_with_metadata("hello")
-
-    assert generation.text == "ok"
-    assert len(calls) == 2
-    assert calls[0]["temperature"] == 0.0
-    assert "temperature" not in calls[1]
-    assert generation.temperature_fallback is True
-    assert generation.dropped_params == ("temperature",)
-
-
-def test_drops_top_p_when_that_is_the_rejected_parameter(monkeypatch) -> None:
-    calls: list[dict] = []
-
-    def fake_completion(**kwargs):
-        calls.append(kwargs)
-        if len(calls) == 1:
-            raise _bad_request("Unsupported parameter: 'top_p' is not supported with this model.")
-        return _ok_response()
-
-    monkeypatch.setattr(models_module, "completion", fake_completion)
     generation = ModelInterface(_fast_config(top_p=0.9)).generate_with_metadata("hello")
 
     assert generation.text == "ok"
+    assert len(calls) == 2
     assert calls[0]["top_p"] == 0.9
     assert "top_p" not in calls[1]
-    # top_p is not temperature: the legacy flag must not be raised for it.
-    assert generation.temperature_fallback is False
     assert generation.dropped_params == ("top_p",)
-
-
-def test_drops_several_parameters_across_successive_rejections(monkeypatch) -> None:
-    calls: list[dict] = []
-
-    def fake_completion(**kwargs):
-        calls.append(kwargs)
-        if "temperature" in kwargs:
-            raise _bad_request("temperature is not supported with this model")
-        if "top_p" in kwargs:
-            raise _bad_request("top_p is not supported with this model")
-        return _ok_response()
-
-    monkeypatch.setattr(models_module, "completion", fake_completion)
-    generation = ModelInterface(_fast_config(top_p=0.9, temperature=0.0)).generate_with_metadata("hello")
-
-    assert generation.text == "ok"
-    assert len(calls) == 3
-    assert set(generation.dropped_params) == {"temperature", "top_p"}
 
 
 def test_unrelated_bad_request_is_not_swallowed(monkeypatch) -> None:
@@ -149,7 +108,7 @@ def test_unrelated_bad_request_is_not_swallowed(monkeypatch) -> None:
     monkeypatch.setattr(models_module, "completion", fake_completion)
 
     with pytest.raises(BadRequestError, match="maximum context length"):
-        ModelInterface(_fast_config()).generate_with_metadata("hello")
+        ModelInterface(_fast_config(top_p=0.9)).generate_with_metadata("hello")
 
     assert len(calls) == 1
 
@@ -160,17 +119,16 @@ def test_rejection_naming_an_already_dropped_parameter_reraises(monkeypatch) -> 
 
     def fake_completion(**kwargs):
         calls.append(kwargs)
-        raise _bad_request("temperature is not supported with this model")
+        raise _bad_request("top_p is not supported with this model")
 
     monkeypatch.setattr(models_module, "completion", fake_completion)
 
     with pytest.raises(BadRequestError):
-        ModelInterface(_fast_config(temperature=0.0)).generate_with_metadata("hello")
+        ModelInterface(_fast_config(top_p=0.9)).generate_with_metadata("hello")
 
-    # One call with temperature, one without, then give up.
     assert len(calls) == 2
-    assert "temperature" in calls[0]
-    assert "temperature" not in calls[1]
+    assert "top_p" in calls[0]
+    assert "top_p" not in calls[1]
 
 
 def test_unsupported_parameter_is_remembered_for_later_calls(monkeypatch) -> None:
@@ -179,23 +137,23 @@ def test_unsupported_parameter_is_remembered_for_later_calls(monkeypatch) -> Non
 
     def fake_completion(**kwargs):
         calls.append(kwargs)
-        if "temperature" in kwargs:
-            raise _bad_request("temperature is not supported with this model")
+        if "top_p" in kwargs:
+            raise _bad_request("top_p is not supported with this model")
         return _ok_response()
 
     monkeypatch.setattr(models_module, "completion", fake_completion)
-    model = ModelInterface(_fast_config(temperature=0.0))
+    model = ModelInterface(_fast_config(top_p=0.9))
 
     first = model.generate_with_metadata("hello")
     second = model.generate_with_metadata("again")
 
     assert first.text == "ok"
     assert second.text == "ok"
-    # Call 1 fails, call 2 succeeds, call 3 is the second generate() — which
+    # Call 1 fails, call 2 succeeds, call 3 is the second generate() -- which
     # must not repeat the known-bad parameter.
     assert len(calls) == 3
-    assert "temperature" not in calls[2]
-    assert second.dropped_params == ("temperature",)
+    assert "top_p" not in calls[2]
+    assert second.dropped_params == ("top_p",)
 
 
 def test_fallback_is_not_counted_as_a_transient_retry(monkeypatch) -> None:
@@ -204,11 +162,11 @@ def test_fallback_is_not_counted_as_a_transient_retry(monkeypatch) -> None:
     def fake_completion(**kwargs):
         calls.append(kwargs)
         if len(calls) == 1:
-            raise _bad_request("temperature is not supported with this model")
+            raise _bad_request("top_p is not supported with this model")
         return _ok_response()
 
     monkeypatch.setattr(models_module, "completion", fake_completion)
-    generation = ModelInterface(_fast_config(temperature=0.0)).generate_with_metadata("hello")
+    generation = ModelInterface(_fast_config(top_p=0.9)).generate_with_metadata("hello")
 
     assert generation.retry_count == 0
 
@@ -218,12 +176,12 @@ def test_dropped_params_are_recorded_in_call_metadata(monkeypatch) -> None:
     from wp_bench.core import _model_call_info
 
     def fake_completion(**kwargs):
-        if "temperature" in kwargs:
-            raise _bad_request("temperature is not supported with this model")
+        if "top_p" in kwargs:
+            raise _bad_request("top_p is not supported with this model")
         return _ok_response()
 
     monkeypatch.setattr(models_module, "completion", fake_completion)
-    generation = ModelInterface(_fast_config(temperature=0.0)).generate_with_metadata("hello")
+    generation = ModelInterface(_fast_config(top_p=0.9)).generate_with_metadata("hello")
 
-    assert _model_call_info(generation)["dropped_params"] == ["temperature"]
+    assert _model_call_info(generation)["dropped_params"] == ["top_p"]
     assert "dropped_params" not in generation.usage_dict()

--- a/python/tests/test_sampling_param_fallback.py
+++ b/python/tests/test_sampling_param_fallback.py
@@ -1,0 +1,229 @@
+"""Durability of the unsupported-sampling-parameter fallback.
+
+Providers retire sampling parameters (``temperature``, ``top_p``, ``top_k``)
+on a per-model basis and describe the rejection in whatever prose they like.
+The harness must recover by dropping the offending parameter rather than
+aborting a suite, without matching on any single vendor's wording.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from litellm.exceptions import BadRequestError
+
+import wp_bench.models as models_module
+from wp_bench.config import ModelConfig
+from wp_bench.models import ModelInterface
+
+
+def _ok_response():
+    return SimpleNamespace(choices=[SimpleNamespace(message={"content": "ok"})])
+
+
+def _bad_request(message: str) -> BadRequestError:
+    return BadRequestError(
+        message=message,
+        model="test-model",
+        llm_provider="test-provider",
+    )
+
+
+def _fast_config(**overrides: object) -> ModelConfig:
+    """Sub-second backoff so tests stay fast; no temperature unless asked."""
+    defaults: dict = {
+        "name": "test-model",
+        "max_retries": 0,
+        "retry_min_seconds": 0.001,
+        "retry_max_seconds": 0.002,
+    }
+    defaults.update(overrides)
+    return ModelConfig.model_validate(defaults)
+
+
+# Wordings observed across providers and generations for the same underlying
+# condition: this model will not accept this sampling parameter.
+REJECTION_WORDINGS = [
+    pytest.param("`temperature` is deprecated for this model.", id="anthropic-deprecated"),
+    pytest.param(
+        "AnthropicException - temperature: Extra inputs are not permitted",
+        id="anthropic-removed",
+    ),
+    pytest.param(
+        "Unsupported value: 'temperature' does not support 0.0 with this model. "
+        "Only the default (1) value is supported.",
+        id="openai-unsupported-value",
+    ),
+    pytest.param(
+        'Invalid request: parameter "temperature" is not supported.',
+        id="generic-not-supported",
+    ),
+]
+
+
+def test_temperature_is_not_sent_by_default() -> None:
+    """The default request carries no sampling parameter that a current
+    frontier model would reject -- no fallback round trip required."""
+    kwargs = ModelInterface(_fast_config())._completion_kwargs("hello")
+
+    assert "temperature" not in kwargs
+    # Nor an explicit null top_p, which is not the same thing as absent.
+    assert "top_p" not in kwargs
+    assert ModelConfig().temperature is None
+
+
+def test_temperature_is_sent_when_explicitly_configured() -> None:
+    """Local and older backends can still ask for it."""
+    kwargs = ModelInterface(_fast_config(temperature=0.2))._completion_kwargs("hello")
+
+    assert kwargs["temperature"] == 0.2
+
+
+@pytest.mark.parametrize("message", REJECTION_WORDINGS)
+def test_drops_temperature_regardless_of_provider_wording(monkeypatch, message: str) -> None:
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise _bad_request(message)
+        return _ok_response()
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+    generation = ModelInterface(_fast_config(temperature=0.0)).generate_with_metadata("hello")
+
+    assert generation.text == "ok"
+    assert len(calls) == 2
+    assert calls[0]["temperature"] == 0.0
+    assert "temperature" not in calls[1]
+    assert generation.temperature_fallback is True
+    assert generation.dropped_params == ("temperature",)
+
+
+def test_drops_top_p_when_that_is_the_rejected_parameter(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise _bad_request("Unsupported parameter: 'top_p' is not supported with this model.")
+        return _ok_response()
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+    generation = ModelInterface(_fast_config(top_p=0.9)).generate_with_metadata("hello")
+
+    assert generation.text == "ok"
+    assert calls[0]["top_p"] == 0.9
+    assert "top_p" not in calls[1]
+    # top_p is not temperature: the legacy flag must not be raised for it.
+    assert generation.temperature_fallback is False
+    assert generation.dropped_params == ("top_p",)
+
+
+def test_drops_several_parameters_across_successive_rejections(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        if "temperature" in kwargs:
+            raise _bad_request("temperature is not supported with this model")
+        if "top_p" in kwargs:
+            raise _bad_request("top_p is not supported with this model")
+        return _ok_response()
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+    generation = ModelInterface(_fast_config(top_p=0.9, temperature=0.0)).generate_with_metadata("hello")
+
+    assert generation.text == "ok"
+    assert len(calls) == 3
+    assert set(generation.dropped_params) == {"temperature", "top_p"}
+
+
+def test_unrelated_bad_request_is_not_swallowed(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        raise _bad_request("This model's maximum context length is 8192 tokens.")
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+
+    with pytest.raises(BadRequestError, match="maximum context length"):
+        ModelInterface(_fast_config()).generate_with_metadata("hello")
+
+    assert len(calls) == 1
+
+
+def test_rejection_naming_an_already_dropped_parameter_reraises(monkeypatch) -> None:
+    """A provider that keeps blaming a parameter we no longer send must not loop."""
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        raise _bad_request("temperature is not supported with this model")
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+
+    with pytest.raises(BadRequestError):
+        ModelInterface(_fast_config(temperature=0.0)).generate_with_metadata("hello")
+
+    # One call with temperature, one without, then give up.
+    assert len(calls) == 2
+    assert "temperature" in calls[0]
+    assert "temperature" not in calls[1]
+
+
+def test_unsupported_parameter_is_remembered_for_later_calls(monkeypatch) -> None:
+    """The 400 is paid once per model, not once per test in a suite."""
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        if "temperature" in kwargs:
+            raise _bad_request("temperature is not supported with this model")
+        return _ok_response()
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+    model = ModelInterface(_fast_config(temperature=0.0))
+
+    first = model.generate_with_metadata("hello")
+    second = model.generate_with_metadata("again")
+
+    assert first.text == "ok"
+    assert second.text == "ok"
+    # Call 1 fails, call 2 succeeds, call 3 is the second generate() — which
+    # must not repeat the known-bad parameter.
+    assert len(calls) == 3
+    assert "temperature" not in calls[2]
+    assert second.dropped_params == ("temperature",)
+
+
+def test_fallback_is_not_counted_as_a_transient_retry(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def fake_completion(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise _bad_request("temperature is not supported with this model")
+        return _ok_response()
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+    generation = ModelInterface(_fast_config(temperature=0.0)).generate_with_metadata("hello")
+
+    assert generation.retry_count == 0
+
+
+def test_dropped_params_are_recorded_in_call_metadata(monkeypatch) -> None:
+    """Auditable in the result record: usage_dict() stays tokens/cost/latency."""
+    from wp_bench.core import _model_call_info
+
+    def fake_completion(**kwargs):
+        if "temperature" in kwargs:
+            raise _bad_request("temperature is not supported with this model")
+        return _ok_response()
+
+    monkeypatch.setattr(models_module, "completion", fake_completion)
+    generation = ModelInterface(_fast_config(temperature=0.0)).generate_with_metadata("hello")
+
+    assert _model_call_info(generation)["dropped_params"] == ["temperature"]
+    assert "dropped_params" not in generation.usage_dict()

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -40,7 +40,13 @@ class ModelConfig(StrictModel):
     #: Routing itself is driven by ``name`` (a LiteLLM model string).
     kind: Literal["openai", "anthropic", "ollama", "openai-compatible"] = "openai"
     name: str = "gpt-4o-mini"
-    temperature: float = 0.0
+    #: Omitted from the request unless explicitly set. Current frontier
+    #: models reject the parameter outright, and no provider has ever
+    #: guaranteed reproducibility at a fixed temperature -- so sending it by
+    #: default bought nothing and broke those models. Still honored by local
+    #: and older backends (``ollama``, ``openai-compatible``), where setting
+    #: it does measurably reduce run-to-run variance.
+    temperature: float | None = None
     max_tokens: int | None = None
     top_p: float | None = None
     request_timeout: float = Field(default=300.0, gt=0)
@@ -54,8 +60,8 @@ class ModelConfig(StrictModel):
 
     @field_validator("temperature")
     @classmethod
-    def _clamp_temperature(cls, value: float) -> float:
-        if value < 0 or value > 2:
+    def _clamp_temperature(cls, value: float | None) -> float | None:
+        if value is not None and not 0 <= value <= 2:
             raise ValueError("temperature must be between 0 and 2")
         return value
 

--- a/python/wp_bench/config.py
+++ b/python/wp_bench/config.py
@@ -40,13 +40,6 @@ class ModelConfig(StrictModel):
     #: Routing itself is driven by ``name`` (a LiteLLM model string).
     kind: Literal["openai", "anthropic", "ollama", "openai-compatible"] = "openai"
     name: str = "gpt-4o-mini"
-    #: Omitted from the request unless explicitly set. Current frontier
-    #: models reject the parameter outright, and no provider has ever
-    #: guaranteed reproducibility at a fixed temperature -- so sending it by
-    #: default bought nothing and broke those models. Still honored by local
-    #: and older backends (``ollama``, ``openai-compatible``), where setting
-    #: it does measurably reduce run-to-run variance.
-    temperature: float | None = None
     max_tokens: int | None = None
     top_p: float | None = None
     request_timeout: float = Field(default=300.0, gt=0)
@@ -57,13 +50,6 @@ class ModelConfig(StrictModel):
     retry_max_seconds: float = 30.0
     retry_on_rate_limit: bool = True
     retry_on_timeout: bool = True
-
-    @field_validator("temperature")
-    @classmethod
-    def _clamp_temperature(cls, value: float | None) -> float | None:
-        if value is not None and not 0 <= value <= 2:
-            raise ValueError("temperature must be between 0 and 2")
-        return value
 
     @field_validator("top_p")
     @classmethod

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -201,6 +201,7 @@ def _model_call_info(generation: Any) -> dict[str, Any]:
         "retry_count": generation.retry_count,
         "provider_response_id": generation.provider_response_id,
         "temperature_fallback": generation.temperature_fallback,
+        "dropped_params": list(getattr(generation, "dropped_params", ())),
     }
 
 

--- a/python/wp_bench/core.py
+++ b/python/wp_bench/core.py
@@ -200,7 +200,6 @@ def _model_call_info(generation: Any) -> dict[str, Any]:
     return {
         "retry_count": generation.retry_count,
         "provider_response_id": generation.provider_response_id,
-        "temperature_fallback": generation.temperature_fallback,
         "dropped_params": list(getattr(generation, "dropped_params", ())),
     }
 

--- a/python/wp_bench/models.py
+++ b/python/wp_bench/models.py
@@ -34,11 +34,12 @@ from tenacity import (
 
 from .config import ModelConfig
 
-#: Sampling parameters a provider may retire on a per-model basis. Dropping
-#: one costs us determinism we never actually had (no provider guarantees
-#: reproducibility at a fixed temperature) and is always preferable to
-#: aborting the run, so these are recoverable rather than fatal.
-_DROPPABLE_SAMPLING_PARAMS: tuple[str, ...] = ("temperature", "top_p", "top_k")
+#: Sampling parameters a provider may retire on a per-model basis. None are
+#: sent unless a config asks for them; when one is asked for and rejected,
+#: dropping it costs determinism we never actually had (no provider
+#: guarantees reproducibility at fixed sampling settings) and beats aborting
+#: the run, so these are recoverable rather than fatal.
+_DROPPABLE_SAMPLING_PARAMS: tuple[str, ...] = ("top_p", "top_k")
 
 #: Exception types that indicate a transient provider problem.
 _TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
@@ -59,10 +60,6 @@ class ModelGeneration:
     retry_count: int
     latency_ms: float
     provider_response_id: str | None
-    #: True when ``temperature`` was omitted because the model rejects it.
-    #: Kept as its own field because existing result records carry it;
-    #: ``dropped_params`` is the general form.
-    temperature_fallback: bool = False
     #: Every sampling parameter omitted from the successful call, whether
     #: dropped in response to this call's rejection or already known bad.
     dropped_params: tuple[str, ...] = field(default_factory=tuple)
@@ -161,7 +158,6 @@ class ModelInterface:
             retry_count=attempt_count - 1,
             latency_ms=latency_ms,
             provider_response_id=getattr(response, "id", None),
-            temperature_fallback="temperature" in dropped_params,
             dropped_params=dropped_params,
             prompt_tokens=usage["prompt_tokens"],
             completion_tokens=usage["completion_tokens"],
@@ -219,11 +215,9 @@ class ModelInterface:
             "max_tokens": self.config.max_tokens,
             "timeout": self.config.request_timeout,
         }
-        # Sampling parameters are opt-in: sending them by default breaks
-        # every current frontier model and never bought reproducibility.
-        # See ModelConfig.temperature.
-        if self.config.temperature is not None:
-            kwargs["temperature"] = self.config.temperature
+        # Sampling parameters are opt-in. Sending them by default breaks
+        # every current frontier model -- all of which reject them -- and
+        # never bought the reproducibility it appeared to.
         if self.config.top_p is not None:
             kwargs["top_p"] = self.config.top_p
         return kwargs

--- a/python/wp_bench/models.py
+++ b/python/wp_bench/models.py
@@ -9,8 +9,9 @@ problems are not hidden behind retries.
 """
 from __future__ import annotations
 
+import re
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from litellm import completion, completion_cost
@@ -33,6 +34,12 @@ from tenacity import (
 
 from .config import ModelConfig
 
+#: Sampling parameters a provider may retire on a per-model basis. Dropping
+#: one costs us determinism we never actually had (no provider guarantees
+#: reproducibility at a fixed temperature) and is always preferable to
+#: aborting the run, so these are recoverable rather than fatal.
+_DROPPABLE_SAMPLING_PARAMS: tuple[str, ...] = ("temperature", "top_p", "top_k")
+
 #: Exception types that indicate a transient provider problem.
 _TRANSIENT_ERRORS: tuple[type[Exception], ...] = (
     RateLimitError,
@@ -52,7 +59,13 @@ class ModelGeneration:
     retry_count: int
     latency_ms: float
     provider_response_id: str | None
+    #: True when ``temperature`` was omitted because the model rejects it.
+    #: Kept as its own field because existing result records carry it;
+    #: ``dropped_params`` is the general form.
     temperature_fallback: bool = False
+    #: Every sampling parameter omitted from the successful call, whether
+    #: dropped in response to this call's rejection or already known bad.
+    dropped_params: tuple[str, ...] = field(default_factory=tuple)
     prompt_tokens: int | None = None
     completion_tokens: int | None = None
     total_tokens: int | None = None
@@ -74,6 +87,10 @@ class ModelInterface:
 
     def __init__(self, config: ModelConfig, system_prompt: str | None = None):
         self.config = config
+        #: Sampling parameters this model has rejected. Learned on the first
+        #: rejection and reused for the rest of the run, so a suite pays the
+        #: failed call once per model rather than once per test.
+        self._unsupported_params: set[str] = set()
         #: Variant state (e.g. injected skill content), deliberately not part
         #: of ModelConfig so it never lands in serialized model config blocks.
         self.system_prompt = system_prompt
@@ -96,10 +113,12 @@ class ModelInterface:
         Latency covers all attempts, including backoff waits, because that
         is the wall-clock cost of obtaining the completion.
         """
-        kwargs = self._completion_kwargs(prompt)
+        requested = self._requested_kwargs(prompt)
+        kwargs = {k: v for k, v in requested.items() if k not in self._unsupported_params}
+        already_dropped = [k for k in requested if k not in kwargs]
         started = time.perf_counter()
         attempt_count = 0
-        temperature_fallback = False
+        newly_dropped: list[str] = []
 
         def _should_retry(error: BaseException) -> bool:
             if not self._retry_enabled_for(error):
@@ -122,20 +141,14 @@ class ModelInterface:
             reraise=True,
         ):
             with attempt:
-                try:
-                    response = completion(**kwargs)
-                except BadRequestError as error:
-                    # Deterministic error, except the known deprecated-
-                    # temperature case which is fixable by dropping the
-                    # parameter. That fallback is intentional behavior,
-                    # not a retry, and is flagged separately.
-                    if not _is_deprecated_temperature_error(error) or "temperature" not in kwargs:
-                        raise
-                    kwargs.pop("temperature")
-                    temperature_fallback = True
-                    response = completion(**kwargs)
+                # Bad requests are deterministic and fail fast, except for a
+                # rejected sampling parameter, which we drop and re-send.
+                # That fallback is intentional behavior, not a transient
+                # retry, so it is flagged separately and not counted.
+                response = self._complete_dropping_unsupported(kwargs, newly_dropped)
 
         assert response is not None  # Retrying(reraise=True) raises otherwise
+        dropped_params = tuple(sorted(set(already_dropped) | set(newly_dropped)))
         latency_ms = (time.perf_counter() - started) * 1000
         choice = response.choices[0]
         usage = _extract_usage(response)
@@ -148,12 +161,34 @@ class ModelInterface:
             retry_count=attempt_count - 1,
             latency_ms=latency_ms,
             provider_response_id=getattr(response, "id", None),
-            temperature_fallback=temperature_fallback,
+            temperature_fallback="temperature" in dropped_params,
+            dropped_params=dropped_params,
             prompt_tokens=usage["prompt_tokens"],
             completion_tokens=usage["completion_tokens"],
             total_tokens=usage["total_tokens"],
             cost_usd=_estimate_cost_safe(response),
         )
+
+    def _complete_dropping_unsupported(
+        self, kwargs: dict[str, Any], dropped: list[str]
+    ) -> ModelResponse:
+        """Call the provider, shedding sampling parameters it rejects.
+
+        Terminates because each iteration removes a key from ``kwargs`` and
+        only parameters still present can be identified as the culprit — so
+        a provider that keeps blaming a parameter we no longer send raises
+        rather than looping.
+        """
+        while True:
+            try:
+                return completion(**kwargs)
+            except BadRequestError as error:
+                param = _rejected_sampling_param(error, kwargs)
+                if param is None:
+                    raise
+                kwargs.pop(param)
+                self._unsupported_params.add(param)
+                dropped.append(param)
 
     def _retry_enabled_for(self, error: BaseException) -> bool:
         """Apply per-category retry switches from config."""
@@ -168,6 +203,12 @@ class ModelInterface:
         return completion_cost(response)
 
     def _completion_kwargs(self, prompt: str) -> dict[str, Any]:
+        """Kwargs as they will actually be sent, minus known-bad parameters."""
+        requested = self._requested_kwargs(prompt)
+        return {k: v for k, v in requested.items() if k not in self._unsupported_params}
+
+    def _requested_kwargs(self, prompt: str) -> dict[str, Any]:
+        """Kwargs as configured, before any learned parameter is stripped."""
         messages: list[dict[str, str]] = []
         if self.system_prompt:
             messages.append({"role": "system", "content": self.system_prompt})
@@ -176,15 +217,35 @@ class ModelInterface:
             "model": self.config.name,
             "messages": messages,
             "max_tokens": self.config.max_tokens,
-            "top_p": self.config.top_p,
             "timeout": self.config.request_timeout,
         }
-        kwargs["temperature"] = self.config.temperature
+        # Sampling parameters are opt-in: sending them by default breaks
+        # every current frontier model and never bought reproducibility.
+        # See ModelConfig.temperature.
+        if self.config.temperature is not None:
+            kwargs["temperature"] = self.config.temperature
+        if self.config.top_p is not None:
+            kwargs["top_p"] = self.config.top_p
         return kwargs
 
 
-def _is_deprecated_temperature_error(error: BadRequestError) -> bool:
-    return "`temperature` is deprecated" in str(error)
+def _rejected_sampling_param(error: BadRequestError, kwargs: dict[str, Any]) -> str | None:
+    """Name the sampling parameter a bad request is complaining about.
+
+    Providers word this differently and change the wording between model
+    generations -- "is deprecated", "Extra inputs are not permitted",
+    "Unsupported value", "is not supported with this model". Matching any
+    one phrase is what made the previous implementation brittle, so we key
+    on the parameter name instead: if a rejection names a droppable
+    parameter we actually sent, that parameter is the thing to drop.
+
+    Returns None for every other bad request, which then fails fast.
+    """
+    message = str(error)
+    for param in _DROPPABLE_SAMPLING_PARAMS:
+        if param in kwargs and re.search(rf"\b{re.escape(param)}\b", message):
+            return param
+    return None
 
 
 def _extract_usage(response: Any) -> dict[str, int | None]:

--- a/python/wp_bench/records.py
+++ b/python/wp_bench/records.py
@@ -34,7 +34,6 @@ def _model_info(model_config: ModelConfig | None) -> dict[str, Any] | None:
     return {
         "name": model_config.name,
         "kind": model_config.kind,
-        "temperature": model_config.temperature,
         "top_p": model_config.top_p,
         "max_tokens": model_config.max_tokens,
     }


### PR DESCRIPTION
## Summary

Runs configured with any current frontier model died on their first test. `ModelConfig.temperature` defaulted to `0.0` and was attached to every request, and Claude Opus 5, Claude Sonnet 5, and Opus 4.7/4.8 all reject the parameter with a 400. Since `BadRequestError` is deliberately excluded from the transient-retry set, the whole suite aborted with it.

This removes `temperature` outright, stops sending `top_p` unless it is explicitly set, and makes a rejected sampling parameter recoverable instead of fatal.

## Why the existing guard did not catch it

There was already a fallback, but it matched a single literal vendor string:

```python
def _is_deprecated_temperature_error(error: BadRequestError) -> bool:
    return "`temperature` is deprecated" in str(error)
```

That is the Opus 4.6-era wording. On the models that *removed* the parameter the 400 reads differently, so the guard returned `False` and the error propagated. Matching on provider prose is what made it brittle.

## Why remove rather than keep as opt-in

The first commit here made `temperature` opt-in, on the reasoning that local backends still honor it. That reasoning did not survive review of the evidence:

- `ollama` and `openai-compatible` appear **exactly once** in the repository — in the `kind` Literal on `config.py:41`. No example config, no documentation, no test, no run.
- All 963 result records on disk are `gpt-4o` or `gpt-4o-mini` at `temperature: 0.0` — the default, which nobody chose.

So the field was being kept for a hypothetical user at a real user's expense. It was also worth less than it appeared: no provider guarantees reproducibility at a fixed temperature, and a benchmark spanning providers cannot hold sampling constant while half its models refuse the parameter. If a local-model workflow ever needs it, reintroducing one optional field is cheap.

## What changed

- `ModelConfig.temperature` and its range validator: **removed**.
- `_requested_kwargs` sends `top_p` only when set, rather than as an explicit `None` (absent and null are not the same thing to every provider).
- `_rejected_sampling_param` replaces `_is_deprecated_temperature_error`. It keys on the parameter *name* appearing in the message, across `top_p` and `top_k`, and only for a parameter actually present in the outgoing kwargs. Every other bad request still fails fast, unchanged.
- `_complete_dropping_unsupported` performs the drop-and-resend loop. It terminates because each pass removes a key and only parameters still present can be identified as the culprit, so a provider that keeps blaming a parameter already gone raises rather than looping. Rejections are remembered on the `ModelInterface`, so a suite pays the failed call once per model rather than once per test.
- `ModelGeneration.dropped_params` records what was omitted and surfaces via `_model_call_info`. `usage_dict()` is untouched — it stays tokens, cost, and latency, per the canonical-shape assertion in `test_usage_capture.py`.

## Breaking changes

1. **A config setting `model.temperature` no longer loads.** `StrictModel` forbids extra keys, so it fails with pydantic's `Extra inputs are not permitted`. Loud beats silently-ignored for a key that no longer does anything. No config in this repository sets it.
2. **Result-record schema.** The `temperature` key is gone from the model block, and `temperature_fallback` from call metadata. Existing files on disk are unaffected; anything asserting on those keys needs updating.

## Testing

- `pytest python` — 206 passing. `test_sampling_param_fallback.py` covers four provider wordings for the same rejection, the no-loop guarantee, and cross-call memoization.
- `ruff check python` and `mypy python` both clean.
- No `temperature` reference remains under `python/wp_bench/`.
- All four models in a local `wp-bench.yaml` now build a request of exactly `model`, `messages`, `max_tokens`, `timeout`.