### PR TITLE
Added MultiSkill testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "wp-bench",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/python/tests/test_skills.py
+++ b/python/tests/test_skills.py
@@ -165,3 +165,56 @@ def test_render_skills_system_prompt_contains_preamble_and_all_skills(tmp_path: 
     prompt = render_skills_system_prompt([first, second])
     assert prompt.index("skill documents") < prompt.index("# Skill: wp-example")
     assert "# Skill: other" in prompt
+
+def _write_second_skill(root: Path, name: str = "wp-second", body: str = "Second body.") -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: Second skill.\n---\n\n{body}",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def test_build_variants_with_two_skills(tmp_path: Path) -> None:
+    first = load_skill(_write_skill(tmp_path))
+    second = load_skill(_write_second_skill(tmp_path))
+
+    both = build_variants([first, second])
+    assert [variant.key for variant in both] == ["baseline", "skills"]
+
+    skills_variant = both[1]
+    # Variant.skills is tuple[LoadedSkill, ...], stored in input order.
+    assert skills_variant.skills == (first, second)
+
+    # render_skills_system_prompt is called with the full list, so both
+    # skills' rendered bodies must appear, in input order.
+    prompt = skills_variant.system_prompt
+    assert prompt is not None
+    assert first.rendered in prompt
+    assert second.rendered in prompt
+    assert prompt.index(first.rendered) < prompt.index(second.rendered)
+
+
+def test_variant_payload_info_with_two_skills(tmp_path: Path) -> None:
+    first = load_skill(_write_skill(tmp_path))
+    second = load_skill(_write_second_skill(tmp_path))
+    variant = build_variants([first, second])[1]
+
+    payload = variant.payload_info()
+    assert payload["skills"] == ["wp-example", "wp-second"]
+    assert payload["system_prompt_sha256"] == variant.record_info()["system_prompt_hash"]
+
+
+def test_render_skills_system_prompt_two_skills_preserve_input_order(tmp_path: Path) -> None:
+    """Regression guard: render_skills_system_prompt joins skill.rendered via
+    blocks.extend(...) over the input list, so order must follow the caller's
+    list order, not any internal sort."""
+    first = load_skill(_write_skill(tmp_path))
+    second = load_skill(_write_second_skill(tmp_path))
+
+    forward = render_skills_system_prompt([first, second])
+    assert forward.index("# Skill: wp-example") < forward.index("# Skill: wp-second")
+
+    backward = render_skills_system_prompt([second, first])
+    assert backward.index("# Skill: wp-second") < backward.index("# Skill: wp-example")

--- a/runtime/package-lock.json
+++ b/runtime/package-lock.json
@@ -554,7 +554,6 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }


### PR DESCRIPTION
## What

Added starting from line 169 to 220 under test_skills.py programs to run a new style of testing that allows multiskill testing
Multi-skill support to WP-Bench, enabling benchmark variants to load and evaluate multiple skills simultaneously while preserving skill ordering and ensuring all skills are included in the generated system prompt and benchmark metadata.

## How to add multiple skills:

Two ways to 
1. In the YAML config, add multiple entries:
skills:
  paths:
    - /path/to/agent-skills/skills/wp-plugin-development
    - /path/to/agent-skills/skills/wp-security-checklist
  include_references: true
  only: false

2. Directly on the CLI
wp-bench run --config wp-bench.yaml \
  --skill /path/to/skills/wp-plugin-development \
  --skill /path/to/skills/wp-security-checklist

## Why

WP-Bench previously evaluated skills individually, but real AI agents often need to use multiple skills together to complete a task. Adding multi-skill testing allows WP-Bench to evaluate whether an agent can combine two skills in a single workflow, rather than only measuring isolated capabilities.

## Verification

<!-- Commands run and their results. At minimum: -->

- [√] `ruff check python` : "All Checks Pasts"
- [√] `mypy python`: Success: no issues found in 41 source files
- [√ ] `pytest python` 201 Passed 
- [ ] PHP syntax / runtime smoke test (when `runtime/` changed)

## Score impact

<!-- Required when changing datasets/, runtime/, or scoring code. -->

- [ TBD] This PR does **not** change how any test is scored, or
- [TBD ] This PR changes scoring/dataset/runtime behavior — bump the relevant
      version (`scoring_version`, suite version, or runtime version), and
      note below whether new scores are comparable to previous runs.

<!-- Comparability note: -->
